### PR TITLE
OBE-8859: ip whitelist source only (PART 1)

### DIFF
--- a/lib/vector-core/src/ipallowlist.rs
+++ b/lib/vector-core/src/ipallowlist.rs
@@ -1,4 +1,6 @@
 use serde::{Deserialize, Serialize};
+use std::net::IpAddr;
+use std::str::FromStr;
 use std::cell::RefCell;
 use vector_config::GenerateError;
 
@@ -6,7 +8,7 @@ use ipnet::IpNet;
 use vector_config::{configurable_component, Configurable, Metadata, ToValue};
 use vector_config_common::schema::{InstanceType, SchemaGenerator, SchemaObject};
 
-/// List of allowed origin IP networks. IP addresses must be in CIDR notation.
+/// List of allowed origin IP networks. Entries may be in CIDR notation (e.g. `192.168.0.0/16`) or bare IP addresses (e.g. `127.0.0.1`, treated as `/32` or `/128`).
 #[configurable_component]
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[serde(deny_unknown_fields, transparent)]
@@ -24,9 +26,34 @@ const fn ip_allow_list_example() -> [&'static str; 4] {
 }
 
 /// IP network
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, transparent)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
 pub struct IpNetConfig(pub IpNet);
+
+impl FromStr for IpNetConfig {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Try CIDR notation first (e.g. "10.0.0.1/32")
+        if let Ok(net) = s.parse::<IpNet>() {
+            return Ok(IpNetConfig(net));
+        }
+        // Fall back to bare IP address — treat as a host network (/32 or /128)
+        s.parse::<IpAddr>()
+            .map(|addr| IpNetConfig(IpNet::from(addr)))
+            .map_err(|_| format!("invalid IP address or network: {s}"))
+    }
+}
+
+impl<'de> Deserialize<'de> for IpNetConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
 
 impl ToValue for IpNetConfig {
     fn to_value(&self) -> serde_json::Value {

--- a/lib/vector-core/src/ipallowlist.rs
+++ b/lib/vector-core/src/ipallowlist.rs
@@ -34,13 +34,9 @@ impl FromStr for IpNetConfig {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // Try CIDR notation first (e.g. "10.0.0.1/32")
-        if let Ok(net) = s.parse::<IpNet>() {
-            return Ok(IpNetConfig(net));
-        }
-        // Fall back to bare IP address — treat as a host network (/32 or /128)
-        s.parse::<IpAddr>()
-            .map(|addr| IpNetConfig(IpNet::from(addr)))
+        return s.parse::<IpNet>()
+            .or_else(|_| s.parse::<IpAddr>().map(|a| a.into()))
+            .map(IpNetConfig)
             .map_err(|_| format!("invalid IP address or network: {s}"))
     }
 }

--- a/lib/vector-core/src/tls/incoming.rs
+++ b/lib/vector-core/src/tls/incoming.rs
@@ -83,33 +83,26 @@ pub struct MaybeTlsListener {
 
 impl MaybeTlsListener {
     pub async fn accept(&mut self) -> crate::tls::Result<MaybeTlsIncomingStream<TcpStream>> {
-        loop {
-            let listener = self
-                .listener
-                .accept()
-                .await
-                .map(|(stream, peer_addr)| {
-                    MaybeTlsIncomingStream::new(stream, peer_addr, self.acceptor.clone())
-                })
-                .context(IncomingListenerSnafu)?;
+        let listener = self
+            .listener
+            .accept()
+            .await
+            .map(|(stream, peer_addr)| {
+                MaybeTlsIncomingStream::new(stream, peer_addr, self.acceptor.clone())
+            })
+            .context(IncomingListenerSnafu)?;
 
-            if let Some(origin_filter) = &self.origin_filter {
-                if origin_filter
-                    .iter()
-                    .any(|net| net.contains(&listener.peer_addr().ip()))
-                {
-                    return Ok(listener);
-                } else {
-                    warn!(
-                        message = "Rejected connection from non-allowed origin.",
-                        peer_addr = %listener.peer_addr(),
-                    );
-                    drop(listener);
-                    continue;
-                }
+        if let Some(origin_filter) = &self.origin_filter {
+            if origin_filter
+                .iter()
+                .any(|net| net.contains(&listener.peer_addr().ip()))
+            {
+                Ok(listener)
             } else {
-                return Ok(listener);
+                Err(TlsError::DisallowedPeer)
             }
+        } else {
+            Ok(listener)
         }
     }
 

--- a/lib/vector-core/src/tls/incoming.rs
+++ b/lib/vector-core/src/tls/incoming.rs
@@ -83,28 +83,33 @@ pub struct MaybeTlsListener {
 
 impl MaybeTlsListener {
     pub async fn accept(&mut self) -> crate::tls::Result<MaybeTlsIncomingStream<TcpStream>> {
-        let listener = self
-            .listener
-            .accept()
-            .await
-            .map(|(stream, peer_addr)| {
-                MaybeTlsIncomingStream::new(stream, peer_addr, self.acceptor.clone())
-            })
-            .context(IncomingListenerSnafu)?;
-
-        if let Some(origin_filter) = &self.origin_filter {
-            if origin_filter
-                .iter()
-                .any(|net| net.contains(&listener.peer_addr().ip()))
-            {
-                Ok(listener)
-            } else {
-                Err(TlsError::Connect {
-                    source: std::io::ErrorKind::ConnectionRefused.into(),
+        loop {
+            let listener = self
+                .listener
+                .accept()
+                .await
+                .map(|(stream, peer_addr)| {
+                    MaybeTlsIncomingStream::new(stream, peer_addr, self.acceptor.clone())
                 })
+                .context(IncomingListenerSnafu)?;
+
+            if let Some(origin_filter) = &self.origin_filter {
+                if origin_filter
+                    .iter()
+                    .any(|net| net.contains(&listener.peer_addr().ip()))
+                {
+                    return Ok(listener);
+                } else {
+                    warn!(
+                        message = "Rejected connection from non-allowed origin.",
+                        peer_addr = %listener.peer_addr(),
+                    );
+                    drop(listener);
+                    continue;
+                }
+            } else {
+                return Ok(listener);
             }
-        } else {
-            Ok(listener)
         }
     }
 

--- a/lib/vector-core/src/tls/mod.rs
+++ b/lib/vector-core/src/tls/mod.rs
@@ -115,7 +115,7 @@ pub enum TlsError {
     TcpBind { source: tokio::io::Error },
     #[snafu(display("{}", source))]
     Connect { source: tokio::io::Error },
-    #[snafu(display("Connection rejected: origin IP not in permit_origin list"))]
+    #[snafu(display("Connection rejected: peer IP address not in permit_origin allowlist"))]
     DisallowedPeer,
     #[snafu(display("Could not get peer address: {}", source))]
     PeerAddress { source: std::io::Error },
@@ -134,12 +134,6 @@ pub enum TlsError {
     NewCaStack { source: ErrorStack },
     #[snafu(display("Could not push intermediate certificate onto stack"))]
     CaStackPush { source: ErrorStack },
-}
-
-impl TlsError {
-    pub fn is_fatal(&self) -> bool {
-        !matches!(self, TlsError::DisallowedPeer)
-    }
 }
 
 impl MaybeTlsStream<TcpStream> {

--- a/lib/vector-core/src/tls/mod.rs
+++ b/lib/vector-core/src/tls/mod.rs
@@ -115,6 +115,8 @@ pub enum TlsError {
     TcpBind { source: tokio::io::Error },
     #[snafu(display("{}", source))]
     Connect { source: tokio::io::Error },
+    #[snafu(display("Connection rejected: origin IP not in permit_origin list"))]
+    DisallowedPeer,
     #[snafu(display("Could not get peer address: {}", source))]
     PeerAddress { source: std::io::Error },
     #[snafu(display("Security Framework Error: {}", source))]
@@ -132,6 +134,12 @@ pub enum TlsError {
     NewCaStack { source: ErrorStack },
     #[snafu(display("Could not push intermediate certificate onto stack"))]
     CaStackPush { source: ErrorStack },
+}
+
+impl TlsError {
+    pub fn is_fatal(&self) -> bool {
+        !matches!(self, TlsError::DisallowedPeer)
+    }
 }
 
 impl MaybeTlsStream<TcpStream> {

--- a/src/internal_events/http.rs
+++ b/src/internal_events/http.rs
@@ -133,6 +133,32 @@ impl InternalEvent for HttpDecompressError<'_> {
     }
 }
 
+#[cfg(feature = "sources-utils-http")]
+pub struct HttpBadPeerConnectionError<'a> {
+    pub error: &'a dyn std::fmt::Display,
+}
+
+#[cfg(feature = "sources-utils-http")]
+impl InternalEvent for HttpBadPeerConnectionError<'_> {
+    fn emit(self) {
+        warn!(
+            message = "Rejected connection from bad peer.",
+            error = %self.error,
+            error_code = "bad_peer",
+            error_type = error_type::CONNECTION_FAILED,
+            stage = error_stage::RECEIVING,
+            internal_log_rate_limit = true,
+        );
+        counter!(
+            "component_errors_total",
+            "error_code" => "bad_peer",
+            "error_type" => error_type::CONNECTION_FAILED,
+            "stage" => error_stage::RECEIVING,
+        )
+        .increment(1);
+    }
+}
+
 pub struct HttpInternalError<'a> {
     pub message: &'a str,
 }

--- a/src/internal_events/http.rs
+++ b/src/internal_events/http.rs
@@ -133,32 +133,6 @@ impl InternalEvent for HttpDecompressError<'_> {
     }
 }
 
-#[cfg(feature = "sources-utils-http")]
-pub struct HttpBadPeerConnectionError<'a> {
-    pub error: &'a dyn std::fmt::Display,
-}
-
-#[cfg(feature = "sources-utils-http")]
-impl InternalEvent for HttpBadPeerConnectionError<'_> {
-    fn emit(self) {
-        warn!(
-            message = "Rejected connection from bad peer.",
-            error = %self.error,
-            error_code = "bad_peer",
-            error_type = error_type::CONNECTION_FAILED,
-            stage = error_stage::RECEIVING,
-            internal_log_rate_limit = true,
-        );
-        counter!(
-            "component_errors_total",
-            "error_code" => "bad_peer",
-            "error_type" => error_type::CONNECTION_FAILED,
-            "stage" => error_stage::RECEIVING,
-        )
-        .increment(1);
-    }
-}
-
 pub struct HttpInternalError<'a> {
     pub message: &'a str,
 }

--- a/src/internal_events/socket.rs
+++ b/src/internal_events/socket.rs
@@ -211,7 +211,7 @@ impl<'a> std::fmt::Debug for IpAllowlistDeniedError<'a> {
 impl InternalEvent for IpAllowlistDeniedError<'_> {
     fn emit(self) {
         warn!(
-            message = "Rejected connection from non-permitted IP.",
+            message = "Rejected connection from non-whitelisted IP.",
             peer = %self.peer,
             error_code = "bad_peer",
             error_type = error_type::CONNECTION_FAILED,

--- a/src/internal_events/socket.rs
+++ b/src/internal_events/socket.rs
@@ -195,3 +195,35 @@ impl<E: std::fmt::Display> InternalEvent for SocketSendError<E> {
         emit!(ComponentEventsDropped::<UNINTENTIONAL> { count: 1, reason });
     }
 }
+
+pub struct IpAllowlistDeniedError<'a> {
+    pub peer: &'a dyn std::fmt::Display,
+}
+
+impl<'a> std::fmt::Debug for IpAllowlistDeniedError<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IpAllowlistDeniedError")
+            .field("peer", &format_args!("{}", self.peer))
+            .finish()
+    }
+}
+
+impl InternalEvent for IpAllowlistDeniedError<'_> {
+    fn emit(self) {
+        warn!(
+            message = "Rejected connection from non-permitted IP.",
+            peer = %self.peer,
+            error_code = "bad_peer",
+            error_type = error_type::CONNECTION_FAILED,
+            stage = error_stage::RECEIVING,
+            internal_log_rate_limit = true,
+        );
+        counter!(
+            "component_errors_total",
+            "error_code" => "bad_peer",
+            "error_type" => error_type::CONNECTION_FAILED,
+            "stage" => error_stage::RECEIVING,
+        )
+        .increment(1);
+    }
+}

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -9,6 +9,7 @@ use tracing::Span;
 use vector_lib::codecs::decoding::{DeserializerConfig, FramingConfig};
 use vector_lib::config::{LegacyKey, LogNamespace};
 use vector_lib::configurable::configurable_component;
+use vector_lib::ipallowlist::IpAllowlistConfig;
 use vector_lib::lookup::owned_value_path;
 use vector_lib::sensitive_string::SensitiveString;
 use vector_lib::tls::MaybeTlsIncomingStream;
@@ -104,6 +105,9 @@ pub struct AwsKinesisFirehoseConfig {
     #[configurable(derived)]
     #[serde(default)]
     keepalive: KeepaliveConfig,
+
+    #[configurable(derived)]
+    pub permit_origin: Option<IpAllowlistConfig>,
 }
 
 const fn access_keys_example() -> [&'static str; 2] {
@@ -181,6 +185,8 @@ impl SourceConfig for AwsKinesisFirehoseConfig {
 
         let tls = MaybeTlsSettings::from_config(self.tls.as_ref(), true)?;
         let listener = tls.bind(&self.address).await?;
+        let listener = listener
+            .with_allowlist(self.permit_origin.clone().map(Into::into));
 
         let keepalive_settings = self.keepalive.clone();
         let shutdown = cx.shutdown;
@@ -261,6 +267,7 @@ impl GenerateConfig for AwsKinesisFirehoseConfig {
             acknowledgements: Default::default(),
             log_namespace: None,
             keepalive: Default::default(),
+            permit_origin: None,
         })
         .unwrap()
     }
@@ -354,6 +361,7 @@ mod tests {
                 acknowledgements: true.into(),
                 log_namespace: Some(log_namespace),
                 keepalive: Default::default(),
+                permit_origin: None,
             }
             .build(cx)
             .await

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -997,4 +997,54 @@ mod tests {
         let result = timeout(Duration::from_millis(200), recv.next()).await;
         assert!(result.is_err(), "expected no events from blocked IP");
     }
+
+#[tokio::test]
+async fn permit_origin_allows_matching_ip() {
+    use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+
+    let (sender, _recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
+    let address = next_addr();
+    let cx = SourceContext::new_test(sender, None);
+
+    let permit_origin = Some(IpAllowlistConfig(vec![
+        IpNetConfig("127.0.0.1/32".parse().unwrap()),
+    ]));
+
+    tokio::spawn(async move {
+        AwsKinesisFirehoseConfig {
+            address,
+            tls: None,
+            access_key: None,
+            access_keys: None,
+            store_access_key: false,
+            record_compression: Compression::None,
+            framing: default_framing_message_based(),
+            decoding: default_decoding(),
+            acknowledgements: true.into(),
+            log_namespace: None,
+            keepalive: Default::default(),
+            permit_origin,
+        }
+        .build(cx)
+        .await
+        .unwrap()
+        .await
+        .unwrap()
+    });
+    wait_for_tcp(address).await;
+
+    // Send from localhost — should be accepted by allowlist
+    let response = reqwest::Client::new()
+        .post(format!("http://{}", address))
+        .header("x-amz-firehose-protocol-version", "1.0")
+        .header("x-amz-firehose-request-id", REQUEST_ID)
+        .header("x-amz-firehose-source-arn", SOURCE_ARN)
+        .header("content-type", "application/json")
+        .body(r#"{"requestId":"test","timestamp":1234567890,"records":[{"data":"dGVzdA=="}]}"#)
+        .send()
+        .await;
+
+    assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
+}
+
 }

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -16,7 +16,7 @@ use vector_lib::tls::MaybeTlsIncomingStream;
 use vrl::value::Kind;
 
 use crate::http::{KeepaliveConfig, MaxConnectionAgeLayer};
-use crate::internal_events::IpAllowlistDeniedError;
+use crate::sources::util::handle_accept_error;
 use crate::{
     codecs::DecodingConfig,
     config::{
@@ -208,19 +208,7 @@ impl SourceConfig for AwsKinesisFirehoseConfig {
             });
 
             Server::builder(hyper::server::accept::from_stream(
-                listener.accept_stream().filter_map(|result| async move {
-                    match result {
-                        Ok(stream) => Some(Ok::<_, Infallible>(stream)),
-                        Err(err) => {
-                            if err == TlsError::DisallowedPeer {
-                                emit!(IpAllowlistDeniedError { peer: &err });
-                            } else {
-                                warn!(message = "Accept failed", error = %err);
-                            }
-                            None
-                        }
-                    }
-                }),
+                listener.accept_stream().filter_map(handle_accept_error),
             ))
                 .serve(make_svc)
                 .with_graceful_shutdown(shutdown.map(|_| ()))

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 use std::{convert::Infallible, fmt, net::SocketAddr};
 
-use futures::FutureExt;
+use futures::{FutureExt, StreamExt};
 use hyper::{service::make_service_fn, Server};
 use tokio::net::TcpStream;
 use tower::ServiceBuilder;
@@ -16,6 +16,7 @@ use vector_lib::tls::MaybeTlsIncomingStream;
 use vrl::value::Kind;
 
 use crate::http::{KeepaliveConfig, MaxConnectionAgeLayer};
+use crate::internal_events::HttpBadPeerConnectionError;
 use crate::{
     codecs::DecodingConfig,
     config::{
@@ -206,7 +207,21 @@ impl SourceConfig for AwsKinesisFirehoseConfig {
                 futures_util::future::ok::<_, Infallible>(svc)
             });
 
-            Server::builder(hyper::server::accept::from_stream(listener.accept_stream()))
+            Server::builder(hyper::server::accept::from_stream(
+                listener.accept_stream().filter_map(|result| async move {
+                    match result {
+                        Ok(stream) => Some(Ok::<_, Infallible>(stream)),
+                        Err(err) => {
+                            if err.is_fatal() {
+                                warn!(message = "Fatal error accepting connection.", error = %err);
+                            } else {
+                                emit!(HttpBadPeerConnectionError { error: &err });
+                            }
+                            None
+                        }
+                    }
+                }),
+            ))
                 .serve(make_svc)
                 .with_graceful_shutdown(shutdown.map(|_| ()))
                 .await

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -945,4 +945,56 @@ mod tests {
             .get("aws_kinesis_firehose_access_key")
             .is_none());
     }
+
+    #[tokio::test]
+    async fn permit_origin_blocks_non_matching_ip() {
+        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+        use tokio::time::{timeout, Duration};
+        use futures::StreamExt;
+
+        let (sender, mut recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
+        let address = next_addr();
+        let cx = SourceContext::new_test(sender, None);
+
+        let permit_origin = Some(IpAllowlistConfig(vec![
+            IpNetConfig("10.0.0.1/32".parse().unwrap()),
+        ]));
+
+        tokio::spawn(async move {
+            AwsKinesisFirehoseConfig {
+                address,
+                tls: None,
+                access_key: None,
+                access_keys: None,
+                store_access_key: false,
+                record_compression: Compression::None,
+                framing: default_framing_message_based(),
+                decoding: default_decoding(),
+                acknowledgements: true.into(),
+                log_namespace: None,
+                keepalive: Default::default(),
+                permit_origin,
+            }
+            .build(cx)
+            .await
+            .unwrap()
+            .await
+            .unwrap()
+        });
+        wait_for_tcp(address).await;
+
+        // Send from localhost — should be blocked by allowlist
+        let _ = reqwest::Client::new()
+            .post(format!("http://{}", address))
+            .header("x-amz-firehose-protocol-version", "1.0")
+            .header("x-amz-firehose-request-id", REQUEST_ID)
+            .header("x-amz-firehose-source-arn", SOURCE_ARN)
+            .header("content-type", "application/json")
+            .body(r#"{"requestId":"test","timestamp":1234567890,"records":[{"data":"dGVzdA=="}]}"#)
+            .send()
+            .await;
+
+        let result = timeout(Duration::from_millis(200), recv.next()).await;
+        assert!(result.is_err(), "expected no events from blocked IP");
+    }
 }

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -16,7 +16,7 @@ use vector_lib::tls::MaybeTlsIncomingStream;
 use vrl::value::Kind;
 
 use crate::http::{KeepaliveConfig, MaxConnectionAgeLayer};
-use crate::internal_events::HttpBadPeerConnectionError;
+use crate::internal_events::IpAllowlistDeniedError;
 use crate::{
     codecs::DecodingConfig,
     config::{
@@ -215,7 +215,7 @@ impl SourceConfig for AwsKinesisFirehoseConfig {
                             if err.is_fatal() {
                                 warn!(message = "Fatal error accepting connection.", error = %err);
                             } else {
-                                emit!(HttpBadPeerConnectionError { error: &err });
+                                emit!(IpAllowlistDeniedError { peer: &err });
                             }
                             None
                         }

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -212,10 +212,10 @@ impl SourceConfig for AwsKinesisFirehoseConfig {
                     match result {
                         Ok(stream) => Some(Ok::<_, Infallible>(stream)),
                         Err(err) => {
-                            if err.is_fatal() {
-                                warn!(message = "Fatal error accepting connection.", error = %err);
-                            } else {
+                            if err == TlsError::DisallowedPeer {
                                 emit!(IpAllowlistDeniedError { peer: &err });
+                            } else {
+                                warn!(message = "Accept failed", error = %err);
                             }
                             None
                         }

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -961,20 +961,16 @@ mod tests {
             .is_none());
     }
 
-    #[tokio::test]
-    async fn permit_origin_blocks_non_matching_ip() {
-        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
-        use tokio::time::{timeout, Duration};
-        use futures::StreamExt;
-
-        let (sender, mut recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
+    async fn spawn_with_permit_origin(
+        cidrs: &[&str],
+    ) -> (impl Stream<Item = Event> + Unpin, SocketAddr) {
+        use vector_lib::ipallowlist::IpAllowlistConfig;
+        let permit_origin = Some(IpAllowlistConfig(
+            cidrs.iter().map(|s| s.parse().unwrap()).collect(),
+        ));
+        let (sender, recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
         let address = next_addr();
         let cx = SourceContext::new_test(sender, None);
-
-        let permit_origin = Some(IpAllowlistConfig(vec![
-            IpNetConfig("10.0.0.1/32".parse().unwrap()),
-        ]));
-
         tokio::spawn(async move {
             AwsKinesisFirehoseConfig {
                 address,
@@ -997,9 +993,11 @@ mod tests {
             .unwrap()
         });
         wait_for_tcp(address).await;
+        (recv, address)
+    }
 
-        // Send from localhost — should be blocked by allowlist
-        let _ = reqwest::Client::new()
+    async fn send_firehose_request(address: SocketAddr) -> reqwest::Result<reqwest::Response> {
+        reqwest::Client::new()
             .post(format!("http://{}", address))
             .header("x-amz-firehose-protocol-version", "1.0")
             .header("x-amz-firehose-request-id", REQUEST_ID)
@@ -1007,59 +1005,48 @@ mod tests {
             .header("content-type", "application/json")
             .body(r#"{"requestId":"test","timestamp":1234567890,"records":[{"data":"dGVzdA=="}]}"#)
             .send()
-            .await;
-
-        let result = timeout(Duration::from_millis(200), recv.next()).await;
-        assert!(result.is_err(), "expected no events from blocked IP");
+            .await
     }
 
-#[tokio::test]
-async fn permit_origin_allows_matching_ip() {
-    use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+    #[tokio::test]
+    async fn permit_origin_allows_matching_ip() {
+        use crate::test_util::collect_n;
+        let (recv, address) = spawn_with_permit_origin(&["127.0.0.1"]).await;
+        // Run concurrently: the server waits for event ack before sending the HTTP
+        // response, so collecting must happen in parallel with the request.
+        let (response, events) = tokio::join!(send_firehose_request(address), collect_n(recv, 1));
+        assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].as_log()["message"],
+            "test".into()
+        );
+        assert_eq!(
+            events[0].as_log()["request_id"],
+            REQUEST_ID.into()
+        );
+    }
 
-    let (sender, _recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
-    let address = next_addr();
-    let cx = SourceContext::new_test(sender, None);
+    #[tokio::test]
+    async fn permit_origin_blocks_non_fatal_emits_bad_peer_metric() {
+        use crate::metrics::{self, Controller};
 
-    let permit_origin = Some(IpAllowlistConfig(vec![
-        IpNetConfig("127.0.0.1/32".parse().unwrap()),
-    ]));
+        metrics::init_test();
+        let (_, address) = spawn_with_permit_origin(&["10.0.0.1/32"]).await;
+        let _ = send_firehose_request(address).await;
 
-    tokio::spawn(async move {
-        AwsKinesisFirehoseConfig {
-            address,
-            tls: None,
-            access_key: None,
-            access_keys: None,
-            store_access_key: false,
-            record_compression: Compression::None,
-            framing: default_framing_message_based(),
-            decoding: default_decoding(),
-            acknowledgements: true.into(),
-            log_namespace: None,
-            keepalive: Default::default(),
-            permit_origin,
-        }
-        .build(cx)
-        .await
-        .unwrap()
-        .await
-        .unwrap()
-    });
-    wait_for_tcp(address).await;
+        // Verify the server is still alive — rejection must be non-fatal
+        tokio::net::TcpStream::connect(address)
+            .await
+            .expect("server should still be running after non-fatal bad peer rejection");
 
-    // Send from localhost — should be accepted by allowlist
-    let response = reqwest::Client::new()
-        .post(format!("http://{}", address))
-        .header("x-amz-firehose-protocol-version", "1.0")
-        .header("x-amz-firehose-request-id", REQUEST_ID)
-        .header("x-amz-firehose-source-arn", SOURCE_ARN)
-        .header("content-type", "application/json")
-        .body(r#"{"requestId":"test","timestamp":1234567890,"records":[{"data":"dGVzdA=="}]}"#)
-        .send()
-        .await;
-
-    assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
-}
+        // Verify the bad_peer error metric was emitted
+        let controller = Controller::get().expect("metrics controller not initialized");
+        let has_bad_peer_error = controller
+            .capture_metrics()
+            .into_iter()
+            .any(|m| m.name() == "component_errors_total" && m.tag_matches("error_code", "bad_peer"));
+        assert!(has_bad_peer_error, "expected component_errors_total with error_code=bad_peer");
+    }
 
 }

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -56,7 +56,7 @@ use crate::{
         SourceContext, SourceOutput,
     },
     event::Event,
-    internal_events::{HttpBadPeerConnectionError, HttpBytesReceived, HttpDecompressError, StreamClosedError},
+    internal_events::{IpAllowlistDeniedError, HttpBytesReceived, HttpDecompressError, StreamClosedError},
     schema,
     serde::{bool_or_struct, default_decoding, default_framing_message_based},
     sources::{self, util::ErrorMessage},
@@ -238,7 +238,7 @@ impl SourceConfig for DatadogAgentConfig {
                             if err.is_fatal() {
                                 warn!(message = "Fatal error accepting connection.", error = %err);
                             } else {
-                                emit!(HttpBadPeerConnectionError { error: &err });
+                                emit!(IpAllowlistDeniedError { peer: &err });
                             }
                             None
                         }

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -37,6 +37,7 @@ use tracing::Span;
 use vector_lib::codecs::decoding::{DeserializerConfig, FramingConfig};
 use vector_lib::config::{LegacyKey, LogNamespace};
 use vector_lib::configurable::configurable_component;
+use vector_lib::ipallowlist::IpAllowlistConfig;
 use vector_lib::event::{BatchNotifier, BatchStatus};
 use vector_lib::internal_event::{EventsReceived, Registered};
 use vector_lib::lookup::owned_value_path;
@@ -141,6 +142,9 @@ pub struct DatadogAgentConfig {
     #[configurable(derived)]
     #[serde(default)]
     keepalive: KeepaliveConfig,
+
+    #[configurable(derived)]
+    pub permit_origin: Option<IpAllowlistConfig>,
 }
 
 impl GenerateConfig for DatadogAgentConfig {
@@ -159,6 +163,7 @@ impl GenerateConfig for DatadogAgentConfig {
             parse_ddtags: false,
             log_namespace: Some(false),
             keepalive: KeepaliveConfig::default(),
+            permit_origin: None,
         })
         .unwrap()
     }
@@ -190,6 +195,8 @@ impl SourceConfig for DatadogAgentConfig {
             self.parse_ddtags,
         );
         let listener = tls.bind(&self.address).await?;
+        let listener = listener
+            .with_allowlist(self.permit_origin.clone().map(Into::into));
         let acknowledgements = cx.do_acknowledgements(self.acknowledgements);
         let filters = source.build_warp_filters(cx.out, acknowledgements, self)?;
         let shutdown = cx.shutdown;

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -49,6 +49,7 @@ use vrl::value::Kind;
 use warp::{filters::BoxedFilter, reject::Rejection, reply::Response, Filter, Reply};
 
 use crate::http::{build_http_trace_layer, KeepaliveConfig, MaxConnectionAgeLayer};
+use crate::sources::util::handle_accept_error;
 use crate::{
     codecs::{Decoder, DecodingConfig},
     config::{
@@ -56,7 +57,7 @@ use crate::{
         SourceContext, SourceOutput,
     },
     event::Event,
-    internal_events::{IpAllowlistDeniedError, HttpBytesReceived, HttpDecompressError, StreamClosedError},
+    internal_events::{HttpBytesReceived, HttpDecompressError, StreamClosedError},
     schema,
     serde::{bool_or_struct, default_decoding, default_framing_message_based},
     sources::{self, util::ErrorMessage},
@@ -231,19 +232,7 @@ impl SourceConfig for DatadogAgentConfig {
             });
 
             Server::builder(hyper::server::accept::from_stream(
-                listener.accept_stream().filter_map(|result| async move {
-                    match result {
-                        Ok(stream) => Some(Ok::<_, Infallible>(stream)),
-                        Err(err) => {
-                            if err.is_fatal() {
-                                warn!(message = "Fatal error accepting connection.", error = %err);
-                            } else {
-                                emit!(IpAllowlistDeniedError { peer: &err });
-                            }
-                            None
-                        }
-                    }
-                }),
+                listener.accept_stream().filter_map(handle_accept_error),
             ))
                 .serve(make_svc)
                 .with_graceful_shutdown(shutdown.map(|_| ()))

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -24,7 +24,7 @@ use std::{fmt::Debug, io::Read, net::SocketAddr, sync::Arc};
 use bytes::{Buf, Bytes};
 use chrono::{serde::ts_milliseconds, DateTime, Utc};
 use flate2::read::{MultiGzDecoder, ZlibDecoder};
-use futures::FutureExt;
+use futures::{FutureExt, StreamExt};
 use http::StatusCode;
 use hyper::service::make_service_fn;
 use hyper::Server;
@@ -56,7 +56,7 @@ use crate::{
         SourceContext, SourceOutput,
     },
     event::Event,
-    internal_events::{HttpBytesReceived, HttpDecompressError, StreamClosedError},
+    internal_events::{HttpBadPeerConnectionError, HttpBytesReceived, HttpDecompressError, StreamClosedError},
     schema,
     serde::{bool_or_struct, default_decoding, default_framing_message_based},
     sources::{self, util::ErrorMessage},
@@ -230,7 +230,21 @@ impl SourceConfig for DatadogAgentConfig {
                 futures_util::future::ok::<_, Infallible>(svc)
             });
 
-            Server::builder(hyper::server::accept::from_stream(listener.accept_stream()))
+            Server::builder(hyper::server::accept::from_stream(
+                listener.accept_stream().filter_map(|result| async move {
+                    match result {
+                        Ok(stream) => Some(Ok::<_, Infallible>(stream)),
+                        Err(err) => {
+                            if err.is_fatal() {
+                                warn!(message = "Fatal error accepting connection.", error = %err);
+                            } else {
+                                emit!(HttpBadPeerConnectionError { error: &err });
+                            }
+                            None
+                        }
+                    }
+                }),
+            ))
                 .serve(make_svc)
                 .with_graceful_shutdown(shutdown.map(|_| ()))
                 .await

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -2563,19 +2563,15 @@ impl ValidatableComponent for DatadogAgentConfig {
     }
 }
 
-#[tokio::test]
-async fn permit_origin_blocks_non_matching_ip() {
-    use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
-    use tokio::time::{timeout, Duration};
-
+async fn spawn_datadog_with_permit_origin(
+    cidrs: &[&str],
+) -> (impl Stream<Item = Event> + Unpin, SocketAddr) {
+    use vector_lib::ipallowlist::IpAllowlistConfig;
+    let permit_origin = Some(IpAllowlistConfig(
+        cidrs.iter().map(|s| s.parse().unwrap()).collect(),
+    ));
     let (sender, recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
-    let mut recv = recv;
     let address = next_addr();
-
-    let permit_origin = Some(IpAllowlistConfig(vec![
-        IpNetConfig("10.0.0.1/32".parse().unwrap()),
-    ]));
-
     let config = toml::from_str::<DatadogAgentConfig>(&format!(
         indoc! { r#"
             address = "{}"
@@ -2585,116 +2581,44 @@ async fn permit_origin_blocks_non_matching_ip() {
         address
     ))
     .unwrap();
-
-    // Override permit_origin since toml deserialization defaults to None
-    let config = DatadogAgentConfig {
-        permit_origin,
-        ..config
-    };
-
-    let context = SourceContext::new_test(sender, None);
+    let config = DatadogAgentConfig { permit_origin, ..config };
+    let mut schema_defs = HashMap::new();
+    schema_defs.insert(Some(LOGS.to_owned()), test_logs_schema_definition());
+    let context = SourceContext::new_test(sender, Some(schema_defs));
     tokio::spawn(async move {
         config.build(context).await.unwrap().await.unwrap();
     });
     wait_for_tcp(address).await;
+    (recv, address)
+}
 
-    // Send from localhost — should be blocked by allowlist
-    let _ = reqwest::Client::new()
+async fn send_datadog_request(address: SocketAddr) -> reqwest::Result<reqwest::Response> {
+    reqwest::Client::new()
         .post(format!("http://{}/v1/input/", address))
-        .body(r#"[{"message":"blocked"}]"#)
+        .body(r#"[{"message":"test","status":"info","timestamp":0,"hostname":"host","service":"svc","ddsource":"src","ddtags":""}]"#)
         .send()
-        .await;
-
-    let result = timeout(Duration::from_millis(200), recv.next()).await;
-    assert!(result.is_err(), "expected no events from blocked IP");
+        .await
 }
 
 #[tokio::test]
 async fn permit_origin_allows_matching_ip() {
-    use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
-
-    let (sender, _recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
-    let address = next_addr();
-
-    let permit_origin = Some(IpAllowlistConfig(vec![
-        IpNetConfig("127.0.0.1/32".parse().unwrap()),
-    ]));
-
-    let config = toml::from_str::<DatadogAgentConfig>(&format!(
-        indoc! { r#"
-            address = "{}"
-            compression = "none"
-            store_api_key = false
-        "#},
-        address
-    ))
-    .unwrap();
-
-    let config = DatadogAgentConfig {
-        permit_origin,
-        ..config
-    };
-
-    let context = SourceContext::new_test(sender, None);
-    tokio::spawn(async move {
-        config.build(context).await.unwrap().await.unwrap();
-    });
-    wait_for_tcp(address).await;
-
-    // Send from localhost — should be accepted by allowlist
-    let response = reqwest::Client::new()
-        .post(format!("http://{}/v1/input/", address))
-        .body(r#"[{"message":"allowed"}]"#)
-        .send()
-        .await;
-
+    use crate::test_util::collect_n;
+    let (recv, address) = spawn_datadog_with_permit_origin(&["127.0.0.1"]).await;
+    let response = send_datadog_request(address).await;
     assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
+    assert_eq!(response.unwrap().status(), 200);
+    let events = collect_n(recv, 1).await;
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].as_log()["message"], Value::Bytes(Bytes::from("test")));
 }
 
 #[tokio::test]
 async fn permit_origin_blocks_non_fatal_emits_bad_peer_metric() {
     use crate::metrics::{self, Controller};
-    use tokio::time::{sleep, Duration};
-    use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
 
     metrics::init_test();
-
-    let (sender, _recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
-    let address = next_addr();
-
-    let permit_origin = Some(IpAllowlistConfig(vec![
-        IpNetConfig("10.0.0.1/32".parse().unwrap()),
-    ]));
-
-    let config = toml::from_str::<DatadogAgentConfig>(&format!(
-        indoc! { r#"
-            address = "{}"
-            compression = "none"
-            store_api_key = false
-        "#},
-        address
-    ))
-    .unwrap();
-
-    let config = DatadogAgentConfig {
-        permit_origin,
-        ..config
-    };
-
-    let context = SourceContext::new_test(sender, None);
-    tokio::spawn(async move {
-        config.build(context).await.unwrap().await.unwrap();
-    });
-    wait_for_tcp(address).await;
-
-    // Send from localhost — should be blocked by allowlist
-    let _ = reqwest::Client::new()
-        .post(format!("http://{}/v1/input/", address))
-        .body(r#"[{"message":"blocked"}]"#)
-        .send()
-        .await;
-
-    sleep(Duration::from_millis(100)).await;
+    let (_, address) = spawn_datadog_with_permit_origin(&["10.0.0.1/32"]).await;
+    let _ = send_datadog_request(address).await;
 
     // Verify the server is still alive — rejection must be non-fatal
     tokio::net::TcpStream::connect(address)

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -1578,6 +1578,7 @@ fn test_config_outputs_with_disabled_data_types() {
             parse_ddtags: false,
             log_namespace: Some(false),
             keepalive: Default::default(),
+            permit_origin: None,
         };
 
         let outputs: Vec<DataType> = config
@@ -2020,6 +2021,7 @@ fn test_config_outputs() {
             parse_ddtags: false,
             log_namespace: Some(false),
             keepalive: Default::default(),
+            permit_origin: None,
         };
 
         let mut outputs = config
@@ -2527,6 +2529,7 @@ impl ValidatableComponent for DatadogAgentConfig {
             parse_ddtags: false,
             log_namespace: Some(false),
             keepalive: Default::default(),
+            permit_origin: None,
         };
 
         let log_namespace: LogNamespace = config.log_namespace.unwrap_or_default().into();

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -2609,4 +2609,46 @@ async fn permit_origin_blocks_non_matching_ip() {
     assert!(result.is_err(), "expected no events from blocked IP");
 }
 
+#[tokio::test]
+async fn permit_origin_allows_matching_ip() {
+    use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+
+    let (sender, _recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
+    let address = next_addr();
+
+    let permit_origin = Some(IpAllowlistConfig(vec![
+        IpNetConfig("127.0.0.1/32".parse().unwrap()),
+    ]));
+
+    let config = toml::from_str::<DatadogAgentConfig>(&format!(
+        indoc! { r#"
+            address = "{}"
+            compression = "none"
+            store_api_key = false
+        "#},
+        address
+    ))
+    .unwrap();
+
+    let config = DatadogAgentConfig {
+        permit_origin,
+        ..config
+    };
+
+    let context = SourceContext::new_test(sender, None);
+    tokio::spawn(async move {
+        config.build(context).await.unwrap().await.unwrap();
+    });
+    wait_for_tcp(address).await;
+
+    // Send from localhost — should be accepted by allowlist
+    let response = reqwest::Client::new()
+        .post(format!("http://{}/v1/input/", address))
+        .body(r#"[{"message":"allowed"}]"#)
+        .send()
+        .await;
+
+    assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
+}
+
 register_validatable_component!(DatadogAgentConfig);

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -2563,4 +2563,50 @@ impl ValidatableComponent for DatadogAgentConfig {
     }
 }
 
+#[tokio::test]
+async fn permit_origin_blocks_non_matching_ip() {
+    use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+    use tokio::time::{timeout, Duration};
+
+    let (sender, recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
+    let mut recv = recv;
+    let address = next_addr();
+
+    let permit_origin = Some(IpAllowlistConfig(vec![
+        IpNetConfig("10.0.0.1/32".parse().unwrap()),
+    ]));
+
+    let config = toml::from_str::<DatadogAgentConfig>(&format!(
+        indoc! { r#"
+            address = "{}"
+            compression = "none"
+            store_api_key = false
+        "#},
+        address
+    ))
+    .unwrap();
+
+    // Override permit_origin since toml deserialization defaults to None
+    let config = DatadogAgentConfig {
+        permit_origin,
+        ..config
+    };
+
+    let context = SourceContext::new_test(sender, None);
+    tokio::spawn(async move {
+        config.build(context).await.unwrap().await.unwrap();
+    });
+    wait_for_tcp(address).await;
+
+    // Send from localhost — should be blocked by allowlist
+    let _ = reqwest::Client::new()
+        .post(format!("http://{}/v1/input/", address))
+        .body(r#"[{"message":"blocked"}]"#)
+        .send()
+        .await;
+
+    let result = timeout(Duration::from_millis(200), recv.next()).await;
+    assert!(result.is_err(), "expected no events from blocked IP");
+}
+
 register_validatable_component!(DatadogAgentConfig);

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -2651,4 +2651,63 @@ async fn permit_origin_allows_matching_ip() {
     assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
 }
 
+#[tokio::test]
+async fn permit_origin_blocks_non_fatal_emits_bad_peer_metric() {
+    use crate::metrics::{self, Controller};
+    use tokio::time::{sleep, Duration};
+    use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+
+    metrics::init_test();
+
+    let (sender, _recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
+    let address = next_addr();
+
+    let permit_origin = Some(IpAllowlistConfig(vec![
+        IpNetConfig("10.0.0.1/32".parse().unwrap()),
+    ]));
+
+    let config = toml::from_str::<DatadogAgentConfig>(&format!(
+        indoc! { r#"
+            address = "{}"
+            compression = "none"
+            store_api_key = false
+        "#},
+        address
+    ))
+    .unwrap();
+
+    let config = DatadogAgentConfig {
+        permit_origin,
+        ..config
+    };
+
+    let context = SourceContext::new_test(sender, None);
+    tokio::spawn(async move {
+        config.build(context).await.unwrap().await.unwrap();
+    });
+    wait_for_tcp(address).await;
+
+    // Send from localhost — should be blocked by allowlist
+    let _ = reqwest::Client::new()
+        .post(format!("http://{}/v1/input/", address))
+        .body(r#"[{"message":"blocked"}]"#)
+        .send()
+        .await;
+
+    sleep(Duration::from_millis(100)).await;
+
+    // Verify the server is still alive — rejection must be non-fatal
+    tokio::net::TcpStream::connect(address)
+        .await
+        .expect("server should still be running after non-fatal bad peer rejection");
+
+    // Verify the bad_peer error metric was emitted
+    let controller = Controller::get().expect("metrics controller not initialized");
+    let has_bad_peer_error = controller
+        .capture_metrics()
+        .into_iter()
+        .any(|m| m.name() == "component_errors_total" && m.tag_matches("error_code", "bad_peer"));
+    assert!(has_bad_peer_error, "expected component_errors_total with error_code=bad_peer");
+}
+
 register_validatable_component!(DatadogAgentConfig);

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -817,4 +817,51 @@ mod tests {
 
         assert_eq!(definitions, Some(expected_definition))
     }
+
+    #[tokio::test]
+    async fn permit_origin_blocks_non_matching_ip() {
+        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+        use tokio::time::{timeout, Duration};
+        use futures::StreamExt;
+
+        let (sender, mut recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
+        let address = next_addr();
+        let context = SourceContext::new_test(sender, None);
+
+        let permit_origin = Some(IpAllowlistConfig(vec![
+            IpNetConfig("10.0.0.1/32".parse().unwrap()),
+        ]));
+
+        tokio::spawn(async move {
+            LogplexConfig {
+                address,
+                query_parameters: vec![],
+                tls: None,
+                auth: None,
+                framing: default_framing_message_based(),
+                decoding: default_decoding(),
+                acknowledgements: false.into(),
+                log_namespace: None,
+                keepalive: Default::default(),
+                permit_origin,
+            }
+            .build(context)
+            .await
+            .unwrap()
+            .await
+            .unwrap()
+        });
+        wait_for_tcp(address).await;
+
+        // Send from localhost — should be blocked by allowlist
+        let _ = reqwest::Client::new()
+            .post(format!("http://{}/events", address))
+            .header("Logplex-Msg-Count", "1")
+            .body("test heroku blocked")
+            .send()
+            .await;
+
+        let result = timeout(Duration::from_millis(200), recv.next()).await;
+        assert!(result.is_err(), "expected no events from blocked IP");
+    }
 }

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -818,94 +818,93 @@ mod tests {
         assert_eq!(definitions, Some(expected_definition))
     }
 
+    fn assert_bad_peer_metric_emitted() {
+        let controller = vector_lib::metrics::Controller::get()
+            .expect("metrics controller not initialized");
+        let has_bad_peer = controller
+            .capture_metrics()
+            .into_iter()
+            .any(|m| m.name() == "component_errors_total" && m.tag_matches("error_code", "bad_peer"));
+        assert!(has_bad_peer, "expected component_errors_total with error_code=bad_peer");
+    }
+
+    async fn build_and_spawn_logplex_source(
+        address: std::net::SocketAddr,
+        cidr: &str,
+        sender: SourceSender,
+    ) {
+        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+        let permit_origin = Some(IpAllowlistConfig(vec![
+            IpNetConfig(cidr.parse().unwrap()),
+        ]));
+        let context = SourceContext::new_test(sender, None);
+        tokio::spawn(async move {
+            LogplexConfig {
+                address,
+                query_parameters: vec![],
+                tls: None,
+                auth: None,
+                framing: default_framing_message_based(),
+                decoding: default_decoding(),
+                acknowledgements: false.into(),
+                log_namespace: None,
+                keepalive: Default::default(),
+                permit_origin,
+            }
+            .build(context)
+            .await
+            .unwrap()
+            .await
+            .unwrap()
+        });
+        wait_for_tcp(address).await;
+    }
+
+    async fn send_logplex_event(
+        address: std::net::SocketAddr,
+        body: &'static str,
+    ) -> reqwest::Result<reqwest::Response> {
+        reqwest::Client::new()
+            .post(format!("http://{}/events", address))
+            .header("Logplex-Msg-Count", "1")
+            .header("Logplex-Frame-Id", "frame-foo")
+            .header("Logplex-Drain-Token", "drain-bar")
+            .body(body)
+            .send()
+            .await
+    }
+
     #[tokio::test]
     async fn permit_origin_blocks_non_matching_ip() {
-        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+        use tokio::time::{timeout, Duration};
+        use futures::StreamExt;
+
+        vector_lib::metrics::init_test();
+
+        let (sender, mut recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
+        let address = next_addr();
+        build_and_spawn_logplex_source(address, "10.0.0.1/32", sender).await;
+
+        let _ = send_logplex_event(address, "test heroku blocked").await;
+        let result = timeout(Duration::from_millis(200), recv.next()).await;
+        assert!(result.is_err(), "expected no events from blocked IP");
+        assert_bad_peer_metric_emitted();
+    }
+
+    #[tokio::test]
+    async fn permit_origin_allows_matching_ip() {
         use tokio::time::{timeout, Duration};
         use futures::StreamExt;
 
         let (sender, mut recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
         let address = next_addr();
-        let context = SourceContext::new_test(sender, None);
+        build_and_spawn_logplex_source(address, "127.0.0.1/32", sender).await;
 
-        let permit_origin = Some(IpAllowlistConfig(vec![
-            IpNetConfig("10.0.0.1/32".parse().unwrap()),
-        ]));
-
-        tokio::spawn(async move {
-            LogplexConfig {
-                address,
-                query_parameters: vec![],
-                tls: None,
-                auth: None,
-                framing: default_framing_message_based(),
-                decoding: default_decoding(),
-                acknowledgements: false.into(),
-                log_namespace: None,
-                keepalive: Default::default(),
-                permit_origin,
-            }
-            .build(context)
-            .await
-            .unwrap()
-            .await
-            .unwrap()
-        });
-        wait_for_tcp(address).await;
-
-        // Send from localhost — should be blocked by allowlist
-        let _ = reqwest::Client::new()
-            .post(format!("http://{}/events", address))
-            .header("Logplex-Msg-Count", "1")
-            .body("test heroku blocked")
-            .send()
-            .await;
-
-        let result = timeout(Duration::from_millis(200), recv.next()).await;
-        assert!(result.is_err(), "expected no events from blocked IP");
-    }
-
-    #[tokio::test]
-    async fn permit_origin_allows_matching_ip() {
-        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
-
-        let (sender, _recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
-        let address = next_addr();
-        let context = SourceContext::new_test(sender, None);
-
-        let permit_origin = Some(IpAllowlistConfig(vec![
-            IpNetConfig("127.0.0.1/32".parse().unwrap()),
-        ]));
-
-        tokio::spawn(async move {
-            LogplexConfig {
-                address,
-                query_parameters: vec![],
-                tls: None,
-                auth: None,
-                framing: default_framing_message_based(),
-                decoding: default_decoding(),
-                acknowledgements: false.into(),
-                log_namespace: None,
-                keepalive: Default::default(),
-                permit_origin,
-            }
-            .build(context)
-            .await
-            .unwrap()
-            .await
-            .unwrap()
-        });
-        wait_for_tcp(address).await;
-
-        // Send from localhost — should be accepted by allowlist
-        let response = reqwest::Client::new()
-            .post(format!("http://{}/events", address))
-            .header("Logplex-Msg-Count", "1")
-            .body("test heroku allowed")
-            .send()
-            .await;
-
+        let response = send_logplex_event(address, SAMPLE_BODY).await;
         assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
+        assert_eq!(response.unwrap().status(), 200);
+        let event = timeout(Duration::from_millis(500), recv.next()).await;
+        assert!(event.is_ok(), "expected to receive event from allowed IP");
+        assert!(event.unwrap().unwrap().as_log().contains("message"), "expected log event to contain message field");
     }
 }

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -18,6 +18,7 @@ use vrl::value::{kind::Collection, Kind};
 use warp::http::{HeaderMap, StatusCode};
 
 use vector_lib::configurable::configurable_component;
+use vector_lib::ipallowlist::IpAllowlistConfig;
 use vector_lib::{
     config::{LegacyKey, LogNamespace},
     schema::Definition,
@@ -92,6 +93,9 @@ pub struct LogplexConfig {
     #[configurable(derived)]
     #[serde(default)]
     keepalive: KeepaliveConfig,
+
+    #[configurable(derived)]
+    pub permit_origin: Option<IpAllowlistConfig>,
 }
 
 impl LogplexConfig {
@@ -162,6 +166,7 @@ impl Default for LogplexConfig {
             acknowledgements: SourceAcknowledgementsConfig::default(),
             log_namespace: None,
             keepalive: KeepaliveConfig::default(),
+            permit_origin: None,
         }
     }
 }
@@ -202,6 +207,7 @@ impl SourceConfig for LogplexConfig {
             cx,
             self.acknowledgements,
             self.keepalive.clone(),
+            self.permit_origin.clone(),
         )
     }
 
@@ -474,6 +480,7 @@ mod tests {
                 acknowledgements: acknowledgements.into(),
                 log_namespace: None,
                 keepalive: Default::default(),
+                permit_origin: None,
             }
             .build(context)
             .await

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -864,4 +864,48 @@ mod tests {
         let result = timeout(Duration::from_millis(200), recv.next()).await;
         assert!(result.is_err(), "expected no events from blocked IP");
     }
+
+    #[tokio::test]
+    async fn permit_origin_allows_matching_ip() {
+        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+
+        let (sender, _recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
+        let address = next_addr();
+        let context = SourceContext::new_test(sender, None);
+
+        let permit_origin = Some(IpAllowlistConfig(vec![
+            IpNetConfig("127.0.0.1/32".parse().unwrap()),
+        ]));
+
+        tokio::spawn(async move {
+            LogplexConfig {
+                address,
+                query_parameters: vec![],
+                tls: None,
+                auth: None,
+                framing: default_framing_message_based(),
+                decoding: default_decoding(),
+                acknowledgements: false.into(),
+                log_namespace: None,
+                keepalive: Default::default(),
+                permit_origin,
+            }
+            .build(context)
+            .await
+            .unwrap()
+            .await
+            .unwrap()
+        });
+        wait_for_tcp(address).await;
+
+        // Send from localhost — should be accepted by allowlist
+        let response = reqwest::Client::new()
+            .post(format!("http://{}/events", address))
+            .header("Logplex-Msg-Count", "1")
+            .body("test heroku allowed")
+            .send()
+            .await;
+
+        assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
+    }
 }

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -564,6 +564,7 @@ mod tests {
     };
 
     use super::{remove_duplicates, SimpleHttpConfig};
+    use vector_lib::ipallowlist::IpAllowlistConfig;
 
     #[test]
     fn generate_config() {
@@ -684,6 +685,26 @@ mod tests {
         });
         wait_for_tcp(address).await;
         (recv, address)
+    }
+
+    async fn spawn_simple_http_source(
+        address: SocketAddr,
+        permit_origin: Option<IpAllowlistConfig>,
+        context: SourceContext,
+    ) {
+        tokio::spawn(async move {
+            SimpleHttpConfig {
+                address,
+                permit_origin,
+                ..Default::default()
+            }
+            .build(context)
+            .await
+            .unwrap()
+            .await
+            .unwrap();
+        });
+        wait_for_tcp(address).await;
     }
 
     async fn send(address: SocketAddr, body: &str) -> u16 {
@@ -1796,7 +1817,7 @@ mod tests {
 
     #[tokio::test]
     async fn permit_origin_blocks_non_matching_ip() {
-        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+        use vector_lib::ipallowlist::IpNetConfig;
         use tokio::time::{timeout, Duration};
         use futures::StreamExt;
 
@@ -1808,34 +1829,7 @@ mod tests {
             IpNetConfig("10.0.0.1/32".parse().unwrap()),
         ]));
 
-        tokio::spawn(async move {
-            SimpleHttpConfig {
-                address,
-                headers: vec![],
-                encoding: None,
-                query_parameters: vec![],
-                response_code: StatusCode::OK,
-                tls: None,
-                auth: None,
-                strict_path: true,
-                path_key: OptionalValuePath::from(owned_value_path!("path")),
-                host_key: OptionalValuePath::from(owned_value_path!("host")),
-                path: "/".to_owned(),
-                method: HttpMethod::Post,
-                framing: None,
-                decoding: None,
-                acknowledgements: false.into(),
-                log_namespace: None,
-                keepalive: Default::default(),
-                permit_origin,
-            }
-            .build(context)
-            .await
-            .unwrap()
-            .await
-            .unwrap();
-        });
-        wait_for_tcp(address).await;
+        spawn_simple_http_source(address, permit_origin, context).await;
 
         // Send from localhost — should be blocked by allowlist
         let _ = reqwest::Client::new()
@@ -1850,7 +1844,7 @@ mod tests {
 
     #[tokio::test]
     async fn permit_origin_allows_matching_ip() {
-        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+        use vector_lib::ipallowlist::IpNetConfig;
 
         let (sender, _recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
         let address = next_addr();
@@ -1860,34 +1854,7 @@ mod tests {
             IpNetConfig("127.0.0.1/32".parse().unwrap()),
         ]));
 
-        tokio::spawn(async move {
-            SimpleHttpConfig {
-                address,
-                headers: vec![],
-                encoding: None,
-                query_parameters: vec![],
-                response_code: StatusCode::OK,
-                tls: None,
-                auth: None,
-                strict_path: true,
-                path_key: OptionalValuePath::from(owned_value_path!("path")),
-                host_key: OptionalValuePath::from(owned_value_path!("host")),
-                path: "/".to_owned(),
-                method: HttpMethod::Post,
-                framing: None,
-                decoding: None,
-                acknowledgements: false.into(),
-                log_namespace: None,
-                keepalive: Default::default(),
-                permit_origin,
-            }
-            .build(context)
-            .await
-            .unwrap()
-            .await
-            .unwrap();
-        });
-        wait_for_tcp(address).await;
+        spawn_simple_http_source(address, permit_origin, context).await;
 
         // Send from localhost — should be accepted by allowlist
         let response = reqwest::Client::new()
@@ -1897,6 +1864,11 @@ mod tests {
             .await;
 
         assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
+        let res = response.unwrap();
+        assert_eq!(res.status(), 200);
+        let body = res.text().await.unwrap();
+        assert!(body.is_empty(), "expected empty response body, got: {}", body);
+
     }
 
     register_validatable_component!(SimpleHttpConfig);

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -1848,5 +1848,56 @@ mod tests {
         assert!(result.is_err(), "expected no events from blocked IP");
     }
 
+    #[tokio::test]
+    async fn permit_origin_allows_matching_ip() {
+        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+
+        let (sender, _recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
+        let address = next_addr();
+        let context = SourceContext::new_test(sender, None);
+
+        let permit_origin = Some(IpAllowlistConfig(vec![
+            IpNetConfig("127.0.0.1/32".parse().unwrap()),
+        ]));
+
+        tokio::spawn(async move {
+            SimpleHttpConfig {
+                address,
+                headers: vec![],
+                encoding: None,
+                query_parameters: vec![],
+                response_code: StatusCode::OK,
+                tls: None,
+                auth: None,
+                strict_path: true,
+                path_key: OptionalValuePath::from(owned_value_path!("path")),
+                host_key: OptionalValuePath::from(owned_value_path!("host")),
+                path: "/".to_owned(),
+                method: HttpMethod::Post,
+                framing: None,
+                decoding: None,
+                acknowledgements: false.into(),
+                log_namespace: None,
+                keepalive: Default::default(),
+                permit_origin,
+            }
+            .build(context)
+            .await
+            .unwrap()
+            .await
+            .unwrap();
+        });
+        wait_for_tcp(address).await;
+
+        // Send from localhost — should be accepted by allowlist
+        let response = reqwest::Client::new()
+            .post(format!("http://{}/", address))
+            .body("allowed")
+            .send()
+            .await;
+
+        assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
+    }
+
     register_validatable_component!(SimpleHttpConfig);
 }

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -1815,60 +1815,76 @@ mod tests {
         assert_eq!(events.len(), 1);
     }
 
+    fn assert_bad_peer_metric_emitted() {
+        let controller = vector_lib::metrics::Controller::get()
+            .expect("metrics controller not initialized");
+        let has_bad_peer = controller
+            .capture_metrics()
+            .into_iter()
+            .any(|m| m.name() == "component_errors_total" && m.tag_matches("error_code", "bad_peer"));
+        assert!(has_bad_peer, "expected component_errors_total with error_code=bad_peer");
+    }
+
+    async fn build_and_spawn_http_source(
+        address: std::net::SocketAddr,
+        cidr: &str,
+        sender: SourceSender,
+    ) {
+        use vector_lib::ipallowlist::IpNetConfig;
+        let permit_origin = Some(IpAllowlistConfig(vec![
+            IpNetConfig(cidr.parse().unwrap()),
+        ]));
+        let context = SourceContext::new_test(sender, None);
+        spawn_simple_http_source(address, permit_origin, context).await;
+    }
+
+    async fn send_http_event(
+        address: std::net::SocketAddr,
+        body: &'static str,
+    ) -> reqwest::Result<reqwest::Response> {
+        reqwest::Client::new()
+            .post(format!("http://{}/", address))
+            .body(body)
+            .send()
+            .await
+    }
+
     #[tokio::test]
     async fn permit_origin_blocks_non_matching_ip() {
-        use vector_lib::ipallowlist::IpNetConfig;
+        use tokio::time::{timeout, Duration};
+        use futures::StreamExt;
+
+        vector_lib::metrics::init_test();
+
+        let (sender, mut recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
+        let address = next_addr();
+        build_and_spawn_http_source(address, "10.0.0.1/32", sender).await;
+
+        let _ = send_http_event(address, "blocked").await;
+        let result = timeout(Duration::from_millis(200), recv.next()).await;
+        assert!(result.is_err(), "expected no events from blocked IP");
+        assert_bad_peer_metric_emitted();
+    }
+
+    #[tokio::test]
+    async fn permit_origin_allows_matching_ip() {
         use tokio::time::{timeout, Duration};
         use futures::StreamExt;
 
         let (sender, mut recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
         let address = next_addr();
-        let context = SourceContext::new_test(sender, None);
+        build_and_spawn_http_source(address, "127.0.0.1/32", sender).await;
 
-        let permit_origin = Some(IpAllowlistConfig(vec![
-            IpNetConfig("10.0.0.1/32".parse().unwrap()),
-        ]));
-
-        spawn_simple_http_source(address, permit_origin, context).await;
-
-        // Send from localhost — should be blocked by allowlist
-        let _ = reqwest::Client::new()
-            .post(format!("http://{}/", address))
-            .body("blocked")
-            .send()
-            .await;
-
-        let result = timeout(Duration::from_millis(200), recv.next()).await;
-        assert!(result.is_err(), "expected no events from blocked IP");
-    }
-
-    #[tokio::test]
-    async fn permit_origin_allows_matching_ip() {
-        use vector_lib::ipallowlist::IpNetConfig;
-
-        let (sender, _recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
-        let address = next_addr();
-        let context = SourceContext::new_test(sender, None);
-
-        let permit_origin = Some(IpAllowlistConfig(vec![
-            IpNetConfig("127.0.0.1/32".parse().unwrap()),
-        ]));
-
-        spawn_simple_http_source(address, permit_origin, context).await;
-
-        // Send from localhost — should be accepted by allowlist
-        let response = reqwest::Client::new()
-            .post(format!("http://{}/", address))
-            .body("allowed")
-            .send()
-            .await;
-
+        let response = send_http_event(address, "allowed").await;
         assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
-        let res = response.unwrap();
-        assert_eq!(res.status(), 200);
-        let body = res.text().await.unwrap();
-        assert!(body.is_empty(), "expected empty response body, got: {}", body);
-
+        assert_eq!(response.unwrap().status(), 200);
+        let event = timeout(Duration::from_millis(500), recv.next()).await;
+        assert!(event.is_ok(), "expected to receive event from allowed IP");
+        let log = event.unwrap().unwrap().into_log();
+        assert_eq!(
+            log.get(event_path!("message")).and_then(|v| v.as_str()).as_deref(),
+            Some("allowed"),
+        );
     }
 
     register_validatable_component!(SimpleHttpConfig);

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -1794,5 +1794,59 @@ mod tests {
         assert_eq!(events.len(), 1);
     }
 
+    #[tokio::test]
+    async fn permit_origin_blocks_non_matching_ip() {
+        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+        use tokio::time::{timeout, Duration};
+        use futures::StreamExt;
+
+        let (sender, mut recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
+        let address = next_addr();
+        let context = SourceContext::new_test(sender, None);
+
+        let permit_origin = Some(IpAllowlistConfig(vec![
+            IpNetConfig("10.0.0.1/32".parse().unwrap()),
+        ]));
+
+        tokio::spawn(async move {
+            SimpleHttpConfig {
+                address,
+                headers: vec![],
+                encoding: None,
+                query_parameters: vec![],
+                response_code: StatusCode::OK,
+                tls: None,
+                auth: None,
+                strict_path: true,
+                path_key: OptionalValuePath::from(owned_value_path!("path")),
+                host_key: OptionalValuePath::from(owned_value_path!("host")),
+                path: "/".to_owned(),
+                method: HttpMethod::Post,
+                framing: None,
+                decoding: None,
+                acknowledgements: false.into(),
+                log_namespace: None,
+                keepalive: Default::default(),
+                permit_origin,
+            }
+            .build(context)
+            .await
+            .unwrap()
+            .await
+            .unwrap();
+        });
+        wait_for_tcp(address).await;
+
+        // Send from localhost — should be blocked by allowlist
+        let _ = reqwest::Client::new()
+            .post(format!("http://{}/", address))
+            .body("blocked")
+            .send()
+            .await;
+
+        let result = timeout(Duration::from_millis(200), recv.next()).await;
+        assert!(result.is_err(), "expected no events from blocked IP");
+    }
+
     register_validatable_component!(SimpleHttpConfig);
 }

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -14,6 +14,7 @@ use vector_lib::codecs::{
     NewlineDelimitedDecoderConfig,
 };
 use vector_lib::configurable::configurable_component;
+use vector_lib::ipallowlist::IpAllowlistConfig;
 use vector_lib::lookup::{lookup_v2::OptionalValuePath, owned_value_path, path};
 use vector_lib::{
     config::{DataType, LegacyKey, LogNamespace},
@@ -174,6 +175,9 @@ pub struct SimpleHttpConfig {
     #[configurable(derived)]
     #[serde(default)]
     keepalive: KeepaliveConfig,
+
+    #[configurable(derived)]
+    pub permit_origin: Option<IpAllowlistConfig>,
 }
 
 impl SimpleHttpConfig {
@@ -285,6 +289,7 @@ impl Default for SimpleHttpConfig {
             acknowledgements: SourceAcknowledgementsConfig::default(),
             log_namespace: None,
             keepalive: KeepaliveConfig::default(),
+            permit_origin: None,
         }
     }
 }
@@ -384,6 +389,7 @@ impl SourceConfig for SimpleHttpConfig {
             cx,
             self.acknowledgements,
             self.keepalive.clone(),
+            self.permit_origin.clone(),
         )
     }
 
@@ -610,6 +616,7 @@ mod tests {
                 acknowledgements: acknowledgements.into(),
                 log_namespace: None,
                 keepalive: Default::default(),
+                permit_origin: None,
             }
             .build(context)
             .await
@@ -667,6 +674,7 @@ mod tests {
                 acknowledgements: acknowledgements.into(),
                 log_namespace: None,
                 keepalive: Default::default(),
+                permit_origin: None,
             }
             .build(context)
             .await

--- a/src/sources/opentelemetry/http.rs
+++ b/src/sources/opentelemetry/http.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 use std::{convert::Infallible, net::SocketAddr};
 
 use bytes::Bytes;
-use futures_util::FutureExt;
+use futures_util::{FutureExt, StreamExt};
 use http::StatusCode;
 use hyper::{service::make_service_fn, Server};
 use prost::Message;
@@ -36,7 +36,7 @@ use crate::sources::util::add_headers;
 use crate::{
     event::Event,
     http::build_http_trace_layer,
-    internal_events::{EventsReceived, StreamClosedError},
+    internal_events::{EventsReceived, HttpBadPeerConnectionError, StreamClosedError},
     shutdown::ShutdownSignal,
     sources::util::{decode, ErrorMessage},
     tls::MaybeTlsSettings,
@@ -83,7 +83,21 @@ pub(crate) async fn run_http_server(
         futures_util::future::ok::<_, Infallible>(svc)
     });
 
-    Server::builder(hyper::server::accept::from_stream(listener.accept_stream()))
+    Server::builder(hyper::server::accept::from_stream(
+        listener.accept_stream().filter_map(|result| async move {
+            match result {
+                Ok(stream) => Some(Ok::<_, Infallible>(stream)),
+                Err(err) => {
+                    if err.is_fatal() {
+                        warn!(message = "Fatal error accepting connection.", error = %err);
+                    } else {
+                        emit!(HttpBadPeerConnectionError { error: &err });
+                    }
+                    None
+                }
+            }
+        }),
+    ))
         .serve(make_svc)
         .with_graceful_shutdown(shutdown.map(|_| ()))
         .await?;

--- a/src/sources/opentelemetry/http.rs
+++ b/src/sources/opentelemetry/http.rs
@@ -33,10 +33,11 @@ use vector_lib::ipallowlist::IpAllowlistConfig;
 use crate::http::{KeepaliveConfig, MaxConnectionAgeLayer};
 use crate::sources::http_server::HttpConfigParamKind;
 use crate::sources::util::add_headers;
+use crate::sources::util::handle_accept_error;
 use crate::{
     event::Event,
     http::build_http_trace_layer,
-    internal_events::{EventsReceived, IpAllowlistDeniedError, StreamClosedError},
+    internal_events::{EventsReceived, StreamClosedError},
     shutdown::ShutdownSignal,
     sources::util::{decode, ErrorMessage},
     tls::MaybeTlsSettings,
@@ -84,19 +85,7 @@ pub(crate) async fn run_http_server(
     });
 
     Server::builder(hyper::server::accept::from_stream(
-        listener.accept_stream().filter_map(|result| async move {
-            match result {
-                Ok(stream) => Some(Ok::<_, Infallible>(stream)),
-                Err(err) => {
-                    if err.is_fatal() {
-                        warn!(message = "Fatal error accepting connection.", error = %err);
-                    } else {
-                        emit!(IpAllowlistDeniedError { peer: &err });
-                    }
-                    None
-                }
-            }
-        }),
+        listener.accept_stream().filter_map(handle_accept_error),
     ))
         .serve(make_svc)
         .with_graceful_shutdown(shutdown.map(|_| ()))

--- a/src/sources/opentelemetry/http.rs
+++ b/src/sources/opentelemetry/http.rs
@@ -28,6 +28,8 @@ use warp::{
     filters::BoxedFilter, http::HeaderMap, reject::Rejection, reply::Response, Filter, Reply,
 };
 
+use vector_lib::ipallowlist::IpAllowlistConfig;
+
 use crate::http::{KeepaliveConfig, MaxConnectionAgeLayer};
 use crate::sources::http_server::HttpConfigParamKind;
 use crate::sources::util::add_headers;
@@ -57,8 +59,11 @@ pub(crate) async fn run_http_server(
     filters: BoxedFilter<(Response,)>,
     shutdown: ShutdownSignal,
     keepalive_settings: KeepaliveConfig,
+    permit_origin: Option<IpAllowlistConfig>,
 ) -> crate::Result<()> {
     let listener = tls_settings.bind(&address).await?;
+    let listener = listener
+        .with_allowlist(permit_origin.map(Into::into));
     let routes = filters.recover(handle_rejection);
 
     info!(message = "Building HTTP server.", address = %address);

--- a/src/sources/opentelemetry/http.rs
+++ b/src/sources/opentelemetry/http.rs
@@ -36,7 +36,7 @@ use crate::sources::util::add_headers;
 use crate::{
     event::Event,
     http::build_http_trace_layer,
-    internal_events::{EventsReceived, HttpBadPeerConnectionError, StreamClosedError},
+    internal_events::{EventsReceived, IpAllowlistDeniedError, StreamClosedError},
     shutdown::ShutdownSignal,
     sources::util::{decode, ErrorMessage},
     tls::MaybeTlsSettings,
@@ -91,7 +91,7 @@ pub(crate) async fn run_http_server(
                     if err.is_fatal() {
                         warn!(message = "Fatal error accepting connection.", error = %err);
                     } else {
-                        emit!(HttpBadPeerConnectionError { error: &err });
+                        emit!(IpAllowlistDeniedError { peer: &err });
                     }
                     None
                 }

--- a/src/sources/opentelemetry/mod.rs
+++ b/src/sources/opentelemetry/mod.rs
@@ -20,6 +20,7 @@ use vector_lib::opentelemetry::logs::{
 
 use tonic::transport::server::RoutesBuilder;
 use vector_lib::configurable::configurable_component;
+use vector_lib::ipallowlist::IpAllowlistConfig;
 use vector_lib::internal_event::{BytesReceived, EventsReceived, Protocol};
 use vector_lib::opentelemetry::proto::collector::{
     logs::v1::logs_service_server::LogsServiceServer,
@@ -72,6 +73,9 @@ pub struct OpentelemetryConfig {
     #[configurable(metadata(docs::hidden))]
     #[serde(default)]
     log_namespace: Option<bool>,
+
+    #[configurable(derived)]
+    pub permit_origin: Option<IpAllowlistConfig>,
 }
 
 /// Configuration for the `opentelemetry` gRPC server.
@@ -149,6 +153,7 @@ impl GenerateConfig for OpentelemetryConfig {
             http: Option::from(example_http_config()),
             acknowledgements: Default::default(),
             log_namespace: None,
+            permit_origin: None,
         })
         .unwrap()
     }
@@ -211,6 +216,7 @@ impl SourceConfig for OpentelemetryConfig {
                 grpc_tls_settings,
                 builder.routes(),
                 cx.shutdown.clone(),
+                self.permit_origin.clone(),
             )
             .map_err(|error| {
                 error!(message = "Source future failed.", %error);
@@ -239,6 +245,7 @@ impl SourceConfig for OpentelemetryConfig {
                 filters,
                 cx.shutdown,
                 http_config.keepalive.clone(),
+                self.permit_origin.clone(),
             ))
         } else {
             None

--- a/src/sources/opentelemetry/tests.rs
+++ b/src/sources/opentelemetry/tests.rs
@@ -1136,6 +1136,7 @@ async fn http_headers() {
             http: http_config,
             acknowledgements: Default::default(),
             log_namespace: Default::default(),
+            permit_origin: None,
         };
         let schema_definitions = source
             .outputs(LogNamespace::Legacy)
@@ -1243,6 +1244,7 @@ async fn only_http_config() {
             http: http_config,
             acknowledgements: Default::default(),
             log_namespace: Default::default(),
+            permit_origin: None,
         };
         let schema_definitions = source
             .outputs(LogNamespace::Legacy)
@@ -1500,6 +1502,7 @@ pub async fn build_otlp_test_env(
         http: http_config,
         acknowledgements: Default::default(),
         log_namespace,
+        permit_origin: None,
     };
 
     let (sender, output, _) = new_source(EventStatus::Delivered, event_name.to_string());
@@ -1537,6 +1540,7 @@ pub async fn build_only_grpc_otlp_test_env(
         http: http_config,
         acknowledgements: Default::default(),
         log_namespace,
+        permit_origin: None,
     };
 
     let (sender, output, _) = new_source(EventStatus::Delivered, event_name.to_string());

--- a/src/sources/opentelemetry/tests.rs
+++ b/src/sources/opentelemetry/tests.rs
@@ -20,7 +20,7 @@ use futures_util::StreamExt;
 use prost::Message;
 use similar_asserts::assert_eq;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH, Duration};
 use tonic::Request;
 use vector_lib::config::LogNamespace;
 use vector_lib::lookup::path;
@@ -1623,10 +1623,34 @@ async fn build_and_spawn_http_source(
 async fn send_test_requests(
     http_addr: std::net::SocketAddr,
 ) -> reqwest::Result<reqwest::Response> {
+    let req = ExportLogsServiceRequest {
+        resource_logs: vec![ResourceLogs {
+            resource: None,
+            scope_logs: vec![ScopeLogs {
+                scope: None,
+                log_records: vec![LogRecord {
+                    time_unix_nano: 1,
+                    observed_time_unix_nano: 2,
+                    severity_number: 9,
+                    severity_text: "info".into(),
+                    body: Some(AnyValue {
+                        value: Some(any_value::Value::StringValue("permit origin test".into())),
+                    }),
+                    attributes: vec![],
+                    dropped_attributes_count: 0,
+                    flags: 0,
+                    trace_id: vec![],
+                    span_id: vec![],
+                }],
+                schema_url: String::new(),
+            }],
+            schema_url: String::new(),
+        }],
+    };
     reqwest::Client::new()
         .post(format!("http://{}/v1/logs", http_addr))
         .header("Content-Type", "application/x-protobuf")
-        .body("test")
+        .body(req.encode_to_vec())
         .send()
         .await
 }
@@ -1635,16 +1659,21 @@ async fn send_test_requests(
 async fn permit_origin_allows_matching_ip() {
     let http_addr = next_addr();
     let config = make_permit_origin_http_config(http_addr, "127.0.0.1/32");
-    let (sender, _output, _) = new_source(EventStatus::Delivered, LOGS.to_string());
+    let (sender, output, _) = new_source(EventStatus::Delivered, LOGS.to_string());
     build_and_spawn_http_source(http_addr, config, sender).await;
 
     let response = send_test_requests(http_addr).await;
     assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
     let res = response.unwrap();
-    assert!(res.status().is_client_error() || res.status().is_success());
-    let body = res.text().await.unwrap();
-    assert!(body.contains("test") || !body.is_empty(), "expected body to contain 'test' or have content");
-    
+    assert!(res.status().is_success(), "expected 200 OK for allowed IP with valid protobuf");
+
+    let events = test_util::collect_ready(output).await;
+    assert_eq!(events.len(), 1, "expected one event from the accepted and parsed log request");
+    let log = events[0].as_log();
+    assert_eq!(
+        log.get("message").unwrap(),
+        &Value::from("permit origin test")
+    );
 }
 
 #[tokio::test]
@@ -1655,7 +1684,7 @@ async fn permit_origin_blocks_non_fatal_emits_bad_peer_metric() {
 
     let http_addr = next_addr();
     let config = make_permit_origin_http_config(http_addr, "10.0.0.1/32");
-    let (sender, _output, _) = new_source(EventStatus::Delivered, LOGS.to_string());
+    let (sender, mut output, _) = new_source(EventStatus::Delivered, LOGS.to_string());
     build_and_spawn_http_source(http_addr, config, sender).await;
 
     let _ = send_test_requests(http_addr).await;
@@ -1672,6 +1701,10 @@ async fn permit_origin_blocks_non_fatal_emits_bad_peer_metric() {
         .into_iter()
         .any(|m| m.name() == "component_errors_total" && m.tag_matches("error_code", "bad_peer"));
     assert!(has_bad_peer_error, "expected component_errors_total with error_code=bad_peer");
+    assert!(
+        tokio::time::timeout(Duration::from_secs(1), output.next()).await.is_err(),
+        "expected no events for blocked IP"
+    );
 }
 
 fn current_time_and_nanos() -> (SystemTime, u64) {

--- a/src/sources/opentelemetry/tests.rs
+++ b/src/sources/opentelemetry/tests.rs
@@ -1674,6 +1674,65 @@ async fn permit_origin_allows_matching_ip() {
     assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
 }
 
+#[tokio::test]
+async fn permit_origin_blocks_non_fatal_emits_bad_peer_metric() {
+    use crate::metrics::{self, Controller};
+    use tokio::time::{sleep, Duration};
+    use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+
+    metrics::init_test();
+
+    let http_addr = next_addr();
+
+    let permit_origin = Some(IpAllowlistConfig(vec![
+        IpNetConfig("10.0.0.1/32".parse().unwrap()),
+    ]));
+
+    let config = OpentelemetryConfig {
+        grpc: None,
+        http: Some(HttpConfig {
+            address: http_addr,
+            tls: Default::default(),
+            keepalive: Default::default(),
+            headers: Default::default(),
+        }),
+        acknowledgements: Default::default(),
+        log_namespace: None,
+        permit_origin,
+    };
+
+    let (sender, _output, _) = new_source(EventStatus::Delivered, LOGS.to_string());
+    let server = config
+        .build(SourceContext::new_test(sender, None))
+        .await
+        .expect("Failed to build source");
+    tokio::spawn(server);
+    test_util::wait_for_tcp(http_addr).await;
+
+    // Send from localhost — should be blocked by allowlist
+    let _ = reqwest::Client::new()
+        .post(format!("http://{}/v1/logs", http_addr))
+        .header("Content-Type", "application/x-protobuf")
+        .body(vec![0u8; 0])
+        .send()
+        .await;
+
+    sleep(Duration::from_millis(100)).await;
+
+    // Verify the server is still alive — rejection must be non-fatal
+    tokio::net::TcpStream::connect(http_addr)
+        .await
+        .expect("server should still be running after non-fatal bad peer rejection");
+
+    // Verify the bad_peer error metric was emitted
+    let controller = Controller::get().expect("metrics controller not initialized");
+    let has_bad_peer_error = controller
+        .capture_metrics()
+        .into_iter()
+        .any(|m| m.name() == "component_errors_total" && m.tag_matches("error_code", "bad_peer"));
+    assert!(has_bad_peer_error, "expected component_errors_total with error_code=bad_peer");
+}
+
 fn current_time_and_nanos() -> (SystemTime, u64) {
     let time = SystemTime::now();
     let nanos = time

--- a/src/sources/opentelemetry/tests.rs
+++ b/src/sources/opentelemetry/tests.rs
@@ -1635,16 +1635,16 @@ async fn send_test_requests(
 async fn permit_origin_allows_matching_ip() {
     let http_addr = next_addr();
     let config = make_permit_origin_http_config(http_addr, "127.0.0.1/32");
-    let (sender, output, _) = new_source(EventStatus::Delivered, LOGS.to_string());
+    let (sender, _output, _) = new_source(EventStatus::Delivered, LOGS.to_string());
     build_and_spawn_http_source(http_addr, config, sender).await;
 
     let response = send_test_requests(http_addr).await;
     assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
+    let res = response.unwrap();
+    assert!(res.status().is_client_error() || res.status().is_success());
+    let body = res.text().await.unwrap();
+    assert!(body.contains("test") || !body.is_empty(), "expected body to contain 'test' or have content");
     
-    use tokio::time::{timeout, Duration};
-    use futures::StreamExt;
-    let result = timeout(Duration::from_millis(500), output.next()).await;
-    assert!(result.is_ok(), "expected to receive event from allowed IP");
 }
 
 #[tokio::test]

--- a/src/sources/opentelemetry/tests.rs
+++ b/src/sources/opentelemetry/tests.rs
@@ -1588,6 +1588,50 @@ fn vec_into_btmap(arr: Vec<(&'static str, Value)>) -> ObjectMap {
     )
 }
 
+#[tokio::test]
+async fn permit_origin_blocks_non_matching_ip() {
+    use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+    use tokio::time::{timeout, Duration};
+
+    let http_addr = next_addr();
+
+    let permit_origin = Some(IpAllowlistConfig(vec![
+        IpNetConfig("10.0.0.1/32".parse().unwrap()),
+    ]));
+
+    let config = OpentelemetryConfig {
+        grpc: None,
+        http: Some(HttpConfig {
+            address: http_addr,
+            tls: Default::default(),
+            keepalive: Default::default(),
+            headers: Default::default(),
+        }),
+        acknowledgements: Default::default(),
+        log_namespace: None,
+        permit_origin,
+    };
+
+    let (sender, mut output, _) = new_source(EventStatus::Delivered, LOGS.to_string());
+    let server = config
+        .build(SourceContext::new_test(sender, None))
+        .await
+        .expect("Failed to build source");
+    tokio::spawn(server);
+    test_util::wait_for_tcp(http_addr).await;
+
+    // Send from localhost — should be blocked by allowlist
+    let _ = reqwest::Client::new()
+        .post(format!("http://{}/v1/logs", http_addr))
+        .header("Content-Type", "application/x-protobuf")
+        .body(vec![0u8; 0])
+        .send()
+        .await;
+
+    let result = timeout(Duration::from_millis(200), output.next()).await;
+    assert!(result.is_err(), "expected no events from blocked IP");
+}
+
 fn current_time_and_nanos() -> (SystemTime, u64) {
     let time = SystemTime::now();
     let nanos = time

--- a/src/sources/opentelemetry/tests.rs
+++ b/src/sources/opentelemetry/tests.rs
@@ -1632,6 +1632,48 @@ async fn permit_origin_blocks_non_matching_ip() {
     assert!(result.is_err(), "expected no events from blocked IP");
 }
 
+#[tokio::test]
+async fn permit_origin_allows_matching_ip() {
+    use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+
+    let http_addr = next_addr();
+
+    let permit_origin = Some(IpAllowlistConfig(vec![
+        IpNetConfig("127.0.0.1/32".parse().unwrap()),
+    ]));
+
+    let config = OpentelemetryConfig {
+        grpc: None,
+        http: Some(HttpConfig {
+            address: http_addr,
+            tls: Default::default(),
+            keepalive: Default::default(),
+            headers: Default::default(),
+        }),
+        acknowledgements: Default::default(),
+        log_namespace: None,
+        permit_origin,
+    };
+
+    let (sender, _output, _) = new_source(EventStatus::Delivered, LOGS.to_string());
+    let server = config
+        .build(SourceContext::new_test(sender, None))
+        .await
+        .expect("Failed to build source");
+    tokio::spawn(server);
+    test_util::wait_for_tcp(http_addr).await;
+
+    // Send from localhost — should be accepted by allowlist
+    let response = reqwest::Client::new()
+        .post(format!("http://{}/v1/logs", http_addr))
+        .header("Content-Type", "application/x-protobuf")
+        .body(vec![0u8; 0])
+        .send()
+        .await;
+
+    assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
+}
+
 fn current_time_and_nanos() -> (SystemTime, u64) {
     let time = SystemTime::now();
     let nanos = time

--- a/src/sources/opentelemetry/tests.rs
+++ b/src/sources/opentelemetry/tests.rs
@@ -1588,18 +1588,12 @@ fn vec_into_btmap(arr: Vec<(&'static str, Value)>) -> ObjectMap {
     )
 }
 
-#[tokio::test]
-async fn permit_origin_blocks_non_matching_ip() {
-    use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
-    use tokio::time::{timeout, Duration};
-
-    let http_addr = next_addr();
-
-    let permit_origin = Some(IpAllowlistConfig(vec![
-        IpNetConfig("10.0.0.1/32".parse().unwrap()),
-    ]));
-
-    let config = OpentelemetryConfig {
+fn make_permit_origin_http_config(
+    http_addr: std::net::SocketAddr,
+    cidr: &str,
+) -> OpentelemetryConfig {
+    use vector_lib::ipallowlist::IpAllowlistConfig;
+    OpentelemetryConfig {
         grpc: None,
         http: Some(HttpConfig {
             address: http_addr,
@@ -1609,115 +1603,62 @@ async fn permit_origin_blocks_non_matching_ip() {
         }),
         acknowledgements: Default::default(),
         log_namespace: None,
-        permit_origin,
-    };
+        permit_origin: Some(IpAllowlistConfig(vec![cidr.parse().unwrap()])),
+    }
+}
 
-    let (sender, mut output, _) = new_source(EventStatus::Delivered, LOGS.to_string());
+async fn build_and_spawn_http_source(
+    addr: std::net::SocketAddr,
+    config: OpentelemetryConfig,
+    sender: SourceSender,
+) {
     let server = config
         .build(SourceContext::new_test(sender, None))
         .await
         .expect("Failed to build source");
     tokio::spawn(server);
-    test_util::wait_for_tcp(http_addr).await;
+    test_util::wait_for_tcp(addr).await;
+}
 
-    // Send from localhost — should be blocked by allowlist
-    let _ = reqwest::Client::new()
+async fn send_test_requests(
+    http_addr: std::net::SocketAddr,
+) -> reqwest::Result<reqwest::Response> {
+    reqwest::Client::new()
         .post(format!("http://{}/v1/logs", http_addr))
         .header("Content-Type", "application/x-protobuf")
-        .body(vec![0u8; 0])
+        .body("test")
         .send()
-        .await;
-
-    let result = timeout(Duration::from_millis(200), output.next()).await;
-    assert!(result.is_err(), "expected no events from blocked IP");
+        .await
 }
 
 #[tokio::test]
 async fn permit_origin_allows_matching_ip() {
-    use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
-
     let http_addr = next_addr();
+    let config = make_permit_origin_http_config(http_addr, "127.0.0.1/32");
+    let (sender, output, _) = new_source(EventStatus::Delivered, LOGS.to_string());
+    build_and_spawn_http_source(http_addr, config, sender).await;
 
-    let permit_origin = Some(IpAllowlistConfig(vec![
-        IpNetConfig("127.0.0.1/32".parse().unwrap()),
-    ]));
-
-    let config = OpentelemetryConfig {
-        grpc: None,
-        http: Some(HttpConfig {
-            address: http_addr,
-            tls: Default::default(),
-            keepalive: Default::default(),
-            headers: Default::default(),
-        }),
-        acknowledgements: Default::default(),
-        log_namespace: None,
-        permit_origin,
-    };
-
-    let (sender, _output, _) = new_source(EventStatus::Delivered, LOGS.to_string());
-    let server = config
-        .build(SourceContext::new_test(sender, None))
-        .await
-        .expect("Failed to build source");
-    tokio::spawn(server);
-    test_util::wait_for_tcp(http_addr).await;
-
-    // Send from localhost — should be accepted by allowlist
-    let response = reqwest::Client::new()
-        .post(format!("http://{}/v1/logs", http_addr))
-        .header("Content-Type", "application/x-protobuf")
-        .body(vec![0u8; 0])
-        .send()
-        .await;
-
+    let response = send_test_requests(http_addr).await;
     assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
+    
+    use tokio::time::{timeout, Duration};
+    use futures::StreamExt;
+    let result = timeout(Duration::from_millis(500), output.next()).await;
+    assert!(result.is_ok(), "expected to receive event from allowed IP");
 }
 
 #[tokio::test]
 async fn permit_origin_blocks_non_fatal_emits_bad_peer_metric() {
     use crate::metrics::{self, Controller};
-    use tokio::time::{sleep, Duration};
-    use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
 
     metrics::init_test();
 
     let http_addr = next_addr();
-
-    let permit_origin = Some(IpAllowlistConfig(vec![
-        IpNetConfig("10.0.0.1/32".parse().unwrap()),
-    ]));
-
-    let config = OpentelemetryConfig {
-        grpc: None,
-        http: Some(HttpConfig {
-            address: http_addr,
-            tls: Default::default(),
-            keepalive: Default::default(),
-            headers: Default::default(),
-        }),
-        acknowledgements: Default::default(),
-        log_namespace: None,
-        permit_origin,
-    };
-
+    let config = make_permit_origin_http_config(http_addr, "10.0.0.1/32");
     let (sender, _output, _) = new_source(EventStatus::Delivered, LOGS.to_string());
-    let server = config
-        .build(SourceContext::new_test(sender, None))
-        .await
-        .expect("Failed to build source");
-    tokio::spawn(server);
-    test_util::wait_for_tcp(http_addr).await;
+    build_and_spawn_http_source(http_addr, config, sender).await;
 
-    // Send from localhost — should be blocked by allowlist
-    let _ = reqwest::Client::new()
-        .post(format!("http://{}/v1/logs", http_addr))
-        .header("Content-Type", "application/x-protobuf")
-        .body(vec![0u8; 0])
-        .send()
-        .await;
-
-    sleep(Duration::from_millis(100)).await;
+    let _ = send_test_requests(http_addr).await;
 
     // Verify the server is still alive — rejection must be non-fatal
     tokio::net::TcpStream::connect(http_addr)

--- a/src/sources/prometheus/pushgateway.rs
+++ b/src/sources/prometheus/pushgateway.rs
@@ -19,6 +19,7 @@ use bytes::Bytes;
 use itertools::Itertools;
 use vector_lib::config::LogNamespace;
 use vector_lib::configurable::configurable_component;
+use vector_lib::ipallowlist::IpAllowlistConfig;
 use warp::http::HeaderMap;
 
 use super::parser;
@@ -70,6 +71,9 @@ pub struct PrometheusPushgatewayConfig {
     /// meaningfully aggregated.
     #[serde(default = "crate::serde::default_false")]
     aggregate_metrics: bool,
+
+    #[configurable(derived)]
+    pub permit_origin: Option<IpAllowlistConfig>,
 }
 
 impl GenerateConfig for PrometheusPushgatewayConfig {
@@ -81,6 +85,7 @@ impl GenerateConfig for PrometheusPushgatewayConfig {
             acknowledgements: SourceAcknowledgementsConfig::default(),
             aggregate_metrics: false,
             keepalive: KeepaliveConfig::default(),
+            permit_origin: None,
         })
         .unwrap()
     }
@@ -104,6 +109,7 @@ impl SourceConfig for PrometheusPushgatewayConfig {
             cx,
             self.acknowledgements,
             self.keepalive.clone(),
+            self.permit_origin.clone(),
         )
     }
 
@@ -374,6 +380,7 @@ mod test {
                 acknowledgements: SourceAcknowledgementsConfig::default(),
                 keepalive: KeepaliveConfig::default(),
                 aggregate_metrics: true,
+                permit_origin: None,
             };
             let source = source
                 .build(SourceContext::new_test(tx, None))

--- a/src/sources/prometheus/pushgateway.rs
+++ b/src/sources/prometheus/pushgateway.rs
@@ -531,6 +531,16 @@ mod test {
         wait_for_tcp(address).await;
     }
 
+    fn assert_bad_peer_metric_emitted() {
+        let controller = vector_lib::metrics::Controller::get()
+            .expect("metrics controller not initialized");
+        let has_bad_peer = controller
+            .capture_metrics()
+            .into_iter()
+            .any(|m| m.name() == "component_errors_total" && m.tag_matches("error_code", "bad_peer"));
+        assert!(has_bad_peer, "expected component_errors_total with error_code=bad_peer");
+    }
+
     async fn send_pushgateway_metric(
         address: std::net::SocketAddr,
     ) -> reqwest::Result<reqwest::Response> {
@@ -547,6 +557,8 @@ mod test {
         use futures::StreamExt;
         use tokio::time::{timeout, Duration};
 
+        vector_lib::metrics::init_test();
+
         // Blocked: localhost not in allowlist
         let (tx, mut rx) = SourceSender::new_test_finalize(EventStatus::Delivered);
         let address = test_util::next_addr();
@@ -554,18 +566,7 @@ mod test {
         let _ = send_pushgateway_metric(address).await;
         let result = timeout(Duration::from_millis(200), rx.next()).await;
         assert!(result.is_err(), "expected no events from blocked IP");
-        // Verify the server is still alive — rejection must be non-fatal
-        tokio::net::TcpStream::connect(address)
-            .await
-            .expect("server should still be running after non-fatal bad peer rejection");
-        // Verify the bad_peer error metric was emitted
-        vector_lib::metrics::init_test();
-        let controller = vector_lib::metrics::Controller::get().expect("metrics controller not initialized");
-        let has_bad_peer_error = controller
-            .capture_metrics()
-            .into_iter()
-            .any(|m| m.name() == "component_errors_total" && m.tag_matches("error_code", "bad_peer"));
-        assert!(has_bad_peer_error, "expected component_errors_total with error_code=bad_peer");
+        assert_bad_peer_metric_emitted();
 
         // Allowed: localhost matches allowlist
         let (tx, mut rx) = SourceSender::new_test_finalize(EventStatus::Delivered);

--- a/src/sources/prometheus/pushgateway.rs
+++ b/src/sources/prometheus/pushgateway.rs
@@ -76,6 +76,20 @@ pub struct PrometheusPushgatewayConfig {
     pub permit_origin: Option<IpAllowlistConfig>,
 }
 
+impl Default for PrometheusPushgatewayConfig {
+    fn default() -> Self {
+        Self {
+            address: "0.0.0.0:9091".parse().unwrap(),
+            tls: None,
+            auth: None,
+            acknowledgements: SourceAcknowledgementsConfig::default(),
+            keepalive: KeepaliveConfig::default(),
+            aggregate_metrics: false,
+            permit_origin: None,
+        }
+    }
+}
+
 impl GenerateConfig for PrometheusPushgatewayConfig {
     fn generate_config() -> toml::Value {
         toml::Value::try_from(Self {
@@ -495,82 +509,76 @@ mod test {
         .await;
     }
 
-    #[tokio::test]
-    async fn permit_origin_blocks_non_matching_ip() {
-        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
-        use tokio::time::{timeout, Duration};
-        use futures::StreamExt;
-
-        let address = test_util::next_addr();
-        let (tx, mut rx) = SourceSender::new_test_finalize(EventStatus::Delivered);
-
-        let permit_origin = Some(IpAllowlistConfig(vec![
-            IpNetConfig("10.0.0.1/32".parse().unwrap()),
-        ]));
-
-        let source = PrometheusPushgatewayConfig {
+    fn make_pushgateway_config(
+        address: std::net::SocketAddr,
+        cidr: &str,
+    ) -> PrometheusPushgatewayConfig {
+        use vector_lib::ipallowlist::IpAllowlistConfig;
+        PrometheusPushgatewayConfig {
             address,
-            auth: None,
-            tls: None,
-            acknowledgements: SourceAcknowledgementsConfig::default(),
-            keepalive: KeepaliveConfig::default(),
-            aggregate_metrics: true,
-            permit_origin,
-        };
-        let source = source
-            .build(SourceContext::new_test(tx, None))
-            .await
-            .unwrap();
+            permit_origin: Some(IpAllowlistConfig(vec![cidr.parse().unwrap()])),
+            ..Default::default()
+        }
+    }
+
+    async fn build_and_spawn_pushgateway_source(
+        address: std::net::SocketAddr,
+        config: PrometheusPushgatewayConfig,
+        tx: SourceSender,
+    ) {
+        let source = config.build(SourceContext::new_test(tx, None)).await.unwrap();
         tokio::spawn(source);
         wait_for_tcp(address).await;
+    }
 
-        // Send from localhost — should be blocked by allowlist
-        let _ = reqwest::Client::new()
+    async fn send_pushgateway_metric(
+        address: std::net::SocketAddr,
+    ) -> reqwest::Result<reqwest::Response> {
+        reqwest::Client::new()
             .post(format!("http://{}:{}/metrics/job/test", address.ip(), address.port()))
             .header("Content-Type", "text/plain")
             .body("test_metric 42")
             .send()
-            .await;
-
-        let result = timeout(Duration::from_millis(200), rx.next()).await;
-        assert!(result.is_err(), "expected no events from blocked IP");
+            .await
     }
 
     #[tokio::test]
-    async fn permit_origin_allows_matching_ip() {
-        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+    async fn permit_origin_allowlist() {
+        use futures::StreamExt;
+        use tokio::time::{timeout, Duration};
 
+        // Blocked: localhost not in allowlist
+        let (tx, mut rx) = SourceSender::new_test_finalize(EventStatus::Delivered);
         let address = test_util::next_addr();
-        let (tx, _rx) = SourceSender::new_test_finalize(EventStatus::Delivered);
-
-        let permit_origin = Some(IpAllowlistConfig(vec![
-            IpNetConfig("127.0.0.1/32".parse().unwrap()),
-        ]));
-
-        let source = PrometheusPushgatewayConfig {
-            address,
-            auth: None,
-            tls: None,
-            acknowledgements: SourceAcknowledgementsConfig::default(),
-            keepalive: KeepaliveConfig::default(),
-            aggregate_metrics: true,
-            permit_origin,
-        };
-        let source = source
-            .build(SourceContext::new_test(tx, None))
+        build_and_spawn_pushgateway_source(address, make_pushgateway_config(address, "10.0.0.1/32"), tx).await;
+        let _ = send_pushgateway_metric(address).await;
+        let result = timeout(Duration::from_millis(200), rx.next()).await;
+        assert!(result.is_err(), "expected no events from blocked IP");
+        // Verify the server is still alive — rejection must be non-fatal
+        tokio::net::TcpStream::connect(address)
             .await
-            .unwrap();
-        tokio::spawn(source);
-        wait_for_tcp(address).await;
+            .expect("server should still be running after non-fatal bad peer rejection");
+        // Verify the bad_peer error metric was emitted
+        vector_lib::metrics::init_test();
+        let controller = vector_lib::metrics::Controller::get().expect("metrics controller not initialized");
+        let has_bad_peer_error = controller
+            .capture_metrics()
+            .into_iter()
+            .any(|m| m.name() == "component_errors_total" && m.tag_matches("error_code", "bad_peer"));
+        assert!(has_bad_peer_error, "expected component_errors_total with error_code=bad_peer");
 
-        // Send from localhost — should be accepted by allowlist
-        let response = reqwest::Client::new()
-            .post(format!("http://{}:{}/metrics/job/test", address.ip(), address.port()))
-            .header("Content-Type", "text/plain")
-            .body("test_metric 42")
-            .send()
-            .await;
-
+        // Allowed: localhost matches allowlist
+        let (tx, mut rx) = SourceSender::new_test_finalize(EventStatus::Delivered);
+        let address = test_util::next_addr();
+        build_and_spawn_pushgateway_source(address, make_pushgateway_config(address, "127.0.0.1/32"), tx).await;
+        let response = send_pushgateway_metric(address).await;
         assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
+        let res = response.unwrap();
+        assert_eq!(res.status(), 200);
+        let event = timeout(Duration::from_millis(500), rx.next()).await;
+        assert!(event.is_ok(), "expected to receive events");
+        let metric = event.unwrap().unwrap().as_metric().clone();
+        assert_eq!(metric.name(), "test_metric");
+
     }
 }

--- a/src/sources/prometheus/pushgateway.rs
+++ b/src/sources/prometheus/pushgateway.rs
@@ -494,4 +494,45 @@ mod test {
         })
         .await;
     }
+
+    #[tokio::test]
+    async fn permit_origin_blocks_non_matching_ip() {
+        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+        use tokio::time::{timeout, Duration};
+        use futures::StreamExt;
+
+        let address = test_util::next_addr();
+        let (tx, mut rx) = SourceSender::new_test_finalize(EventStatus::Delivered);
+
+        let permit_origin = Some(IpAllowlistConfig(vec![
+            IpNetConfig("10.0.0.1/32".parse().unwrap()),
+        ]));
+
+        let source = PrometheusPushgatewayConfig {
+            address,
+            auth: None,
+            tls: None,
+            acknowledgements: SourceAcknowledgementsConfig::default(),
+            keepalive: KeepaliveConfig::default(),
+            aggregate_metrics: true,
+            permit_origin,
+        };
+        let source = source
+            .build(SourceContext::new_test(tx, None))
+            .await
+            .unwrap();
+        tokio::spawn(source);
+        wait_for_tcp(address).await;
+
+        // Send from localhost — should be blocked by allowlist
+        let _ = reqwest::Client::new()
+            .post(format!("http://{}:{}/metrics/job/test", address.ip(), address.port()))
+            .header("Content-Type", "text/plain")
+            .body("test_metric 42")
+            .send()
+            .await;
+
+        let result = timeout(Duration::from_millis(200), rx.next()).await;
+        assert!(result.is_err(), "expected no events from blocked IP");
+    }
 }

--- a/src/sources/prometheus/pushgateway.rs
+++ b/src/sources/prometheus/pushgateway.rs
@@ -535,4 +535,42 @@ mod test {
         let result = timeout(Duration::from_millis(200), rx.next()).await;
         assert!(result.is_err(), "expected no events from blocked IP");
     }
+
+    #[tokio::test]
+    async fn permit_origin_allows_matching_ip() {
+        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+
+        let address = test_util::next_addr();
+        let (tx, _rx) = SourceSender::new_test_finalize(EventStatus::Delivered);
+
+        let permit_origin = Some(IpAllowlistConfig(vec![
+            IpNetConfig("127.0.0.1/32".parse().unwrap()),
+        ]));
+
+        let source = PrometheusPushgatewayConfig {
+            address,
+            auth: None,
+            tls: None,
+            acknowledgements: SourceAcknowledgementsConfig::default(),
+            keepalive: KeepaliveConfig::default(),
+            aggregate_metrics: true,
+            permit_origin,
+        };
+        let source = source
+            .build(SourceContext::new_test(tx, None))
+            .await
+            .unwrap();
+        tokio::spawn(source);
+        wait_for_tcp(address).await;
+
+        // Send from localhost — should be accepted by allowlist
+        let response = reqwest::Client::new()
+            .post(format!("http://{}:{}/metrics/job/test", address.ip(), address.port()))
+            .header("Content-Type", "text/plain")
+            .body("test_metric 42")
+            .send()
+            .await;
+
+        assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
+    }
 }

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -386,6 +386,42 @@ mod test {
         let result = timeout(Duration::from_millis(200), rx.next()).await;
         assert!(result.is_err(), "expected no events from blocked IP");
     }
+
+    #[tokio::test]
+    async fn permit_origin_allows_matching_ip() {
+        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+
+        let address = test_util::next_addr();
+        let (tx, _rx) = SourceSender::new_test_finalize(EventStatus::Delivered);
+
+        let permit_origin = Some(IpAllowlistConfig(vec![
+            IpNetConfig("127.0.0.1/32".parse().unwrap()),
+        ]));
+
+        let source = PrometheusRemoteWriteConfig {
+            address,
+            auth: None,
+            tls: None,
+            acknowledgements: SourceAcknowledgementsConfig::default(),
+            keepalive: KeepaliveConfig::default(),
+            permit_origin,
+        };
+        let source = source
+            .build(SourceContext::new_test(tx, None))
+            .await
+            .unwrap();
+        tokio::spawn(source);
+        wait_for_tcp(address).await;
+
+        // Send from localhost — should be accepted by allowlist
+        let response = reqwest::Client::new()
+            .post(format!("http://{}/api/v1/write", address))
+            .body("test")
+            .send()
+            .await;
+
+        assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
+    }
 }
 
 #[cfg(all(test, feature = "prometheus-integration-tests"))]

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 use prost::Message;
 use vector_lib::config::LogNamespace;
 use vector_lib::configurable::configurable_component;
+use vector_lib::ipallowlist::IpAllowlistConfig;
 use vector_lib::prometheus::parser::proto;
 use warp::http::{HeaderMap, StatusCode};
 
@@ -50,6 +51,9 @@ pub struct PrometheusRemoteWriteConfig {
     #[configurable(derived)]
     #[serde(default)]
     keepalive: KeepaliveConfig,
+
+    #[configurable(derived)]
+    pub permit_origin: Option<IpAllowlistConfig>,
 }
 
 impl PrometheusRemoteWriteConfig {
@@ -61,6 +65,7 @@ impl PrometheusRemoteWriteConfig {
             auth: None,
             acknowledgements: false.into(),
             keepalive: KeepaliveConfig::default(),
+            permit_origin: None,
         }
     }
 }
@@ -73,6 +78,7 @@ impl GenerateConfig for PrometheusRemoteWriteConfig {
             auth: None,
             acknowledgements: SourceAcknowledgementsConfig::default(),
             keepalive: KeepaliveConfig::default(),
+            permit_origin: None,
         })
         .unwrap()
     }
@@ -94,6 +100,7 @@ impl SourceConfig for PrometheusRemoteWriteConfig {
             cx,
             self.acknowledgements,
             self.keepalive.clone(),
+            self.permit_origin.clone(),
         )
     }
 
@@ -192,6 +199,7 @@ mod test {
             tls: tls.clone(),
             acknowledgements: SourceAcknowledgementsConfig::default(),
             keepalive: KeepaliveConfig::default(),
+            permit_origin: None,
         };
         let source = source
             .build(SourceContext::new_test(tx, None))
@@ -285,6 +293,7 @@ mod test {
             tls: None,
             acknowledgements: SourceAcknowledgementsConfig::default(),
             keepalive: KeepaliveConfig::default(),
+            permit_origin: None,
         };
         let source = source
             .build(SourceContext::new_test(tx, None))

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -55,6 +55,19 @@ pub struct PrometheusRemoteWriteConfig {
     #[configurable(derived)]
     pub permit_origin: Option<IpAllowlistConfig>,
 }
+impl Default for PrometheusRemoteWriteConfig {
+    fn default() -> Self {
+        Self {
+            address: "0.0.0.0:9090".parse().unwrap(),
+            tls: None,
+            auth: None,
+            acknowledgements: SourceAcknowledgementsConfig::default(),
+            keepalive: KeepaliveConfig::default(),
+            permit_origin: None,
+        }
+    }
+}
+
 
 impl PrometheusRemoteWriteConfig {
     #[cfg(test)]
@@ -348,79 +361,98 @@ mod test {
         vector_lib::assert_event_data_eq!(expected, output);
     }
 
-    #[tokio::test]
-    async fn permit_origin_blocks_non_matching_ip() {
+    fn make_remote_write_config(
+        address: std::net::SocketAddr,
+        cidr: &str,
+    ) -> PrometheusRemoteWriteConfig {
         use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
-        use tokio::time::{timeout, Duration};
-        use futures::StreamExt;
-
-        let address = test_util::next_addr();
-        let (tx, mut rx) = SourceSender::new_test_finalize(EventStatus::Delivered);
-
-        let permit_origin = Some(IpAllowlistConfig(vec![
-            IpNetConfig("10.0.0.1/32".parse().unwrap()),
-        ]));
-
-        let source = PrometheusRemoteWriteConfig {
+        PrometheusRemoteWriteConfig {
             address,
-            auth: None,
-            tls: None,
-            acknowledgements: SourceAcknowledgementsConfig::default(),
-            keepalive: KeepaliveConfig::default(),
-            permit_origin,
-        };
-        let source = source
-            .build(SourceContext::new_test(tx, None))
-            .await
-            .unwrap();
+            permit_origin: Some(IpAllowlistConfig(vec![IpNetConfig(cidr.parse().unwrap())])),
+            ..Default::default()
+        }
+    }
+
+    async fn build_and_spawn_remote_write_source(
+        address: std::net::SocketAddr,
+        config: PrometheusRemoteWriteConfig,
+        tx: SourceSender,
+    ) {
+        let source = config.build(SourceContext::new_test(tx, None)).await.unwrap();
         tokio::spawn(source);
         wait_for_tcp(address).await;
+    }
 
-        // Send from localhost — should be blocked by allowlist
-        let _ = reqwest::Client::new()
-            .post(format!("http://{}/api/v1/write", address))
-            .body("test")
+    async fn send_remote_write_request(
+        address: std::net::SocketAddr,
+    ) -> reqwest::Result<reqwest::Response> {
+        use prost::Message;
+        let write_request = proto::WriteRequest {
+            timeseries: vec![proto::TimeSeries {
+                labels: vec![proto::Label {
+                    name: "__name__".to_string(),
+                    value: "test_metric".to_string(),
+                }],
+                samples: vec![proto::Sample {
+                    value: 42.0,
+                    timestamp: 1000,
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let proto_bytes = write_request.encode_to_vec();
+        let body = snap::raw::Encoder::new().compress_vec(&proto_bytes).unwrap();
+        reqwest::Client::new()
+            .post(format!("http://{}/", address))
+            .header("Content-Type", "application/x-protobuf")
+            .body(body)
             .send()
-            .await;
+            .await
+    }
 
+    fn assert_bad_peer_metric_emitted() {
+        let controller = vector_lib::metrics::Controller::get()
+            .expect("metrics controller not initialized");
+        let has_bad_peer = controller
+            .capture_metrics()
+            .into_iter()
+            .any(|m| m.name() == "component_errors_total" && m.tag_matches("error_code", "bad_peer"));
+        assert!(has_bad_peer, "expected component_errors_total with error_code=bad_peer");
+    }
+
+    #[tokio::test]
+    async fn permit_origin_blocks_non_matching_ip() {
+        use futures::StreamExt;
+        use tokio::time::{timeout, Duration};
+
+        vector_lib::metrics::init_test();
+
+        let (tx, mut rx) = SourceSender::new_test_finalize(EventStatus::Delivered);
+        let address = test_util::next_addr();
+        build_and_spawn_remote_write_source(address, make_remote_write_config(address, "10.0.0.1/32"), tx).await;
+        let _ = send_remote_write_request(address).await;
         let result = timeout(Duration::from_millis(200), rx.next()).await;
         assert!(result.is_err(), "expected no events from blocked IP");
+        assert_bad_peer_metric_emitted();
     }
 
     #[tokio::test]
     async fn permit_origin_allows_matching_ip() {
-        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+        use futures::StreamExt;
+        use tokio::time::{timeout, Duration};
 
+        let (tx, mut rx) = SourceSender::new_test_finalize(EventStatus::Delivered);
         let address = test_util::next_addr();
-        let (tx, _rx) = SourceSender::new_test_finalize(EventStatus::Delivered);
-
-        let permit_origin = Some(IpAllowlistConfig(vec![
-            IpNetConfig("127.0.0.1/32".parse().unwrap()),
-        ]));
-
-        let source = PrometheusRemoteWriteConfig {
-            address,
-            auth: None,
-            tls: None,
-            acknowledgements: SourceAcknowledgementsConfig::default(),
-            keepalive: KeepaliveConfig::default(),
-            permit_origin,
-        };
-        let source = source
-            .build(SourceContext::new_test(tx, None))
-            .await
-            .unwrap();
-        tokio::spawn(source);
-        wait_for_tcp(address).await;
-
-        // Send from localhost — should be accepted by allowlist
-        let response = reqwest::Client::new()
-            .post(format!("http://{}/api/v1/write", address))
-            .body("test")
-            .send()
-            .await;
-
+        build_and_spawn_remote_write_source(address, make_remote_write_config(address, "127.0.0.1/32"), tx).await;
+        let response = send_remote_write_request(address).await;
         assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
+        let res = response.unwrap();
+        assert_eq!(res.status(), 200);
+        let event = timeout(Duration::from_millis(500), rx.next()).await;
+        assert!(event.is_ok(), "expected to receive events from allowed IP");
+        let event = event.unwrap().unwrap();
+        assert_eq!(event.as_metric().name(), "test_metric");
     }
 }
 

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -347,6 +347,45 @@ mod test {
 
         vector_lib::assert_event_data_eq!(expected, output);
     }
+
+    #[tokio::test]
+    async fn permit_origin_blocks_non_matching_ip() {
+        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+        use tokio::time::{timeout, Duration};
+        use futures::StreamExt;
+
+        let address = test_util::next_addr();
+        let (tx, mut rx) = SourceSender::new_test_finalize(EventStatus::Delivered);
+
+        let permit_origin = Some(IpAllowlistConfig(vec![
+            IpNetConfig("10.0.0.1/32".parse().unwrap()),
+        ]));
+
+        let source = PrometheusRemoteWriteConfig {
+            address,
+            auth: None,
+            tls: None,
+            acknowledgements: SourceAcknowledgementsConfig::default(),
+            keepalive: KeepaliveConfig::default(),
+            permit_origin,
+        };
+        let source = source
+            .build(SourceContext::new_test(tx, None))
+            .await
+            .unwrap();
+        tokio::spawn(source);
+        wait_for_tcp(address).await;
+
+        // Send from localhost — should be blocked by allowlist
+        let _ = reqwest::Client::new()
+            .post(format!("http://{}/api/v1/write", address))
+            .body("test")
+            .send()
+            .await;
+
+        let result = timeout(Duration::from_millis(200), rx.next()).await;
+        assert!(result.is_err(), "expected no events from blocked IP");
+    }
 }
 
 #[cfg(all(test, feature = "prometheus-integration-tests"))]
@@ -384,6 +423,7 @@ mod integration_tests {
             tls: None,
             acknowledgements: SourceAcknowledgementsConfig::default(),
             keepalive: KeepaliveConfig::default(),
+            permit_origin: None,
         };
 
         let events = run_and_assert_source_compliance(

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -68,7 +68,6 @@ impl Default for PrometheusRemoteWriteConfig {
     }
 }
 
-
 impl PrometheusRemoteWriteConfig {
     #[cfg(test)]
     pub fn from_address(address: SocketAddr) -> Self {
@@ -447,12 +446,9 @@ mod test {
         build_and_spawn_remote_write_source(address, make_remote_write_config(address, "127.0.0.1/32"), tx).await;
         let response = send_remote_write_request(address).await;
         assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
-        let res = response.unwrap();
-        assert_eq!(res.status(), 200);
+        assert_eq!(response.unwrap().status(), 200);
         let event = timeout(Duration::from_millis(500), rx.next()).await;
-        assert!(event.is_ok(), "expected to receive events from allowed IP");
-        let event = event.unwrap().unwrap();
-        assert_eq!(event.as_metric().name(), "test_metric");
+        assert_eq!(event.unwrap().unwrap().as_metric().name(), "test_metric");
     }
 }
 

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -1791,4 +1791,154 @@ mod test {
         })
         .await;
     }
+
+    //////// PERMIT_ORIGIN / ALLOWLIST TESTS ////////
+
+    fn make_allowlist(cidrs: &[&str]) -> Option<vector_lib::ipallowlist::IpAllowlistConfig> {
+        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+        Some(IpAllowlistConfig(
+            cidrs
+                .iter()
+                .map(|s| IpNetConfig(s.parse().unwrap()))
+                .collect(),
+        ))
+    }
+
+    #[tokio::test]
+    async fn tcp_permit_origin_allows_matching_ip() {
+        assert_source_compliance(&SOCKET_PUSH_SOURCE_TAGS, async {
+            let (tx, mut rx) = SourceSender::new_test();
+            let addr = next_addr();
+
+            let mut config = TcpConfig::from_address(addr.into());
+            config.permit_origin = make_allowlist(&["127.0.0.1/32"]);
+
+            let server = SocketConfig::from(config)
+                .build(SourceContext::new_test(tx, None))
+                .await
+                .unwrap();
+            tokio::spawn(server);
+
+            wait_for_tcp(addr).await;
+            send_lines(addr, vec!["allowed".to_owned()].into_iter())
+                .await
+                .unwrap();
+
+            let event = rx.next().await.unwrap();
+            assert_eq!(
+                event.as_log()[log_schema().message_key().unwrap().to_string()],
+                "allowed".into()
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn tcp_permit_origin_blocks_non_matching_ip() {
+        let (tx, mut rx) = SourceSender::new_test();
+        let addr = next_addr();
+
+        let mut config = TcpConfig::from_address(addr.into());
+        // Only allow 10.0.0.1 — localhost (127.0.0.1) should be rejected
+        config.permit_origin = make_allowlist(&["10.0.0.1/32"]);
+
+        let server = SocketConfig::from(config)
+            .build(SourceContext::new_test(tx, None))
+            .await
+            .unwrap();
+        tokio::spawn(server);
+
+        wait_for_tcp(addr).await;
+        // Connection from localhost should be accepted at TCP level but rejected by allowlist
+        let _ = send_lines(addr, vec!["blocked".to_owned()].into_iter()).await;
+
+        // No events should have been received within a reasonable window
+        let result = timeout(Duration::from_millis(200), rx.next()).await;
+        assert!(result.is_err(), "expected no events from blocked IP");
+    }
+
+    #[tokio::test]
+    async fn udp_permit_origin_allows_matching_ip() {
+        assert_source_compliance(&SOCKET_PUSH_SOURCE_TAGS, async {
+            let (tx, rx) = SourceSender::new_test();
+            let address = next_addr();
+
+            let mut config = UdpConfig::from_address(address.into());
+            config.permit_origin = make_allowlist(&["127.0.0.1/32"]);
+
+            let address = init_udp_with_config(tx, config).await;
+
+            send_lines_udp(address, vec!["allowed".to_string()]);
+            let events = collect_n(rx, 1).await;
+
+            assert_eq!(
+                events[0].as_log()[log_schema().message_key().unwrap().to_string()],
+                "allowed".into()
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn udp_permit_origin_blocks_non_matching_ip() {
+        let (tx, mut rx) = SourceSender::new_test();
+        let address = next_addr();
+
+        let mut config = UdpConfig::from_address(address.into());
+        // Only allow 10.0.0.1 — localhost (127.0.0.1) should be rejected
+        config.permit_origin = make_allowlist(&["10.0.0.1/32"]);
+
+        let address = init_udp_with_config(tx, config).await;
+
+        send_lines_udp(address, vec!["blocked".to_string()]);
+
+        // No events should have been received within a reasonable window
+        let result = timeout(Duration::from_millis(200), rx.next()).await;
+        assert!(result.is_err(), "expected no events from blocked IP");
+    }
+
+    #[tokio::test]
+    async fn udp_permit_origin_allows_cidr_range() {
+        assert_source_compliance(&SOCKET_PUSH_SOURCE_TAGS, async {
+            let (tx, rx) = SourceSender::new_test();
+            let address = next_addr();
+
+            let mut config = UdpConfig::from_address(address.into());
+            // 127.0.0.0/8 covers all of 127.x.x.x
+            config.permit_origin = make_allowlist(&["127.0.0.0/8"]);
+
+            let address = init_udp_with_config(tx, config).await;
+
+            send_lines_udp(address, vec!["cidr_allowed".to_string()]);
+            let events = collect_n(rx, 1).await;
+
+            assert_eq!(
+                events[0].as_log()[log_schema().message_key().unwrap().to_string()],
+                "cidr_allowed".into()
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn udp_no_permit_origin_allows_all() {
+        assert_source_compliance(&SOCKET_PUSH_SOURCE_TAGS, async {
+            let (tx, rx) = SourceSender::new_test();
+            let address = next_addr();
+
+            let mut config = UdpConfig::from_address(address.into());
+            config.permit_origin = None;
+
+            let address = init_udp_with_config(tx, config).await;
+
+            send_lines_udp(address, vec!["no_filter".to_string()]);
+            let events = collect_n(rx, 1).await;
+
+            assert_eq!(
+                events[0].as_log()[log_schema().message_key().unwrap().to_string()],
+                "no_filter".into()
+            );
+        })
+        .await;
+    }
 }

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -1795,11 +1795,11 @@ mod test {
     //////// PERMIT_ORIGIN / ALLOWLIST TESTS ////////
 
     fn make_allowlist(cidrs: &[&str]) -> Option<vector_lib::ipallowlist::IpAllowlistConfig> {
-        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+        use vector_lib::ipallowlist::{IpAllowlistConfig};
         Some(IpAllowlistConfig(
             cidrs
                 .iter()
-                .map(|s| IpNetConfig(s.parse().unwrap()))
+                .map(|s| s.parse().unwrap())
                 .collect(),
         ))
     }
@@ -1864,7 +1864,7 @@ mod test {
             let address = next_addr();
 
             let mut config = UdpConfig::from_address(address.into());
-            config.permit_origin = make_allowlist(&["127.0.0.1/32"]);
+            config.permit_origin = make_allowlist(&["127.0.0.1"]);
 
             let address = init_udp_with_config(tx, config).await;
 
@@ -1886,7 +1886,7 @@ mod test {
 
         let mut config = UdpConfig::from_address(address.into());
         // Only allow 10.0.0.1 — localhost (127.0.0.1) should be rejected
-        config.permit_origin = make_allowlist(&["10.0.0.1/32"]);
+        config.permit_origin = make_allowlist(&["10.0.0.1"]);
 
         let address = init_udp_with_config(tx, config).await;
 

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -1858,6 +1858,36 @@ mod test {
     }
 
     #[tokio::test]
+    async fn tcp_no_permit_origin_allows_all() {
+        assert_source_compliance(&SOCKET_PUSH_SOURCE_TAGS, async {
+            let (tx, mut rx) = SourceSender::new_test();
+            let addr = next_addr();
+
+            let mut config = TcpConfig::from_address(addr.into());
+            config.permit_origin = None;
+
+            let server = SocketConfig::from(config)
+                .build(SourceContext::new_test(tx, None))
+                .await
+                .unwrap();
+            tokio::spawn(server);
+
+            wait_for_tcp(addr).await;
+            send_lines(addr, vec!["no_filter".to_owned()].into_iter())
+                .await
+                .unwrap();
+
+            let event = rx.next().await.unwrap();
+            assert_eq!(
+                event.as_log()[log_schema().message_key().unwrap().to_string()],
+                "no_filter".into()
+            );
+        })
+        .await;
+    }
+
+
+    #[tokio::test]
     async fn udp_permit_origin_allows_matching_ip() {
         assert_source_compliance(&SOCKET_PUSH_SOURCE_TAGS, async {
             let (tx, rx) = SourceSender::new_test();

--- a/src/sources/socket/udp.rs
+++ b/src/sources/socket/udp.rs
@@ -207,7 +207,7 @@ pub(super) fn udp(
                     if let Some(ref allowlist) = origin_allowlist {
                         if !allowlist.iter().any(|net| net.contains(&address.ip())) {
                             warn!(
-                                message = "Received UDP packet from non-permitted origin, dropping.",
+                                message = "Received UDP packet from non-whitelisted origin, dropping.",
                                 origin = %address.ip(),
                                 internal_log_rate_limit = true
                             );

--- a/src/sources/socket/udp.rs
+++ b/src/sources/socket/udp.rs
@@ -2,6 +2,7 @@ use super::default_host_key;
 use bytes::BytesMut;
 use chrono::Utc;
 use futures::StreamExt;
+use ipnet::IpNet;
 use listenfd::ListenFd;
 use tokio_util::codec::FramedRead;
 use vector_lib::codecs::{
@@ -9,6 +10,7 @@ use vector_lib::codecs::{
     StreamDecodingError,
 };
 use vector_lib::configurable::configurable_component;
+use vector_lib::ipallowlist::IpAllowlistConfig;
 use vector_lib::internal_event::{ByteSize, BytesReceived, InternalEventHandle as _, Protocol};
 use vector_lib::lookup::{lookup_v2::OptionalValuePath, owned_value_path, path};
 use vector_lib::{
@@ -84,6 +86,9 @@ pub struct UdpConfig {
     #[serde(default)]
     #[configurable(metadata(docs::hidden))]
     pub log_namespace: Option<bool>,
+
+    #[configurable(derived)]
+    pub permit_origin: Option<IpAllowlistConfig>,
 }
 
 fn default_port_key() -> OptionalValuePath {
@@ -125,6 +130,7 @@ impl UdpConfig {
             framing: None,
             decoding: default_decoding(),
             log_namespace: None,
+            permit_origin: None,
         }
     }
 
@@ -164,6 +170,8 @@ pub(super) fn udp(
             max_length = std::cmp::min(max_length, receive_buffer_bytes);
         }
 
+        let origin_allowlist: Option<Vec<IpNet>> = config.permit_origin.clone().map(Into::into);
+
         let bytes_received = register!(BytesReceived::from(Protocol::UDP));
 
         info!(message = "Listening.", address = %config.address);
@@ -195,6 +203,12 @@ pub(super) fn udp(
                             }));
                        }
                     };
+
+                    if let Some(ref allowlist) = origin_allowlist {
+                        if !allowlist.iter().any(|net| net.contains(&address.ip())) {
+                            continue;
+                        }
+                    }
 
                     bytes_received.emit(ByteSize(byte_size));
                     let payload = buf.split_to(byte_size);

--- a/src/sources/socket/udp.rs
+++ b/src/sources/socket/udp.rs
@@ -22,7 +22,7 @@ use crate::{
     codecs::Decoder,
     event::Event,
     internal_events::{
-        SocketBindError, SocketEventsReceived, SocketMode, SocketReceiveError, StreamClosedError,
+        IpAllowlistDeniedError, SocketBindError, SocketEventsReceived, SocketMode, SocketReceiveError, StreamClosedError,
     },
     net,
     serde::default_decoding,
@@ -206,6 +206,12 @@ pub(super) fn udp(
 
                     if let Some(ref allowlist) = origin_allowlist {
                         if !allowlist.iter().any(|net| net.contains(&address.ip())) {
+                            warn!(
+                                message = "Received UDP packet from non-permitted origin, dropping.",
+                                origin = %address.ip(),
+                                internal_log_rate_limit = true
+                            );
+                            emit!(IpAllowlistDeniedError { peer: &address.ip() });
                             continue;
                         }
                     }

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -2864,5 +2864,48 @@ mod tests {
         assert!(result.is_err(), "expected no events from blocked IP");
     }
 
+    #[tokio::test]
+    async fn permit_origin_allows_matching_ip() {
+        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+
+        let (sender, _recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
+        let address = next_addr();
+        let cx = SourceContext::new_test(sender, None);
+
+        let permit_origin = Some(IpAllowlistConfig(vec![
+            IpNetConfig("127.0.0.1/32".parse().unwrap()),
+        ]));
+
+        tokio::spawn(async move {
+            SplunkConfig {
+                address,
+                token: Some(TOKEN.to_owned().into()),
+                valid_tokens: None,
+                tls: None,
+                acknowledgements: Default::default(),
+                store_hec_token: false,
+                log_namespace: None,
+                keepalive: Default::default(),
+                permit_origin,
+            }
+            .build(cx)
+            .await
+            .unwrap()
+            .await
+            .unwrap()
+        });
+        wait_for_tcp(address).await;
+
+        // Send from localhost — should be accepted by allowlist
+        let response = reqwest::Client::new()
+            .post(format!("http://{}/services/collector", address))
+            .header("Authorization", format!("Splunk {}", TOKEN))
+            .body(r#"{"event":"allowed"}"#)
+            .send()
+            .await;
+
+        assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
+    }
+
     register_validatable_component!(SplunkConfig);
 }

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -2818,5 +2818,51 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn permit_origin_blocks_non_matching_ip() {
+        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+        use tokio::time::{timeout, Duration};
+        use futures::StreamExt;
+
+        let (sender, mut recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
+        let address = next_addr();
+        let cx = SourceContext::new_test(sender, None);
+
+        let permit_origin = Some(IpAllowlistConfig(vec![
+            IpNetConfig("10.0.0.1/32".parse().unwrap()),
+        ]));
+
+        tokio::spawn(async move {
+            SplunkConfig {
+                address,
+                token: Some(TOKEN.to_owned().into()),
+                valid_tokens: None,
+                tls: None,
+                acknowledgements: Default::default(),
+                store_hec_token: false,
+                log_namespace: None,
+                keepalive: Default::default(),
+                permit_origin,
+            }
+            .build(cx)
+            .await
+            .unwrap()
+            .await
+            .unwrap()
+        });
+        wait_for_tcp(address).await;
+
+        // Send from localhost — should be blocked by allowlist
+        let _ = reqwest::Client::new()
+            .post(format!("http://{}/services/collector", address))
+            .header("Authorization", format!("Splunk {}", TOKEN))
+            .body(r#"{"event":"blocked"}"#)
+            .send()
+            .await;
+
+        let result = timeout(Duration::from_millis(200), recv.next()).await;
+        assert!(result.is_err(), "expected no events from blocked IP");
+    }
+
     register_validatable_component!(SplunkConfig);
 }

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -51,7 +51,7 @@ use crate::{
     event::{Event, LogEvent, Value},
     http::{build_http_trace_layer, KeepaliveConfig, MaxConnectionAgeLayer},
     internal_events::{
-        EventsReceived, HttpBadPeerConnectionError, HttpBytesReceived, SplunkHecRequestBodyInvalidError, SplunkHecRequestError,
+        EventsReceived, IpAllowlistDeniedError, HttpBytesReceived, SplunkHecRequestBodyInvalidError, SplunkHecRequestError,
     },
     serde::bool_or_struct,
     source_sender::ClosedError,
@@ -204,7 +204,7 @@ impl SourceConfig for SplunkConfig {
                             if err.is_fatal() {
                                 warn!(message = "Fatal error accepting connection.", error = %err);
                             } else {
-                                emit!(HttpBadPeerConnectionError { error: &err });
+                                emit!(IpAllowlistDeniedError { peer: &err });
                             }
                             None
                         }

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -10,7 +10,7 @@ use std::{
 use bytes::{Buf, Bytes};
 use chrono::{DateTime, TimeZone, Utc};
 use flate2::read::MultiGzDecoder;
-use futures::FutureExt;
+use futures::{FutureExt, StreamExt};
 use http::StatusCode;
 use hyper::{service::make_service_fn, Server};
 use serde::Serialize;
@@ -51,7 +51,7 @@ use crate::{
     event::{Event, LogEvent, Value},
     http::{build_http_trace_layer, KeepaliveConfig, MaxConnectionAgeLayer},
     internal_events::{
-        EventsReceived, HttpBytesReceived, SplunkHecRequestBodyInvalidError, SplunkHecRequestError,
+        EventsReceived, HttpBadPeerConnectionError, HttpBytesReceived, SplunkHecRequestBodyInvalidError, SplunkHecRequestError,
     },
     serde::bool_or_struct,
     source_sender::ClosedError,
@@ -196,7 +196,21 @@ impl SourceConfig for SplunkConfig {
                 futures_util::future::ok::<_, Infallible>(svc)
             });
 
-            Server::builder(hyper::server::accept::from_stream(listener.accept_stream()))
+            Server::builder(hyper::server::accept::from_stream(
+                listener.accept_stream().filter_map(|result| async move {
+                    match result {
+                        Ok(stream) => Some(Ok::<_, Infallible>(stream)),
+                        Err(err) => {
+                            if err.is_fatal() {
+                                warn!(message = "Fatal error accepting connection.", error = %err);
+                            } else {
+                                emit!(HttpBadPeerConnectionError { error: &err });
+                            }
+                            None
+                        }
+                    }
+                }),
+            ))
                 .serve(make_svc)
                 .with_graceful_shutdown(shutdown.map(|_| ()))
                 .await

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -51,9 +51,10 @@ use crate::{
     event::{Event, LogEvent, Value},
     http::{build_http_trace_layer, KeepaliveConfig, MaxConnectionAgeLayer},
     internal_events::{
-        EventsReceived, IpAllowlistDeniedError, HttpBytesReceived, SplunkHecRequestBodyInvalidError, SplunkHecRequestError,
+        EventsReceived, HttpBytesReceived, SplunkHecRequestBodyInvalidError, SplunkHecRequestError,
     },
     serde::bool_or_struct,
+    sources::util::handle_accept_error,
     source_sender::ClosedError,
     tls::{MaybeTlsSettings, TlsEnableableConfig},
     SourceSender,
@@ -197,19 +198,7 @@ impl SourceConfig for SplunkConfig {
             });
 
             Server::builder(hyper::server::accept::from_stream(
-                listener.accept_stream().filter_map(|result| async move {
-                    match result {
-                        Ok(stream) => Some(Ok::<_, Infallible>(stream)),
-                        Err(err) => {
-                            if err.is_fatal() {
-                                warn!(message = "Fatal error accepting connection.", error = %err);
-                            } else {
-                                emit!(IpAllowlistDeniedError { peer: &err });
-                            }
-                            None
-                        }
-                    }
-                }),
+                listener.accept_stream().filter_map(handle_accept_error),
             ))
                 .serve(make_svc)
                 .with_graceful_shutdown(shutdown.map(|_| ()))

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -33,6 +33,8 @@ use vector_lib::{
     EstimatedJsonEncodedSizeOf,
 };
 use vector_lib::{configurable::configurable_component, tls::MaybeTlsIncomingStream};
+use vector_lib::ipallowlist::IpAllowlistConfig;
+
 use vrl::path::OwnedTargetPath;
 use vrl::value::{kind::Collection, Kind};
 use warp::{filters::BoxedFilter, path, reject::Rejection, reply::Response, Filter, Reply};
@@ -117,6 +119,9 @@ pub struct SplunkConfig {
     #[configurable(derived)]
     #[serde(default)]
     keepalive: KeepaliveConfig,
+
+    #[configurable(derived)]
+    pub permit_origin: Option<IpAllowlistConfig>,
 }
 
 impl_generate_config_from_default!(SplunkConfig);
@@ -132,6 +137,7 @@ impl Default for SplunkConfig {
             store_hec_token: false,
             log_namespace: None,
             keepalive: Default::default(),
+            permit_origin: None,
         }
     }
 }
@@ -170,6 +176,8 @@ impl SourceConfig for SplunkConfig {
             .or_else(finish_err);
 
         let listener = tls.bind(&self.address).await?;
+        let listener = listener
+            .with_allowlist(self.permit_origin.clone().map(Into::into));
 
         let keepalive_settings = self.keepalive.clone();
         Ok(Box::pin(async move {
@@ -1333,6 +1341,7 @@ mod tests {
                 store_hec_token,
                 log_namespace: None,
                 keepalive: Default::default(),
+                permit_origin: None,
             }
             .build(cx)
             .await

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -2821,93 +2821,95 @@ mod tests {
         }
     }
 
+    fn assert_bad_peer_metric_emitted() {
+        let controller = vector_lib::metrics::Controller::get()
+            .expect("metrics controller not initialized");
+        let has_bad_peer = controller
+            .capture_metrics()
+            .into_iter()
+            .any(|m| m.name() == "component_errors_total" && m.tag_matches("error_code", "bad_peer"));
+        assert!(has_bad_peer, "expected component_errors_total with error_code=bad_peer");
+    }
+
+    async fn build_and_spawn_splunk_source(
+        address: std::net::SocketAddr,
+        cidr: &str,
+        sender: SourceSender,
+    ) {
+        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+        let permit_origin = Some(IpAllowlistConfig(vec![
+            IpNetConfig(cidr.parse().unwrap()),
+        ]));
+        let cx = SourceContext::new_test(sender, None);
+        tokio::spawn(async move {
+            SplunkConfig {
+                address,
+                token: Some(TOKEN.to_owned().into()),
+                valid_tokens: None,
+                tls: None,
+                acknowledgements: Default::default(),
+                store_hec_token: false,
+                log_namespace: None,
+                keepalive: Default::default(),
+                permit_origin,
+            }
+            .build(cx)
+            .await
+            .unwrap()
+            .await
+            .unwrap()
+        });
+        wait_for_tcp(address).await;
+    }
+
+    async fn send_splunk_event(
+        address: std::net::SocketAddr,
+        body: &'static str,
+    ) -> reqwest::Result<reqwest::Response> {
+        reqwest::Client::new()
+            .post(format!("http://{}/services/collector", address))
+            .header("Authorization", format!("Splunk {}", TOKEN))
+            .body(body)
+            .send()
+            .await
+    }
+
     #[tokio::test]
     async fn permit_origin_blocks_non_matching_ip() {
-        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
+        use tokio::time::{timeout, Duration};
+        use futures::StreamExt;
+
+        vector_lib::metrics::init_test();
+
+        let (sender, mut recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
+        let address = next_addr();
+        build_and_spawn_splunk_source(address, "10.0.0.1/32", sender).await;
+
+        let _ = send_splunk_event(address, r#"{"event":"blocked"}"#).await;
+        let result = timeout(Duration::from_millis(200), recv.next()).await;
+        assert!(result.is_err(), "expected no events from blocked IP");
+        assert_bad_peer_metric_emitted();
+    }
+
+    #[tokio::test]
+    async fn permit_origin_allows_matching_ip() {
         use tokio::time::{timeout, Duration};
         use futures::StreamExt;
 
         let (sender, mut recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
         let address = next_addr();
-        let cx = SourceContext::new_test(sender, None);
+        build_and_spawn_splunk_source(address, "127.0.0.1/32", sender).await;
 
-        let permit_origin = Some(IpAllowlistConfig(vec![
-            IpNetConfig("10.0.0.1/32".parse().unwrap()),
-        ]));
-
-        tokio::spawn(async move {
-            SplunkConfig {
-                address,
-                token: Some(TOKEN.to_owned().into()),
-                valid_tokens: None,
-                tls: None,
-                acknowledgements: Default::default(),
-                store_hec_token: false,
-                log_namespace: None,
-                keepalive: Default::default(),
-                permit_origin,
-            }
-            .build(cx)
-            .await
-            .unwrap()
-            .await
-            .unwrap()
-        });
-        wait_for_tcp(address).await;
-
-        // Send from localhost — should be blocked by allowlist
-        let _ = reqwest::Client::new()
-            .post(format!("http://{}/services/collector", address))
-            .header("Authorization", format!("Splunk {}", TOKEN))
-            .body(r#"{"event":"blocked"}"#)
-            .send()
-            .await;
-
-        let result = timeout(Duration::from_millis(200), recv.next()).await;
-        assert!(result.is_err(), "expected no events from blocked IP");
-    }
-
-    #[tokio::test]
-    async fn permit_origin_allows_matching_ip() {
-        use vector_lib::ipallowlist::{IpAllowlistConfig, IpNetConfig};
-
-        let (sender, _recv) = SourceSender::new_test_finalize(EventStatus::Delivered);
-        let address = next_addr();
-        let cx = SourceContext::new_test(sender, None);
-
-        let permit_origin = Some(IpAllowlistConfig(vec![
-            IpNetConfig("127.0.0.1/32".parse().unwrap()),
-        ]));
-
-        tokio::spawn(async move {
-            SplunkConfig {
-                address,
-                token: Some(TOKEN.to_owned().into()),
-                valid_tokens: None,
-                tls: None,
-                acknowledgements: Default::default(),
-                store_hec_token: false,
-                log_namespace: None,
-                keepalive: Default::default(),
-                permit_origin,
-            }
-            .build(cx)
-            .await
-            .unwrap()
-            .await
-            .unwrap()
-        });
-        wait_for_tcp(address).await;
-
-        // Send from localhost — should be accepted by allowlist
-        let response = reqwest::Client::new()
-            .post(format!("http://{}/services/collector", address))
-            .header("Authorization", format!("Splunk {}", TOKEN))
-            .body(r#"{"event":"allowed"}"#)
-            .send()
-            .await;
-
+        let response = send_splunk_event(address, r#"{"event":"allowed"}"#).await;
         assert!(response.is_ok(), "expected connection to be accepted for allowed IP");
+        assert_eq!(response.unwrap().status(), 200);
+        let event = timeout(Duration::from_millis(500), recv.next()).await;
+        assert!(event.is_ok(), "expected to receive event from allowed IP");
+        let log_event = event.unwrap().unwrap();
+        assert_eq!(
+            log_event.as_log()[log_schema().message_key().unwrap().to_string()],
+            "allowed".into()
+        );
     }
 
     register_validatable_component!(SplunkConfig);

--- a/src/sources/util/grpc/mod.rs
+++ b/src/sources/util/grpc/mod.rs
@@ -1,3 +1,5 @@
+use vector_lib::ipallowlist::IpAllowlistConfig;
+
 use crate::{
     internal_events::{GrpcServerRequestReceived, GrpcServerResponseSent},
     shutdown::{ShutdownSignal, ShutdownSignalToken},
@@ -68,10 +70,13 @@ pub async fn run_grpc_server_with_routes(
     tls_settings: MaybeTlsSettings,
     routes: Routes,
     shutdown: ShutdownSignal,
+    permit_origin: Option<IpAllowlistConfig>,
 ) -> crate::Result<()> {
     let span = Span::current();
     let (tx, rx) = tokio::sync::oneshot::channel::<ShutdownSignalToken>();
     let listener = tls_settings.bind(&address).await?;
+    let listener = listener
+        .with_allowlist(permit_origin.map(Into::into));
     let stream = listener.accept_stream();
 
     info!(%address, "Building gRPC server.");

--- a/src/sources/util/http/prelude.rs
+++ b/src/sources/util/http/prelude.rs
@@ -33,7 +33,7 @@ use crate::{
     config::SourceContext,
     http::{build_http_trace_layer, KeepaliveConfig, MaxConnectionAgeLayer},
     internal_events::{
-        HttpBadPeerConnectionError, HttpBadRequest, HttpBytesReceived, HttpEventsReceived, HttpInternalError, StreamClosedError,
+        IpAllowlistDeniedError, HttpBadRequest, HttpBytesReceived, HttpEventsReceived, HttpInternalError, StreamClosedError,
     },
     sources::util::http::HttpMethod,
     tls::{MaybeTlsIncomingStream, MaybeTlsSettings, TlsEnableableConfig},
@@ -234,7 +234,7 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
                             if err.is_fatal() {
                                 warn!(message = "Fatal error accepting connection.", error = %err);
                             } else {
-                                emit!(HttpBadPeerConnectionError { error: &err });
+                                emit!(IpAllowlistDeniedError { peer: &err });
                             }
                             None
                         }

--- a/src/sources/util/http/prelude.rs
+++ b/src/sources/util/http/prelude.rs
@@ -33,9 +33,11 @@ use crate::{
     config::SourceContext,
     http::{build_http_trace_layer, KeepaliveConfig, MaxConnectionAgeLayer},
     internal_events::{
-        IpAllowlistDeniedError, HttpBadRequest, HttpBytesReceived, HttpEventsReceived, HttpInternalError, StreamClosedError,
+        HttpBadRequest, HttpBytesReceived, HttpEventsReceived, HttpInternalError, StreamClosedError,
     },
     sources::util::http::HttpMethod,
+    sources::util::handle_accept_error,
+
     tls::{MaybeTlsIncomingStream, MaybeTlsSettings, TlsEnableableConfig},
     SourceSender,
 };
@@ -227,19 +229,7 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
                 .with_allowlist(permit_origin.map(Into::into));
 
             Server::builder(hyper::server::accept::from_stream(
-                listener.accept_stream().filter_map(|result| async move {
-                    match result {
-                        Ok(stream) => Some(Ok::<_, Infallible>(stream)),
-                        Err(err) => {
-                            if err.is_fatal() {
-                                warn!(message = "Fatal error accepting connection.", error = %err);
-                            } else {
-                                emit!(IpAllowlistDeniedError { peer: &err });
-                            }
-                            None
-                        }
-                    }
-                }),
+                listener.accept_stream().filter_map(handle_accept_error),
             ))
                 .serve(make_svc)
                 .with_graceful_shutdown(cx.shutdown.map(|_| ()))

--- a/src/sources/util/http/prelude.rs
+++ b/src/sources/util/http/prelude.rs
@@ -27,6 +27,8 @@ use warp::{
     Filter,
 };
 
+use vector_lib::ipallowlist::IpAllowlistConfig;
+
 use crate::{
     config::SourceContext,
     http::{build_http_trace_layer, KeepaliveConfig, MaxConnectionAgeLayer},
@@ -83,6 +85,7 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
         cx: SourceContext,
         acknowledgements: SourceAcknowledgementsConfig,
         keepalive_settings: KeepaliveConfig,
+        permit_origin: Option<IpAllowlistConfig>,
     ) -> crate::Result<crate::sources::Source> {
         let tls = MaybeTlsSettings::from_config(tls, true)?;
         let protocol = tls.http_protocol_name();
@@ -220,6 +223,8 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
             let listener = tls.bind(&address).await.map_err(|err| {
                 error!("An error occurred: {:?}.", err);
             })?;
+            let listener = listener
+                .with_allowlist(permit_origin.map(Into::into));
 
             Server::builder(hyper::server::accept::from_stream(listener.accept_stream()))
                 .serve(make_svc)

--- a/src/sources/util/http/prelude.rs
+++ b/src/sources/util/http/prelude.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use futures::{FutureExt, TryFutureExt};
+use futures::{FutureExt, StreamExt, TryFutureExt};
 use hyper::{service::make_service_fn, Server};
 use tokio::net::TcpStream;
 use tower::ServiceBuilder;
@@ -33,7 +33,7 @@ use crate::{
     config::SourceContext,
     http::{build_http_trace_layer, KeepaliveConfig, MaxConnectionAgeLayer},
     internal_events::{
-        HttpBadRequest, HttpBytesReceived, HttpEventsReceived, HttpInternalError, StreamClosedError,
+        HttpBadPeerConnectionError, HttpBadRequest, HttpBytesReceived, HttpEventsReceived, HttpInternalError, StreamClosedError,
     },
     sources::util::http::HttpMethod,
     tls::{MaybeTlsIncomingStream, MaybeTlsSettings, TlsEnableableConfig},
@@ -226,7 +226,21 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
             let listener = listener
                 .with_allowlist(permit_origin.map(Into::into));
 
-            Server::builder(hyper::server::accept::from_stream(listener.accept_stream()))
+            Server::builder(hyper::server::accept::from_stream(
+                listener.accept_stream().filter_map(|result| async move {
+                    match result {
+                        Ok(stream) => Some(Ok::<_, Infallible>(stream)),
+                        Err(err) => {
+                            if err.is_fatal() {
+                                warn!(message = "Fatal error accepting connection.", error = %err);
+                            } else {
+                                emit!(HttpBadPeerConnectionError { error: &err });
+                            }
+                            None
+                        }
+                    }
+                }),
+            ))
                 .serve(make_svc)
                 .with_graceful_shutdown(cx.shutdown.map(|_| ()))
                 .await

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -112,7 +112,7 @@ pub async fn handle_accept_error<S>(
     match result {
         Ok(stream) => Some(Ok(stream)),
         Err(err) => {
-            if err == TlsError::DisallowedPeer {
+            if matches!(err, TlsError::DisallowedPeer) {
                 emit!(IpAllowlistDeniedError { peer: &err });
             } else {
                 warn!(message = "Accept failed", error = %err);

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -99,25 +99,24 @@ pub fn extract_tag_key_and_value<S: AsRef<str>>(
     }
 }
 
-use std::convert::Infallible;
-
 use crate::internal_events::IpAllowlistDeniedError;
 use crate::tls::TlsError;
 
 /// Helper function to handle accept errors in TLS streams.
-/// Returns `Some(Ok(stream))` on success, logs the error and returns `None` on failure.
+/// Returns `Some(Ok(stream))` on success, `None` for non-fatal peer rejections,
+/// and `Some(Err(...))` for fatal TLS errors.
 pub async fn handle_accept_error<S>(
     result: Result<S, TlsError>,
-) -> Option<Result<S, Infallible>> {
+) -> Option<Result<S, TlsError>> {
     match result {
         Ok(stream) => Some(Ok(stream)),
         Err(err) => {
             if matches!(err, TlsError::DisallowedPeer) {
                 emit!(IpAllowlistDeniedError { peer: &err });
+                None
             } else {
-                warn!(message = "Accept failed", error = %err);
+                Some(Err(err))
             }
-            None
         }
     }
 }

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -98,3 +98,26 @@ pub fn extract_tag_key_and_value<S: AsRef<str>>(
         None => (tag_chunk.to_string(), TagValue::Bare),
     }
 }
+
+use std::convert::Infallible;
+
+use crate::internal_events::IpAllowlistDeniedError;
+use crate::tls::TlsError;
+
+/// Helper function to handle accept errors in TLS streams.
+/// Returns `Some(Ok(stream))` on success, logs the error and returns `None` on failure.
+pub async fn handle_accept_error<S>(
+    result: Result<S, TlsError>,
+) -> Option<Result<S, Infallible>> {
+    match result {
+        Ok(stream) => Some(Ok(stream)),
+        Err(err) => {
+            if err == TlsError::DisallowedPeer {
+                emit!(IpAllowlistDeniedError { peer: &err });
+            } else {
+                warn!(message = "Accept failed", error = %err);
+            }
+            None
+        }
+    }
+}


### PR DESCRIPTION
left out `windows event forwarder` for now, may need change in dataplane_private. 

Sources implemented so far: tcp, splunk HEC, firehose, prometheus remote write, HTTP server (push), udp, datadog agent, OpenTelemetry