### PR TITLE
Upgrade Rust toolchain from 1.83 to 1.88

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.83"
+channel = "1.88"
 profile = "default"


### PR DESCRIPTION
Required to support the latest Azure SDK for Rust (azure_identity 0.33, azure_messaging_eventhubs 0.12) which has transitive dependencies requiring Rust 1.85+.