### PR TITLE
docs: import upstream AGENTS.md and sync referenced docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,74 @@
+## Summary
+<!-- Please provide a brief summary about what this PR does.
+This should help the reviewers give feedback faster and with higher quality. -->
+
+## Vector configuration
+<!-- Include Vector configuration(s) you used to test and debug your changes. -->
+
+## How did you test this PR?
+<!-- Please describe how you tested your changes. Also include any information about your setup. -->
+
+## Change Type
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Dependencies
+- [ ] Non-functional (chore, refactoring, docs)
+- [ ] Performance
+
+## Is this a breaking change?
+
+- [ ] Yes
+- [ ] No
+
+## Does this PR include user facing changes?
+<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
+Changes to CI, website, playground and similar are generally not considered user facing -->
+
+- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
+- [ ] No. A maintainer will apply the `no-changelog` label to this PR.
+
+## References
+
+<!--
+- Closes: #<issue/PR number or link>
+-->
+<!--
+- Related: #<issue/PR number or link>
+-->
+
+## Notes
+
+- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
+- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
+- Some CI checks run only after we manually approve them.
+  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
+  - Alternatively, we recommend running the following locally before pushing to the remote branch:
+    - `make fmt`
+    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
+    - `make test`
+- After a review is requested, please avoid force pushes to help us review incrementally.
+  - Feel free to push as many commits as you want. They will be squashed into one before merging.
+  - For example, you can run `git merge origin master` and `git push`.
+- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
+  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).
+
+
+<!--
+  Your PR title must conform to the conventional commit spec:
+  https://www.conventionalcommits.org/en/v1.0.0/
+
+  <type>(<scope>)!: <description>
+
+  * `type` = chore, enhancement, feat, fix, docs, revert
+  * `!` = OPTIONAL: signals a breaking change
+  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
+  * `description` = short description of the change
+
+Examples:
+
+  * enhancement(file source): Add `sort` option to sort discovered files
+  * feat(new source): Initial `statsd` source
+  * fix(file source): Fix a bug discovering new files
+  * chore(external docs): Clarify `batch_size` option
+-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,282 @@
+# Quick Reference for Vector Development
+
+This guide provides quick commands and coding conventions for Vector development. It's designed to help both AI assistants and human
+contributors get started quickly.
+
+**For comprehensive information, see [CONTRIBUTING.md](CONTRIBUTING.md) and [docs/DEVELOPING.md](docs/DEVELOPING.md).**
+
+## Project Summary
+
+Vector is a high-performance, end-to-end observability data pipeline written in Rust. It collects, transforms, and routes logs, metrics, and
+traces from various sources to any destination. Vector is designed to be reliable, fast, and vendor-neutral, enabling dramatic cost
+reduction and improved data quality for observability infrastructure.
+
+## Project Structure
+
+### Core Directories
+
+- `/src/` - Main Rust source code
+  - `sources/` - Data ingestion components
+  - `transforms/` - Data processing and routing components
+  - `sinks/` - Data output destinations
+  - `config/` - Configuration system and validation
+  - `topology/` - Component graph management
+  - `api/` - gRPC API for management and monitoring
+  - `cli.rs` - Command-line interface
+
+- `/lib/` - Modular library crates
+  - `vector-lib/` - Unified library re-exporting core Vector components
+  - `vector-core/` - Core event system and abstractions
+  - `vector-config/` - Configuration framework with schema generation
+  - `vector-buffers/` - Buffering and backpressure management
+  - `codecs/` - Data encoding/decoding (JSON, Avro, Protobuf)
+  - `enrichment/` - Data enrichment (GeoIP, custom tables)
+  - `file-source/` - File watching and reading
+  - `prometheus-parser/` - Prometheus metrics parsing
+
+- `/config/` - Configuration examples and templates
+- `/distribution/` - Packaging and deployment configs
+  - `docker/` - Docker images (Alpine, Debian, Distroless)
+  - `kubernetes/` - Kubernetes manifests
+  - `systemd/` - SystemD service files
+  - `debian/`, `rpm/` - Linux package configurations
+
+- `/scripts/` - Build, test, and deployment automation
+- `/docs/` - Developer documentation
+- `/tests/` - Integration and E2E tests
+
+## Development Workflow
+
+### Iterative Development Process
+
+When working on Vector's Rust codebase, follow this iterative development cycle:
+
+1. Make code changes
+2. Run `make check-clippy` to check for linting issues
+3. Fix any issues found (use `make clippy-fix` for auto-fixes)
+4. Continue to next task or mark current task complete
+
+Run this cycle after any code modification.
+
+When editing markdown files (*.md), run `make check-markdown` after changes.
+
+## Two Different Workflows
+
+### Rust Development (Most Common)
+
+If you're working on Vector's Rust codebase (sources, sinks, transforms, core functionality):
+
+**Format your code:**
+
+```bash
+make fmt
+```
+
+**Check formatting:**
+
+```bash
+make check-fmt
+```
+
+**Run Clippy (linter):**
+
+```bash
+make check-clippy
+```
+
+**Auto-fix Clippy issues:**
+
+```bash
+make clippy-fix
+```
+
+**Run unit tests:**
+
+```bash
+make test
+# or
+cargo nextest run --workspace --no-default-features --features "${FEATURES}"
+```
+
+**Run integration tests:**
+
+```bash
+# See available integration tests:
+# cargo vdev int show
+./scripts/run-integration-test.sh <integration-name>
+```
+
+See [Integration Tests](#integration-tests) section below for more details.
+
+**Before committing (recommended checks):**
+
+```bash
+make fmt                      # Format code
+make check-fmt                # Verify formatting
+make check-clippy             # Run Clippy linter
+make check-markdown           # Check markdown files
+make check-generated-docs     # Check generated documentation
+./scripts/check_changelog_fragments.sh  # Verify changelog
+```
+
+### Website/Docs Development (Separate Process)
+
+If you're working on vector.dev website or documentation content:
+
+**Prerequisites:**
+
+- Hugo static site generator
+- CUE CLI tool
+- Node.js and Yarn
+- htmltest
+
+**Run the site locally:**
+
+```bash
+cd website
+make serve
+# Navigate to http://localhost:1313
+```
+
+**Build website:**
+
+```bash
+cd website
+make cue-build
+```
+
+**Note:** Website changes use Hugo, CUE, Tailwind CSS, and TypeScript. See [website/README.md](website/README.md) for details.
+
+## Configuration Format
+
+Always generate Vector configuration examples in **YAML** unless the user explicitly asks for TOML or JSON. YAML is Vector's recommended and default configuration format.
+
+## Common Patterns
+
+### Development Tools
+
+Vector uses `cargo vdev` for most development tasks. This is a custom CLI tool that wraps common operations:
+
+```bash
+cargo vdev check rust         # Clippy
+cargo vdev check fmt          # Formatting check
+cargo vdev check events       # Event instrumentation check
+cargo vdev check licenses     # License compliance
+cargo vdev test               # Unit tests
+cargo vdev int test <name>    # Integration tests
+cargo vdev fmt                # Format code
+```
+
+### Pre-Push Hook (Optional but Recommended)
+
+Create `.git/hooks/pre-push` with:
+
+```bash
+#!/bin/sh
+set -e
+
+echo "Format code"
+make fmt
+
+echo "Running pre-push checks..."
+make check-licenses
+make check-fmt
+make check-clippy
+make check-markdown
+make check-generated-docs
+
+./scripts/check_changelog_fragments.sh
+```
+
+Then: `chmod +x .git/hooks/pre-push`
+
+## Detailed Documentation
+
+| Topic | Document |
+| ----- | -------- |
+| Rust style patterns | [docs/RUST_STYLE.md](docs/RUST_STYLE.md) |
+| Code style rules (formatting, const strings, organization) | [STYLE.md](STYLE.md) |
+| System architecture (sources, transforms, sinks, topology) | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) |
+| Component specification (naming, configuration, health checks) | [docs/specs/component.md](docs/specs/component.md) |
+| Instrumentation requirements (event/metric naming) | [docs/specs/instrumentation.md](docs/specs/instrumentation.md) |
+| How to document code changes | [docs/DOCUMENTING.md](docs/DOCUMENTING.md) |
+| Adding changelog entries | [changelog.d/README.md](changelog.d/README.md) |
+
+## Architecture Notes
+
+### Component Development
+
+- **Sources**: Ingest data from external systems
+- **Transforms**: Modify, filter, or enrich event data
+- **Sinks**: Send data to external systems
+
+Component docs are auto-generated from code annotations. Run `make check-generated-docs` after changes.
+
+### Integration Tests
+
+Integration tests verify Vector works with real external services. Require Docker or Podman.
+
+**Run integration tests:**
+
+```bash
+# List available tests
+cargo vdev int show
+
+# Run specific test (example: aws)
+cargo vdev int start aws # need to initiate dev environment first
+cargo vdev int test aws
+```
+
+See [docs/DEVELOPING.md](docs/DEVELOPING.md#integration-tests) for adding new integration tests.
+
+### Key Files
+
+- `Makefile` - Common build/test/check targets
+- `vdev/` - Custom development CLI tool
+- `src/` - Rust source code
+- `website/` - Hugo-based documentation site
+- `tests/` - Integration and behavior tests
+
+## Common Issues
+
+### Formatting Fails
+
+Run `make fmt` before committing. Formatting must be exact.
+
+### Clippy Errors
+
+Run `make clippy-fix` to auto-fix many issues. Manual fixes may be required.
+
+### Generated Docs Out of Sync
+
+Documentation is generated from code. Run:
+
+```bash
+make check-generated-docs
+```
+
+### License Check Fails
+
+After adding/updating dependencies:
+
+```bash
+cargo install dd-rust-license-tool --locked
+make build-licenses
+```
+
+## Creating Pull Requests
+
+Before opening a PR, read [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) and use it as the reference for the PR body structure and title.
+
+### PR Title Format
+
+PR titles must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec and are validated by `.github/workflows/semantic.yml`.
+
+Examples:
+
+```text
+feat(kafka source): add consumer group lag metric
+fix(loki sink): handle empty label sets correctly
+docs(internal docs): update contributing guide
+chore(deps): bump tokio to X
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,178 @@
+@AGENTS.md
+
+# CLAUDE.md — Observo Vector Overlay
+
+This is the **Observo fork of Vector**. The line above pulls in upstream's `AGENTS.md`, which covers generic Vector dev: `make fmt`, `make check-clippy`, `cargo vdev`, integration tests, PR conventions, project layout, YAML config defaults, license checks. **Don't duplicate those here.**
+
+This file is the **Observo-specific overlay**: how the fork diverges, the proprietary components in `lib/observo/`, and the non-obvious architectural details that aren't in AGENTS.md.
+
+## Architecture (Beyond AGENTS.md)
+
+AGENTS.md describes sources/transforms/sinks at a high level. The performance- and correctness-critical details below are unique to this file.
+
+### Data Flow & Channels
+
+```
+Sources -> async channels -> Transforms -> async channels -> Sinks
+```
+
+Connected via a **Topology** (`src/topology/`) that supports hot-reload. Channels carry **`EventArray`** batches (an enum: `Logs(Vec<LogEvent>)` / `Metrics(Vec<Metric>)` / `Traces(Vec<TraceEvent>)`), not individual `Event`s. This is the central perf decision — homogeneous `Vec` layout, one tag check per batch, bulk-serializable. **Don't introduce per-event channels in hot paths.**
+
+### Core Types (from `vector-lib` / `vector-core`)
+
+- **`Event`** — enum wrapping `LogEvent`, `Metric`, `TraceEvent`
+- **`EventArray`** — the channeled type; one variant per `Event` variant
+- **`SourceConfig` / `SinkConfig` / `TransformConfig`** — traits every component config implements (returned `Source` / `VectorSink` / `Transform` are runtime values)
+- **`Source`** — type alias for `BoxFuture<'static, Result<(), ()>>`; sources are one-shot futures, not long-lived trait objects
+- **`Transform`** — enum: `Function` / `Synchronous` / `Task` (each wraps a different trait object; not unified under one trait)
+- **`VectorSink`** — enum: `Sink(Box<dyn Sink<EventArray>>)` / `Stream(Box<dyn StreamSink<EventArray>>)`
+- **`Fanout`** — custom 1→N broadcast at `lib/vector-core/src/fanout.rs` with `Add`/`Remove`/`Pause`/`Replace` control messages for hot-reload (not `tokio::sync::broadcast`)
+- **`TopologyController`** — top-level lifecycle: start, reload, stop
+
+### Key Files
+
+- `src/topology/builder.rs` — builds component tasks from config (`build_sources`, `build_transforms`, `build_sinks`; the transform `Runner` and `run_inline` / `run_concurrently` modes). Also home of Observo's `CHECKPT_STORE` global.
+- `src/topology/running.rs` — `RunningTopology`, `spawn_*` functions, reload state machine
+- `src/topology/task.rs` — `Task` wrapper (`BoxFuture` + `ComponentKey` + `typetag`)
+- `lib/vector-core/src/fanout.rs` — the trickiest concurrency primitive
+- `lib/vector-core/src/event/mod.rs` + `event/array.rs` — event model
+- `lib/vector-buffers/src/topology/channel/sender.rs` — pluggable buffer backends
+
+### Component Registration
+
+All components use `#[configurable_component]` + `#[typetag::serde]` + `inventory` for compile-time self-registration:
+
+```rust
+#[configurable_component(source("my_source", "Description"))]
+#[derive(Clone, Debug)]
+pub struct MySourceConfig { /* fields */ }
+
+#[async_trait]
+#[typetag::serde(name = "my_source")]
+impl SourceConfig for MySourceConfig {
+    async fn build(&self, cx: SourceContext) -> Result<Source> { /* ... */ }
+    fn outputs(&self, _: LogNamespace) -> Vec<SourceOutput> { /* ... */ }
+}
+```
+
+Each component lives behind a feature flag: `sources-{name}`, `sinks-{name}`, `transforms-{name}`.
+
+### Transform Variants
+
+- `FunctionTransform` — simple event-by-event; cloned per worker when concurrent
+- `SyncTransform` — broader; can write to multiple named outputs
+- `TaskTransform<EventArray>` — stateful, stream-to-stream; coordination barrier (cannot be parallelized)
+
+### Sink Variants
+
+- Stream-based (`StreamSink`) or `futures::Sink<EventArray>`, typically composed with Tower middleware in `src/sinks/util/` for batching, retries, rate-limiting.
+
+### Backpressure
+
+Structural — every channel is bounded. Per-sink `WhenFull` policy (`lib/vector-buffers/src/lib.rs`):
+
+- `Block` (default) — backpressure all the way up to the source
+- `DropNewest` — shed load (intentionally breaks backpressure)
+- `Overflow` — multi-stage buffers (memory → disk)
+
+### Concurrency Model
+
+- One tokio runtime, multi-threaded (worker count = CPU count by default)
+- Per source: 2 tasks (the source future + a "pump" task draining `SourceSender` into `Fanout`)
+- Per transform / sink: 1 task each
+- Synchronous transforms can opt into `run_concurrently` (clones the transform, spawns sub-tasks via `FuturesOrdered`); task transforms cannot
+- Use `tokio::select! { biased; ... }` when shutdown must trump other branches
+- Bounded channels for data (`BufferSender`, `LimitedSender`); unbounded `mpsc` only for control plane (e.g., fanout `ControlMessage`, `abort_tx`)
+
+## Observo-Specific Development
+
+### Private Submodule Architecture
+
+Observo proprietary code lives in `lib/observo/private/` — a git submodule (URL in `.gitmodules`). Public wrapper crates under `lib/observo/{name}/` re-export from the private tree; build manifests (`Cargo.toml`) stay in the public tree.
+
+After cloning, initialize the submodule: `git submodule update --init`
+
+For IDE / rust-analyzer setup, see the private submodule's own tooling.
+
+Observo crates do not register components with `inventory` themselves. They expose engine primitives; the integration glue lives in `src/sources/`, `src/sinks/`, `src/transforms/` gated behind feature flags (e.g., `#[cfg(feature = "sources-scol")] pub mod scol;`).
+
+### Observo Feature Flags
+
+- `observo` — aggregates all Observo features (lext, scol, lv3, chkpts, stcp, wef, vrl, gcs, azs, ssa)
+- `observo-test` — enables test-scenario features for scol, lv3, ssa
+- `observo-lext`, `observo-lv3`, `observo-chkpts`, `observo-ssa` — individual feature flags
+
+**Makefile behavior**: By default, Observo crates are excluded from builds via `EXCLUDE_WORKSPACES`. Setting `FEATURES=observo` automatically clears this exclusion.
+
+**Build awareness**: Default `cargo check` / `cargo build` / `make test` do *not* build Observo crates and do *not* mirror what CI tests. Before pushing changes that touch component-config glue, `mod.rs` files under `src/sources/` / `src/sinks/` / `src/transforms/`, or anything used by Observo crates, run:
+
+```bash
+FEATURES=observo cargo check              # catch breakages early
+FEATURES=observo make test                # Observo unit tests
+FEATURES=observo,observo-test make test   # + Observo test scenarios
+```
+
+Adding `use crate::sources::scol` (or any Observo-touching path) without a `#[cfg(feature = "...")]` gate will break the default build.
+
+### Observo Crates
+
+| Crate   | Purpose |
+|---------|---------|
+| azs     | Azure Storage sink |
+| chkpts  | Checkpointing / state |
+| gcs     | GCS source/sink |
+| lext    | Lua extensions |
+| lv3     | Lua v3 transform |
+| obvrl   | Custom VRL functions |
+| sauth   | Auth framework |
+| scol    | Streaming collection/transform |
+| ssa     | Streaming aggregation |
+| stcp    | TCP source |
+| wef     | WEF format handler |
+
+### VRL Fork
+
+This repo depends on `Observo-Inc/vrl.git` (custom fork), not upstream VRL. The rev is pinned in root `Cargo.toml`. For local VRL iteration, see vdev README for git server setup (`git://172.17.0.1/vrl`). Observo VRL extensions (MessagePack, XML, etc.) live in `lib/observo/obvrl` and are wired in via the `observo-vrl` feature on `vector-vrl-functions`.
+
+### Process-wide CheckpointStore
+
+Observo introduces one deliberate global singleton in `src/topology/builder.rs` that exposes a checkpoint store to sources via `SourceContext`. It survives topology reloads (in-place `reload()` rather than rebuild). This is a deliberate exception to Vector's "no shared state" stance — sources need persistent checkpoints across reloads. **Don't add hot-path locking; checkpoint access should be per-batch, not per-event.**
+
+## Code Style
+
+- **Logging**: Use `tracing` with key-value style: `warn!(message = "Failed.", %error);` — not `warn!("Failed: {}", err);`
+- **Error variable naming**: Always spell out `error`, never `e` or `err`
+- **Display over Debug**: Prefer `%error` over `?error` in tracing macros
+- **Error handling**: Use `snafu` crate for structured errors. Never panic in regular code paths.
+- **Rust version**: Toolchain 1.83, MSRV 1.81
+
+## Testing Notes (Observo-specific)
+
+- Default `cargo test` and `make test` skip Observo crates (excluded via `EXCLUDE_WORKSPACES`). Run `FEATURES=observo make test` to include them.
+- `cargo-nextest` retries 3× before reporting failure (config in `.config/nextest.toml`, 30s slow-test threshold, no fail-fast) — flaky tests slip through. Watch the test summary for "flaky retries."
+- `#[tokio::test]` defaults to single-threaded; use `#[tokio::test(flavor = "multi_thread")]` when concurrency is required for the test logic.
+- Config generation test: `crate::test_util::test_generate_config::<MyConfig>()`
+- Test utilities in `src/test_util/`: `start_topology()`, `random_events_with_stream()`, compliance assertions
+- For transform-only tests, fake source/sink helpers exist as `UnitTestStreamSourceConfig` / `UnitTestStreamSinkConfig` (`src/config/unit_test/`)
+
+## CI (Observo Fork)
+
+- `.github/workflows/observo.test.yml` — triggers test workflow in external `dataplane-build` repo on PRs and master pushes
+- `.github/workflows/observo.release.yml` — triggers publish workflow on `test.*` or `release.*` tags
+- Actual build/test execution happens in the separate `Observo-Inc/dataplane-build` repo (not in this repo's GitHub Actions)
+
+## Syncing AGENTS.md from Upstream
+
+`AGENTS.md` at the repo root is a verbatim copy of `vectordotdev/vector`'s file. To refresh it:
+
+```bash
+# One-time: register upstream (already done locally; check `git remote -v`)
+git remote add upstream https://github.com/vectordotdev/vector.git
+
+# Resync
+git fetch upstream master
+git checkout upstream/master -- AGENTS.md
+git diff --staged AGENTS.md   # review before committing
+```
+
+If upstream's AGENTS.md introduces commands or conventions that conflict with our fork (e.g., new linting requirements, removed `make` targets), update this file's overlay accordingly rather than diverging AGENTS.md.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,353 @@
+# Contributing
+
+First, thank you for contributing to Vector! The goal of this document is to
+provide everything you need to start contributing to Vector. The
+following TOC is sorted progressively, starting with the basics and
+expanding into more specifics. Everyone from a first time contributor to a
+Vector team member will find this document useful.
+
+- [Introduction](#introduction)
+- [Your First Contribution](#your-first-contribution)
+  - [New sources, sinks, and transforms](#new-sources-sinks-and-transforms)
+- [Workflow](#workflow)
+  - [Git Branches](#git-branches)
+  - [Git Commits](#git-commits)
+    - [Style](#style)
+  - [GitHub Pull Requests](#github-pull-requests)
+    - [Title](#title)
+    - [Reviews & Approvals](#reviews--approvals)
+    - [Merge Style](#merge-style)
+  - [CI](#ci)
+    - [Releasing](#releasing)
+    - [Testing](#testing)
+      - [Skipping tests](#skipping-tests)
+      - [Daily tests](#daily-tests)
+    - [Flakey tests](#flakey-tests)
+      - [Test harness](#test-harness)
+  - [Running Tests Locally](#running-tests-locally)
+  - [Deprecations](#deprecations)
+  - [Dependencies](#dependencies)
+- [Next steps](#next-steps)
+- [Legal](#legal)
+  - [Contributor License Agreement](#contributor-license-agreement)
+  - [Granted rights and copyright assignment](#granted-rights-and-copyright-assignment)
+
+## Introduction
+
+1. **You're familiar with [GitHub](https://github.com) and the pull request
+   workflow.**
+2. **You've read Vector's [docs](https://vector.dev/docs/).**
+3. **You know about the [Vector community](https://vector.dev/community/).
+   Please use this for help.**
+
+## Your First Contribution
+
+1. For large PRs or for breaking changes, ensure your change has an issue! Find an
+   [existing issue][urls.existing_issues] or [open a new issue][urls.new_issue].
+   - This is where you can get a feel if the change will be accepted or not.
+2. Once approved, [fork the Vector repository][urls.fork_repo] in your own
+   GitHub account (only applicable to outside contributors).
+3. [Create a new Git branch][urls.create_branch].
+4. Make your changes.
+5. [Submit the branch as a pull request][urls.submit_pr] to the main Vector
+   repo. A Vector team member should comment and/or review your pull request
+   within a few days. Although, depending on the circumstances, it may take
+   longer.
+
+### New sources, sinks, and transforms
+
+If you're thinking of contributing a new source, sink, or transform to Vector, thank you that's way cool! The answers to
+the below questions are required for each newly proposed component and depending on the answers, we may elect to not
+include the proposed component. If you're having trouble with any of the questions, we're available to help you.
+
+**Prior to beginning work on a new source or sink if a GitHub Issue does not already exist, please open one to discuss
+the introduction of the new integration.** Maintainers will review the proposal with the following checklist in mind,
+try and consider them when sharing your proposal to reduce the amount of time it takes to review your proposal. This
+list is not exhaustive, and may be updated over time.
+
+- [ ] Can the proposed component’s functionality be replicated by an existing component, with a specific configuration?
+(ex: Azure Event Hub as a `kafka` sink configuration)
+  - [ ] Alternatively implemented as a wrapper around an existing component. (ex. `axiom` wrapping `elasticsearch`)
+- [ ] Can an existing component replicate the proposed component’s functionality, with non-breaking changes?
+- [ ] Can an existing component be rewritten in a more generic fashion to cover both the existing and proposed functions?
+- [ ] Is the proposed component generically usable or is it specific to a particular service?
+  - [ ] How established is the target of the integration, what is the relative market share of the integrated service?
+- [ ] Is there sufficient demand for the component?
+  - [ ] If the integration can be served with a workaround or more generic component, how painful is this for users?
+- [ ] Is the contribution from an individual or the organization owning the integrated service? (examples of
+organization backed integrations: `databend` sink, `axiom` sink)
+  - [ ] Is the contributor committed to maintaining the integration if it is accepted?
+- [ ] What is the overall complexity of the proposed design of this integration from a technical and functional
+standpoint, and what is the expected ongoing maintenance burden?
+- [ ] How will this integration be tested and QA’d for any changes and fixes?
+  - [ ] Will we have access to an account with the service if the integration is not open source?
+
+To merge a new source, sink, or transform, the pull request is required to:
+
+- [ ] Add tests, especially integration tests if your contribution connects to an external service.
+- [ ] Add instrumentation so folks using your integration can get insight into how it's working and performing. You can
+see some [example of instrumentation in existing integrations](https://github.com/vectordotdev/vector/tree/master/src/internal_events).
+- [ ] Add documentation. You need to generate and create documentation files for your component. See the [component documentation guide](docs/DOCUMENTING.md#adding-documentation-for-new-components) for detailed instructions.
+
+When adding new integration tests, the following changes are needed in the GitHub Workflows:
+
+- in `.github/workflows/integration.yml`, add another entry in the matrix definition for the new integration.
+- in `.github/workflows/integration-comment.yml`, add another entry in the matrix definition for the new integration.
+- in `.github/workflows/changes.yml`, add a new filter definition for files changed, and update the `changes` job
+outputs to reference the filter, and finally update the outputs of `workflow_call` to include the new filter.
+
+## Workflow
+
+### Git Branches
+
+_All_ changes must be made in a branch and submitted as [pull requests](#github-pull-requests).
+
+If you want your branch to have a website preview build created, include the word `website` in the
+branch.
+
+Otherwise, Vector does not adopt any type of branch naming style, but please use something
+descriptive of your changes.
+
+### Git Commits
+
+#### Style
+
+Please ensure your commits are small and focused; they should tell a story of
+your change. This helps reviewers to follow your changes, especially for more
+complex changes.
+
+#### Pre-push
+
+To reduce iterations you can create do the following:
+
+```shell
+touch .git/hooks/pre-push
+chmod +x .git/hooks/pre-push
+```
+
+You can use the following as a starting point:
+
+```shell
+#!/bin/sh
+set -e
+
+echo "Format code"
+
+make fmt
+
+echo "Running pre-push checks..."
+
+# We recommend always running all the following checks.
+make check-licenses
+make check-fmt
+make check-clippy
+make check-generated-docs
+
+# Some other checks that in our experience rarely fail on PRs.
+make check-deny
+make check-docs
+make check-examples
+make check-scripts
+
+./scripts/check_changelog_fragments.sh
+
+# The following check is very slow.
+# make check-component-features
+```
+
+Please note that `make check-all` covers all checks, but it is slow and may runs checks not
+relevant to your PR. This command is defined in the
+[Makefile](https://github.com/vectordotdev/vector/blob/1ef01aeeef592c21d32ba4d663e199f0608f615b/Makefile#L450-L454).
+
+### GitHub Pull Requests
+
+Once your changes are ready you must submit your branch as a [pull request](https://github.com/vectordotdev/vector/pulls).
+
+#### Title
+
+The pull request title must follow the format outlined in the [conventional commits spec](https://www.conventionalcommits.org).
+[Conventional commits](https://www.conventionalcommits.org) is a standardized
+format for commit messages. Vector only requires this format for commits on
+the `master` branch. And because Vector squashes commits before merging
+branches, this means that only the pull request title must conform to this
+format. Vector performs a pull request check to verify the pull request title
+in case you forget.
+
+A list of allowed sub-categories is defined in the
+[semantic.yml workflow](https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L21).
+
+The following are all good examples of pull request titles:
+
+```text
+feat(new sink): new `xyz` sink
+feat(tcp source): add foo bar baz feature
+fix(tcp source): fix foo bar baz bug
+chore: improve build process
+docs: fix typos
+```
+
+#### Reviews & Approvals
+
+All pull requests should be reviewed by:
+
+- No review required for cosmetic changes like whitespace, typos, and spelling
+  by a maintainer
+- One Vector team member for minor changes or trivial changes from contributors
+- Two Vector team members for major changes
+- Three Vector team members for RFCs
+
+If CODEOWNERS are assigned, a review from an individual from each of the sets of owners is required.
+
+#### Merge Style
+
+All pull requests are squashed and merged. We generally discourage large pull
+requests that are over 300-500 lines of diff. If you would like to propose a
+change that is larger we suggest coming onto our [Discord server](https://chat.vector.dev/) and discuss it
+with one of our engineers. This way we can talk through the solution and
+discuss if a change that large is even needed! This will produce a quicker
+response to the change and likely produce code that aligns better with our
+process.
+
+#### Changelog
+
+By default, all pull requests are assumed to include user-facing changes that
+need to be communicated in the project's changelog. If your pull request does
+not contain user-facing changes that warrant describing in the changelog, add
+the label 'no-changelog' to your PR. When in doubt, consult the vector team
+for guidance. The details on how to add a changelog entry for your PR are
+outlined in detail in [changelog.d/README.md](changelog.d/README.md).
+
+### CI
+
+Currently, Vector uses GitHub Actions to run tests. The workflows are defined in
+`.github/workflows`.
+
+#### Releasing
+
+GitHub Actions is responsible for releasing updated versions of Vector through
+various channels.
+
+#### Testing
+
+##### Skipping tests
+
+Tests are run for all changes except those that have the label:
+
+```text
+ci-condition: skip
+```
+
+##### Daily tests
+
+Some long-running tests are only run daily, rather than on every pull request.
+If needed, an administrator can kick off these tests manually via the button on
+the [nightly build action
+page](https://github.com/vectordotdev/vector/actions?query=workflow%3Anightly)
+
+#### Flakey tests
+
+Historically, we've had some trouble with tests being flakey. If your PR does
+not have passing tests:
+
+- Ensure that the test failures are unrelated to your change
+  - Is it failing on master?
+  - Does it fail if you rerun CI?
+  - Can you reproduce locally?
+- Find or open an issue for the test failure
+  ([example](https://github.com/vectordotdev/vector/issues/3781))
+- Link the PR in the issue for the failing test so that there are more examples
+
+##### Test harness
+
+You can invoke the [test harness][urls.vector_test_harness] by commenting on
+any pull request with:
+
+```bash
+/test -t <name>
+```
+
+### Running Tests Locally
+
+To run tests locally, use [cargo vdev](https://github.com/vectordotdev/vector/blob/master/vdev/README.md).
+
+Unit tests can be run by calling `cargo vdev test`.
+
+Integration tests are not run by default when running
+`cargo vdev test`. Instead, they are accessible via the integration subcommand (example:
+`cargo vdev int test aws` runs aws-related integration tests). You can find the list of available integration tests using `cargo vdev int show`. Integration tests require docker or podman to run.
+
+### Running other checks
+
+There are other checks that are run by CI before the PR can be merged. These should be run locally
+first to ensure they pass.
+
+```sh
+# Run the Clippy linter to catch common mistakes.
+cargo vdev check rust --fix
+# Ensure all code is properly formatted. Code can be run through `rustfmt` using `cargo fmt` to ensure it is properly formatted.
+cargo vdev check fmt
+# Ensure the internal metrics that Vector emits conform to standards.
+cargo vdev check events
+# Ensure the `LICENSE-3rdparty.csv` file is up to date with the licenses each of Vector's dependencies are published under.
+cargo vdev check licenses
+# Vector's documentation for each component is generated from the comments attached to the Component structs and members.
+# Running this ensures that the generated docs are up to date.
+make check-generated-docs
+# Generate the code documentation for the Vector project.
+# Run this to ensure the docs can be generated without errors (warnings are acceptable at the minute).
+cd rust-doc && make docs
+```
+
+### Updating licences
+
+```sh
+cargo install dd-rust-license-tool --locked
+make build-licenses
+git commit -am "updated LICENSE-3rdparty.csv"
+git push
+```
+
+### Deprecations
+
+When deprecating functionality in Vector, see [DEPRECATION.md](docs/DEPRECATION.md).
+
+### Dependencies
+
+When adding, modifying, or removing a dependency in Vector you may find that you need to update the
+inventory of third-party licenses maintained in `LICENSE-3rdparty.csv`. This file is generated using
+[dd-rust-license-tool](https://github.com/DataDog/rust-license-tool.git) and can be updated using
+`make build-licenses`.
+
+## Next steps
+
+As discussed in the [`README`](README.md), you should continue to the following
+documents:
+
+1. **[DEVELOPING.md](docs/DEVELOPING.md)** - Everything necessary to develop
+2. **[DOCUMENTING.md](docs/DOCUMENTING.md)** - Preparing your change for Vector users
+3. **[DEPRECATION.md](docs/DEPRECATION.md)** - Deprecating functionality in Vector
+
+## Legal
+
+To protect all users of Vector, the following legal requirements are made.
+If you have additional questions, please [contact us].
+
+### Contributor License Agreement
+
+Vector requires all contributors to sign the Contributor License Agreement
+(CLA). This gives Vector the right to use your contribution as well as ensuring
+that you own your contributions and can use them for other purposes.
+
+The [full text of the CLA](https://gist.github.com/bits-bot/55bdc97a4fdad52d97feb4d6c3d1d618) is available on GitHub.
+
+### Granted rights and copyright assignment
+
+This is covered by the CLA.
+
+[contact us]: https://vector.dev/community
+[urls.create_branch]: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-and-deleting-branches-within-your-repository
+[urls.existing_issues]: https://github.com/vectordotdev/vector/issues
+[urls.fork_repo]: https://help.github.com/en/github/getting-started-with-github/fork-a-repo
+[urls.new_issue]: https://github.com/vectordotdev/vector/issues/new
+[urls.submit_pr]: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork
+[urls.vector_test_harness]: https://github.com/vectordotdev/vector-test-harness/

--- a/STYLE.md
+++ b/STYLE.md
@@ -1,0 +1,345 @@
+# Vector Style Guide
+
+As a large, open-source project, it can be a struggle to ensure a consistent level of code quality.
+This style guide is meant to be the canonical reference for all things style: code comments,
+formatting, acceptable (or unacceptable) crates, data structures, or algorithms, and so on.
+
+In essence, we hope to turn pull request review comments like "why did you do it this way?" or "I
+think you could try doing it this way" into "we always do X this way: <link to style guide>".
+
+## Formatting
+
+At a high-level, code formatting is straightforward: we use the native `rustfmt` exclusively, and
+comprehensively.  All Rust source code within the repository should be formatted using `rustfmt`.
+
+You can acquire `rustfmt` -- which is invoked as `cargo fmt` -- by following the directions listed
+out [in the rustfmt repository](https://github.com/rust-lang/rustfmt#on-the-stable-toolchain).
+
+Vector has its own formatting rules (`.rustfmt.toml`) that will automatically be used when you run
+`cargo fmt` within the repository.  If you're ever in doubt, you can also run `make check-fmt` which
+will invoke `cargo fmt` in a dry-run mode, checking to see if any changed files are not currently
+formatted correctly.
+
+As an additional note, `rustfmt` sometimes can fail to format code within macros, so if you happen
+to see such code that doesn't look like it's formatted correctly, you may need to manually tweak it
+if `rustfmt` cannot be persuaded to format it correctly for you. :)
+
+### Const strings
+
+When re-typing the same raw string literal more than once, this can lead to typo
+errors, especially when names ares similar. In general, when reasonable, it is
+preferred to use [Compile-time constants](https://doc.rust-lang.org/std/keyword.const.html)
+when dealing with non-dynamic strings. For example, when working with field names
+for event metadata.
+
+As this has not always been a consistently enforced code style for the project,
+please take the opportunity to update existing raw strings to use constants
+when modifying existing code
+
+## Code Organization
+
+Code is primarily split into two main directories: `lib/` and `src/`.
+
+### `lib/`: shared libraries, etc
+
+We use `lib` almost entirely for shared libraries and for isolating specific pieces of code. As
+Vector itself involves a large number of dependencies, it can be beneficial to move code into
+isolated crates under `lib/` in order to allow them not only to be shared, but also to reduce the
+amount of code that must be processed by helper tools like `cargo check` and `rust-analyzer` during
+normal development, which in turn speeds up the feedback loop between writing code and getting
+informed about errors, warnings, and so on.
+
+### `src/`: main binary and all related functionality
+
+The bulk of functional code resides in the `src/` directory/crate.  When we refer to functional
+code, we're talking about code that powers user-visible aspects of Vector, such as the sources,
+transforms, and sinks themselves. There is also, of course, the requisite glue code such as parsing
+command-line arguments, reading the configuration, constructing and configuring components, and
+wiring them together.
+
+## Internal telemetry: logging, metrics, traces
+
+As a tool for ingesting, transforming, enriching, and shipping observability data, Vector has a
+significant amount of its own internal telemetry. This telemetry is primarily logging and metrics,
+but also includes some amount of tracing.
+
+### Logging
+
+For logging, we use **[`tracing`](https://docs.rs/tracing/latest/tracing)**, which doubles as both a
+way to emit logs but also a way to use distributed tracing techniques to add nested and contextual
+metadata by utilizing [spans](https://docs.rs/tracing/latest/tracing/#spans).
+
+#### Basic Usage
+
+For logging, we use `tracing`'s event macros which should look very similar to almost all other
+logging libraries, with names that emulate the logging level being used i.e. `info!("A wild log has
+appeared.");`.
+
+All of tracing's event macros -- `trace!`, `debug!`, `info!`, `warn!`, and `error!` -- support the
+same argument format, which allows logging in some common ways:
+
+```rust
+// Basic string literal message, no formatting:
+info!("Server has started.");
+
+// A formatted message, with the same formatting support as `println!`/`format!`:
+debug!("User connected: {}", username);
+
+// Adding structured fields to the even, mixing and matching the message format:
+trace!(bytes_sent = 22, "Sent heartbeat packet to client.")`
+error!(client_addr = %conn.get_ref().peer_addr, "Client actor received malformed packet: {}", parse_err.to_string())
+```
+
+While this does not cover all the permutations of what the macros in `tracing` support, these
+examples represent the preferred style of using the macros.
+
+#### Passing in the event message
+
+The `tracing` event macros support passing the event message itself in a few ways, but we prefer the
+**fields/message/message arguments** order:
+
+```rust
+// Don't do this:
+info!(message = "Something happened.");
+// Do this instead:
+info!("Something happened.");
+
+// Don't do this:
+debug!(%client_id, message = "Client entered authentication phase.");
+debug!(message = "Client entered authentication phase.", %client_id);
+// Do this instead:
+debug!(%client_id, "Client entered authentication phase.");
+```
+
+#### Writing a good log message
+
+In general, there are both a few rules and a few suggestions to follow when it comes to writing a
+(good) log message:
+
+- Messages must be written in English. No preference on which specific English dialect is used e.g.
+  American English, British English, Canadian English, etc.
+- Sentences must be capitalized, and end with a period.
+- Proper spelling and grammar when possible. Not all of us are native English speakers, and so this
+  is simply an ask, but not a hard requirement.
+- Identifiers, or passages of note, should be called out by some means i.e. wrapping them in
+  backticks or quotes.  Wrapping with special characters can be helpful in drawing the users eye to
+  anything of importance.
+- If it's longer than one or two sentences, it's probably better suited as a single sentence briefly
+  explaining the event, with a link to external documentation that explains further.
+
+#### Choosing the right log level
+
+Similarly, choosing the right level can be important, both from the perspective of making it easy
+for users to grok what they should pay attention to, but also to avoid the performance overhead of
+excess logging (even if we filter it out and it never makes it to the console).
+
+- **TRACE**: Typically contains a high level of detail for deep/rich debugging.
+
+  As trace logging is typically reached for when instrumenting algorithms and core pieces of logic,
+  care should be taken to avoid trace logging being added to tight loops, or commonly used
+  codepaths, where possible. Even when disabled, there can still be a small overhead associated with
+  logging an event at all.
+- **DEBUG**: Basic information that can be helpful for initially debugging issues.
+
+  Should typically not be used for things that happen per-event, or scales with event throughput,
+  but in some cases -- i.e. if it happens every 1000th event, etc -- it can safely be used.
+- **INFO**: Common information about normal processes.
+
+  This includes logical/temporal events such as notifications when components are stopped and
+  started, or other high-level events that, crucially, do not represent an event that an operator
+  needs to worry about.
+
+  Said another way, **INFO** is primarily there for information that lets them know that an action
+  they just took completed successfully, whether that's the server initially starting up
+  successfully, or reloading a configuration successfully, or exiting Vector after receiving
+  SIGTERM.
+- **WARN**: Something unexpected happened, but no data has been lost, nothing has crashed, and we
+  can recover from it without an issue. An operator might be interested in something at the **WARN**
+  level, but it shouldn't be informing them of things serious enough to require immediate attention.
+- **ERROR**: Data loss, unrecoverable errors, and anything else that will require an operator to
+  intervene and recover from. These should be rare so that they maintain a high signal-to-noise
+  ratio in the observability tooling that operators themselves are using.
+
+### Metrics
+
+For metrics, we use **[`metrics`](https://docs.rs/metrics/latest/metrics/)**, which like `tracing`,
+provides macros for emitting counters, gauges, and histograms.
+
+#### Basic Usage
+
+There are three basic metric types: counters, gauges, and histograms. **Counters** are meant for
+counting things, such as the total number of requests processed, where the count only grows over
+time. This is also sometimes called a *monotonic counter*, or a *monotonically increasing* counter.
+**Gauges** are for tracking a single value that changes over time, and can go up and down, such as
+the number of current connections. **Histograms** are for tracking multiple observations of the same
+logical event, such as the time it takes to serve a request.
+
+Emitting metrics always involves a metric name and a value being measured. They can optionally
+accept descriptive labels:
+
+```rust
+// Counters can be incremented by an arbitrary amount, or `increment_counter!`
+// can be used to simply increment by one:
+counter!("bytes_sent_total", 212);
+increment_counter!("requests_processed_total", "service" => "admin_grpc");
+
+// Gauges can be set to an absolute value, such as setting it to the latest value of an
+// external measurement, or it can be incremented and decremented by an arbitrary amount:
+gauge!("bytes_allocated", 42.0);
+increment_gauge!("bytes_allocated", 2048.0, "table_name" => self.table_name.to_string());
+increment_gauge!("bytes_allocated", 512.0, "table_name" => self.table_name.to_string());
+decrement_gauge!("bytes_allocated", 2560.0, "table_name" => self.table_name.to_string())
+
+// Histograms simply record a measurement, but there's a fun little trait that `metrics`
+// uses called `IntoF64` that lets custom types provide a way to convert themselves to a
+// `f64`, which there's a default implementation of for `Duration`:
+let delta = Duration::from_micros(750);
+histogram!("request_duration_ns", delta);
+histogram!("request_duration_ns", 742_130, "endpoint" => "frontend");
+```
+
+#### Avoiding pitfalls with gauges
+
+Many values can appear, at first, to be best tracked as a gauge: current connection count, in-flight
+request count, and so on. However, in some cases, the value being measured may change too frequently
+to be reliably tracked.  Metrics are typically collected on an interval, which is fine for counters
+and histograms: they're purely additive.  However, since a gauge is simply the _latest_ value, you
+cannot know _how_ it's changed since the last time you've observed it.
+
+This is a common problem where a gauge tracks something like a queue size. If there's an event where
+the queue grows rapidly but drains back down quickly, you may not ever observe the gauge having
+changed if your collection interval is greater than the duration of such events.
+
+A simple pattern to follow to handle these scenarios is to use two counters -- one for the
+increments, one for the decrements -- so that you can graph the difference between them, giving you
+the equivalent of the "current" value. In our example above, we might have `queue_items_pushed` and
+`queued_items_popped`, and if `queue_items_pushed` equals 100, and `queued_items_popped` equals 80,
+we know our queue size is 20. More importantly, if we queried both of them at the same time, and
+they were both zero, and then queried them both a second later, and saw that both were 100,000, we
+would know that the queue size was _currently_ zero but we'd also know that we just processed
+100,000 items in the past second.
+
+#### Best Practices
+
+- **Do** attempt to limit the cardinality, or number of unique values, of label values. If the
+  number of unique values for a label grows over time, this can represent a large amount of consumed
+  memory. This is a problem we expect to be fixed in the medium-term
+  ([#11995](https://github.com/vectordotdev/vector/issues/11995)) but is a good rule to follow
+  unless there's a competing reason to do so, such as when following the guidelines in the
+  [Component
+  Specification](https://github.com/vectordotdev/vector/blob/master/docs/specs/component.md).
+- **Don't** emit metrics in tight loops. Each metric emission carries an overhead, and emitting them
+  in tight loops can cause that overhead to become noticeable in terms of CPU usage and throughput
+  reduction. Instead of incrementing a counter every time a loop iteration occurs, you might
+  consider incrementing a local variable instead, and then emitting that sum after the loop is over.
+- **Don't** update a counter to measure the total number of operations/events/etc if you're already
+  tracking a histogram of those operations/events/etc. Histograms have a `count` property that
+  counts how many samples the histogram has recorded, as well as a `sum` property that is a sum of
+  the value of all samples the histogram has recorded. This means you can potentially get three
+  metrics for the cost of emitting one.
+
+## Dependencies
+
+### Error handling
+
+For error handling, there are two parts: _creating errors_ and _working with errors_.
+
+For **creating errors**, we prefer **[`snafu`](https://docs.rs/snafu)**. The `snafu` crate provides
+a derive for generating the boilerplate `std::error::Error` implementation on your custom error
+struct or enum. It additionally provides helpers for defining the `Display` output for your error
+(potentially on a per-variant basis when working with enums).
+
+While there are popular alternatives such as [`failure`](https://docs.rs/failure) and
+[`thiserror`](https://docs.rs/thiserror), they generally lack either the thoroughness in
+documentation or the flexibility of `snafu`.
+
+For **working with errors**, we have a more lax approach. At the highest level, we use a boxed trait
+approach -- `Box<dyn std::error::Error + Send + Sync + 'static>` -- for maximum flexibility. This
+allows developers to avoid needing to _always_ derive custom error types in order to return errors
+back up the call stack. This does not prevent, and indeed, should not discourage developers from
+using `snafu` to create rich error types that provide additional context, whether through
+descriptive error messages, source errors, or backtraces.
+
+### Concurrency and synchronization
+
+#### Atomics
+
+In general, we strive to use the atomic types in the [standard
+library](https://doc.rust-lang.org/stable/std/sync/atomic/index.html) when possible, as they are the
+most portable and well-tested. In cases where the standard library atomics cannot be used, such as
+when using a 64-bit atomic but wanting to support a 32-bit platform, or support a platform without
+atomic instructions at all, we prefer to use
+**[`crossbeam-utils`](https://docs.rs/crossbeam-utils)** and its `AtomicCell` helper. This type will
+automatically handle either using native atomic support or ensuring mutually exclusive access, and
+handle it in a transparent way. It uses a fixed acquire/release ordering that generally provides the
+expected behavior when using atomics, but may not be suitable for usages which require stronger
+ordering.
+
+#### Global state
+
+When there is a need or desire to share global state, there are a few options depending on the
+required constraints.
+
+If you're working with data that _never changes after initialization_,
+we prefer `std::sync::OnceLock` over **[`once_cell`](https://docs.rs/once_cell)** or
+[`lazy_static`](https://docs.rs/lazy-static). It is slightly faster and provides a richer API than
+`lazy_static`, and has equivalent features to the `once_cell` version.
+
+If you're working with data that _changes over time_, but has a very high read-to-write ratio, such
+as _many readers_, but _one writer_ and infrequent writes, we prefer
+**[`arc-swap`](https://docs.rs/arc-swap)**.  The main feature of this crate is allowing a piece of
+data to be atomically updated while being shared concurrently. It does this by wrapping all data in
+`Arc<T>` to provide the safe, concurrent access, while adding the ability to atomically swap the
+`Arc<T>` itself. As it cannot be constructed in a const fashion, `arc-swap` pairs well with
+`once_cell` for actually storing it in a global static variable.
+
+#### Concurrent data structures
+
+When there is a need for a concurrent and _indexable_ storage, we prefer
+**[`sharded-slab`](https://docs.rs/sharded-slab)**.  This crate provides a means to insert items
+such that the caller gets back to the index by which it can access the item again in the future.
+Additionally, when an item is removed, its storage can be reused by future inserts, making
+`sharded-slab` a good choice for long-running processes where memory allocation reduction is
+paramount. There is also a pool data structure based on the same underlying design of the slab
+itself for use cases where pooling is desired.
+
+### Synchronization
+
+Synchronization can be a very common sight when writing multi-threaded code in any language, and
+this document does not aim to familiarize you with all of the common synchronization primitives and
+their intended usage. Instead, however, there are some caveats that you must be aware of when using
+synchronization primitives in synchronous versus asynchronous code.
+
+Generally speaking, developers will lean on the synchronization primitives in `std::sync`, such as
+`Mutex`, `RwLock`, and so on. These are typically the right choice -- in terms of using the ones
+provided by `std`, vs alternative implementations of the same primitives -- as they're well-tested,
+and have been improving over time in terms of performance. However, developers must be careful when
+using these primitives in asynchronous code, as their behavior can sometimes adversely affect the
+performance and correctness of Vector.
+
+To wit, developers must exercise caution when using synchronous (i.e. `std::sync`, `parking_lot`,
+etc) synchronization primitives in asynchronous code, as they can be used in a way that deadlocks
+the asynchronous runtime even though the code compiles and appears to be correct. In some cases,
+you'll need to use an asynchronous-specific synchronization primitives, namely the ones from `tokio`
+itself. The documentation on `tokio`'s own
+[`Mutex`](https://docs.rs/tokio/latest/tokio/sync/struct.Mutex.html), for example, calls out the
+specifics of when and where you might need to use it vs the one from `std::sync`.
+
+
+## New Configuration Fields vs CLI flags
+
+Vector makes the distinction between configuration items that are essential to understand data
+pipelines and runtime flags that determine the details of the runtime behavior. The main configuration
+generally lives in a file in the current directory or in `/etc/vector`.
+
+Examples of main configuration fields are source, transformation, and sink declaration, as well as
+information about where any disk buffers should be persisted.
+
+For configuration items that purely inform details of Vector's runtime behavior, CLI flags without
+corresponding configuration fields should be used.
+
+An example of a runtime flag is
+`vector run --no-graceful-shutdown-limit`, which tells Vector to ignore SIGINTs and to continue running
+as normal until a SIGKILL is received. In this case, as the configuration describes the desired runtime
+behavior in a specific environment and not to the underlying data pipeline, no corresponding field in
+the configuration file should exist.

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -1,8 +1,6 @@
 # Developing
 
 - [Setup](#setup)
-  - [Using a Docker or Podman environment](#using-a-docker-or-podman-environment)
-  - [Bring your own toolbox](#bring-your-own-toolbox)
 - [The basics](#the-basics)
   - [Directory structure](#directory-structure)
   - [Makefile](#makefile)
@@ -14,6 +12,7 @@
   - [Minimum Supported Rust Version](#minimum-supported-rust-version)
 - [Guidelines](#guidelines)
   - [Sink healthchecks](#sink-healthchecks)
+  - [Disabling internal log rate limiting](#disabling-internal-log-rate-limiting)
 - [Testing](#testing)
   - [Unit tests](#unit-tests)
   - [Integration tests](#integration-tests)
@@ -40,95 +39,31 @@
 
 ## Setup
 
-We're super excited to have you interested in working on Vector! Before you start you should pick how you want to develop.
-
-For small or first-time contributions, we recommend the Docker method. Prefer to do it yourself? That's fine too!
-
-### Using a Docker or Podman environment
-
-> **Targets:** You can use this method to produce AARCH64, Arm6/7, as well as x86/64 Linux builds.
-
-Since not everyone has a full working native environment, we took our environment and stuffed it into a Docker (or Podman) container!
-
-This is ideal for users who want it to "Just work" and just want to start contributing. It's also what we use for our CI, so you know if it breaks we can't do anything else until we fix it. 😉
-
-**Before you go further, install Docker or Podman through your official package manager, or from the [Docker](https://docs.docker.com/get-docker/) or [Podman](https://podman.io/) sites.**
-
-```bash
-# Optional: Only if you use `podman`
-export CONTAINER_TOOL="podman"
-```
-
-If your Linux environment runs SELinux in Enforcing mode, you will need to relabel the vector source code checkout with `container_home_t` context. Otherwise, the container environment cannot read/write the code:
-
-```bash
-cd your/checkout/of/vector/
-sudo semanage fcontext -a "${PWD}(/.*)?" -t container_file_t
-sudo restorecon . -R
-```
-
-By default, `make environment` style tasks will do a `docker pull` from GitHub's container repository, you can **optionally** build your own environment while you make your morning coffee ☕:
-
-```bash
-# Optional: Only if you want to go make a coffee
-make environment-prepare
-```
-
-Now that you have your coffee, you can enter the shell!
-
-```bash
-# Enter a shell with optimized mounts for interactive processes.
-# Inside here, you can use Vector like you have full toolchain (See below!)
-make environment
-# Try out a specific container tool. (Docker/Podman)
-make environment CONTAINER_TOOL="podman"
-# Add extra cli opts
-make environment CLI_OPTS="--publish 3000:2000"
-```
-
-Now you can use the jobs detailed in **"Bring your own toolbox"** below.
-
-Want to run from outside of the environment? _Clever. Good thinking._ You can run any of the following:
-
-```bash
-# Validate your code can compile
-make check ENVIRONMENT=true
-# Validate your code actually does compile (in dev mode)
-make build-dev ENVIRONMENT=true
-# Validate your test pass
-make test SCOPE="sources::example" ENVIRONMENT=true
-# Validate tests (that do not require other services) pass
-make test ENVIRONMENT=true
-# Validate your tests pass (starting required services in Docker)
-make test-integration SCOPE="sources::example" ENVIRONMENT=true
-# Validate your tests pass against a live service.
-make test-integration SCOPE="sources::example" AUTOSPAWN=false ENVIRONMENT=true
-# Validate all tests pass (starting required services in Docker)
-make test-integration ENVIRONMENT=true
-# Run your benchmarks
-make bench SCOPE="transforms::example" ENVIRONMENT=true
-# Format your code before pushing!
-make fmt ENVIRONMENT=true
-```
-
-We use explicit environment opt-in as many contributors choose to keep their Rust toolchain local.
-
-### Bring your own toolbox
-
-> **Targets:** This option is required for MSVC/Mac/FreeBSD toolchains. It can be used to build for any environment or OS.
+We're super excited to have you interested in working on Vector!
 
 To build Vector on your own host will require a fairly complete development environment!
 
 Loosely, you'll need the following:
 
 - **To build Vector:** Have working Rustup, Protobuf tools, C++/C build tools (LLVM, GCC, or MSVC), Python, and Perl, `make` (the GNU one preferably), `bash`, `cmake`, `GNU coreutils`, and `autotools`.
+  - The `default` feature does not enable Kerberos/GSSAPI SASL for kafka, so local dev builds (`cargo build`, `make build`) have no extra system prerequisites beyond the C build tools above.
+  - To enable GSSAPI for kafka, choose one of:
+    - `gssapi`: dynamically links against system `libsasl2`. Requires `libsasl2-dev` (Ubuntu: `sudo apt-get install -y libsasl2-dev`) or `cyrus-sasl` (macOS: `brew install cyrus-sasl`) installed.
+    - `gssapi-vendored` (or `vendored`, which includes it): builds `libsasl2` and `krb5` from bundled source. No system install needed. Linux only; the bundled path does not currently link on macOS arm64.
+
 - **To run `make test`:** Install [`cargo-nextest`](https://nexte.st/)
 - **To run integration tests:** Have `docker` available, or a real live version of that service. (Use `AUTOSPAWN=false`)
 - **To run `make check-component-features`:** Have `remarshal` installed.
-- **To run `make check-licenses` or `cargo vdev build licenses`:** Have `dd-rust-license-tool` [installed](https://github.com/DataDog/rust-license-tool).
-- **To run `cargo vdev build component-docs`:** Have `cue` [installed](https://cuelang.org/docs/install/).
+- **To run `make check-licenses` or `make build-licenses`:** Have `dd-rust-license-tool` [installed](https://github.com/DataDog/rust-license-tool).
+- **To run `make generate-docs`:** Have `cue` [installed](https://cuelang.org/docs/install/).
 
-If you find yourself needing to run something inside the Docker environment described above, that's totally fine, they won't collide or hurt each other. In this case, you'd just run `make environment-generate`.
+**Tooling shortcut:** Once the system-level dependencies above are in place, you can install the Rust and npm tooling (`cargo-nextest`, `cargo-deny`, `dd-rust-license-tool`, `vdev`, `markdownlint-cli2`, `prettier`, and others) in one shot:
+
+```bash
+bash scripts/environment/prepare.sh
+```
+
+This is the same script CI uses to provision its toolchain, so what you get locally matches what CI installs.
 
 We're interested in reducing our dependencies if simple options exist. Got an idea? Try it out, we'd love to hear of your successes and failures!
 
@@ -140,7 +75,6 @@ cargo check
 make check
 # Validate your code actually does compile (in dev mode)
 cargo build
-make build-dev
 # Validate your test pass
 cargo test sources::example
 make test SCOPE="sources::example"
@@ -160,8 +94,8 @@ cargo bench transforms::example
 # Format your code before pushing!
 make fmt
 cargo fmt
-# Build component documentation for the website
-cargo vdev build component-docs
+# Build component and VRL documentation for the website
+make generate-docs
 ```
 
 If you run `make` you'll see a full list of all our tasks. Some of these will start Docker containers, sign commits, or even make releases. These are not common development commands and your mileage may vary.
@@ -328,6 +262,28 @@ that fall into a false negative circumstance. Our goal should be to minimize the
 likelihood of users needing to pull that lever while still making a good effort
 to detect common problems.
 
+### Disabling internal log rate limiting
+
+Vector rate limits its own internal logs by default (10-second windows). During development, you may want to see all log occurrences.
+
+**Globally** (CLI flag or environment variable):
+
+```bash
+vector --config vector.yaml -r 1
+# or
+VECTOR_INTERNAL_LOG_RATE_LIMIT=1 vector --config vector.yaml
+```
+
+**Per log statement**:
+
+```rust
+// Disable rate limiting for this log
+warn!(message = "Error occurred.", %error, internal_log_rate_limit = false);
+
+// Override rate limit window to 1 second
+info!(message = "Processing batch.", batch_size, internal_log_rate_secs = 1);
+```
+
 ## Testing
 
 Testing is very important since Vector's primary design principle is reliability.
@@ -412,14 +368,7 @@ tests related only to this component, the following approach can reduce waiting
 times:
 
 1. Install [cargo-watch](https://github.com/passcod/cargo-watch).
-2. (Only for GNU/Linux) Install LLVM 9 (for example, package `llvm-9` on Debian)
-   and set `RUSTFLAGS` environment variable to use `lld` as the linker:
-
-   ```sh
-   export RUSTFLAGS='-Clinker=clang-9 -Clink-arg=-fuse-ld=lld'
-   ```
-
-3. Run in the root directory of Vector's source
+2. Run in the root directory of Vector's source
 
    ```sh
    cargo watch -s clear -s \
@@ -438,8 +387,8 @@ times:
 
 We use `flog` to build a sample set of log files to test sending logs from a
 file. This can be done with the following commands on Mac with `homebrew`.
-Installation instruction for flog can be found
-[here](https://github.com/mingrammer/flog#installation).
+Installation instruction for flog can be found in the
+[flog README](https://github.com/mingrammer/flog#installation).
 
 ```bash
 flog --bytes $((100 * 1024 * 1024)) > sample.log

--- a/docs/DOCUMENTING.md
+++ b/docs/DOCUMENTING.md
@@ -11,12 +11,13 @@ documentation in tandem with code changes.
 2. [Reference documentation](#reference-documentation)
    1. [Installing CUE](#installing-cue)
    2. [Generating from source code](#generating-from-source-code)
-   3. [Formatting](#formatting)
-   4. [Validating](#validating)
+   3. [Adding Documentation for New Components](#adding-documentation-for-new-components)
+   4. [Formatting](#formatting)
+   5. [Validating](#validating)
       1. [Tips & tricks](#tips--tricks)
          1. [Make small incremental changes](#make-small-incremental-changes)
-   5. [Changelog](#changelog)
-   6. [Release highlights](#release-highlights)
+   6. [Changelog](#changelog)
+   7. [Release highlights](#release-highlights)
       1. [FAQ](#faq)
          1. [What makes a release highlight noteworthy?](#what-makes-a-release-highlight-noteworthy)
          2. [How is a release highlight different from a blog post?](#how-is-a-release-highlight-different-from-a-blog-post)
@@ -61,8 +62,44 @@ Much of Vector's reference documentation is automatically compiled from source c
 To regenerate this content, run:
 
 ```bash
-make generate-component-docs
+make generate-docs
 ```
+
+### Adding Documentation for New Components
+
+When introducing a new source, sink, or transform, you need to create documentation in two steps:
+
+1. **Generate the base documentation** from your Rust configuration schema:
+
+   ```bash
+   make generate-component-docs
+   ```
+
+   This creates an auto-generated CUE file in `website/cue/reference/components/{sources,sinks,transforms}/generated/<component_name>.cue` containing all the configuration options from your Rust code.
+   Note that documentation for config parameters behavior should be part of the Rust docs. The above command will generate a CUE file populated with the Rust docs.
+
+2. **Create a manual CUE file** with additional metadata that cannot be auto-generated:
+   - Create a new file at `website/cue/reference/components/{sources,sinks,transforms}/<component_name>.cue`
+   - This file should include metadata like title, description, examples, feature classifications, and how-it-works sections. See existing CUE files for guidance.
+   - Look at existing components for examples, such as `website/cue/reference/components/transforms/remap.cue`
+
+3. **Format the CUE files**:
+
+   ```bash
+   ./scripts/cue.sh fmt
+   ```
+
+4. **Create a markdown documentation file** for the website:
+   - Create a new file at `website/content/en/docs/reference/configuration/{sources,sinks,transforms}/<component_name>.md`
+   - Look at existing examples e.g. `website/content/en/docs/reference/configuration/transforms/remap.md`
+
+5. **Verify your documentation** is correct:
+
+   ```bash
+   make check-generated-docs
+   ```
+
+6. It is recommended to `cd website && make serve` to view how the documentation renders on the Vector website.
 
 ### Formatting
 
@@ -72,7 +109,7 @@ properly formatted. To run CUE's autoformatting, first [install cue](https://cue
 then run this command from the `vector` root:
 
 ```bash
-./website/scripts/cue.sh fmt
+./scripts/cue.sh fmt
 ```
 
 If that rewrites any files, make sure to commit your changes or else you'll see
@@ -110,9 +147,12 @@ watchexec "make check-docs"
 
 ### Changelog
 
-Contributors do not need to maintain a changelog. This is automatically generated
-via the `make release` command, made possible by the use of
-[conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) titles.
+Contributors document user-facing changes by adding a fragment under
+[`changelog.d/`](../changelog.d/README.md); the release CUE file's user-facing
+changelog section is assembled from those fragments by `cargo vdev release
+prepare` during release prep. The CUE file's `commits:` array is populated
+from the git log via [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
+titles, so PR titles must follow that spec.
 
 ### Release highlights
 

--- a/docs/RUST_STYLE.md
+++ b/docs/RUST_STYLE.md
@@ -1,0 +1,125 @@
+# Rust Style Guide for Vector
+
+> **Note:
+** This is a draft document primarily intended for AI agents (like Claude) to understand Vector's Rust coding conventions. These guidelines help ensure consistent code generation and modifications.
+
+This document outlines Rust coding conventions and patterns for Vector development.
+
+## Import Statements (`use`)
+
+All `use` statements must be at the **top of the file/module** or at the top of `mod tests`.
+This is for consistency.
+
+**Correct:**
+
+```rust
+use std::time::Duration;
+use governor::clock;
+use crate::config::TransformConfig;
+
+fn my_function() {
+    // function code
+}
+```
+
+**Incorrect:**
+
+```rust
+fn my_function() {
+    use std::time::Duration;  // WRONG; Do not insert `use` inside functions
+    // function code
+}
+```
+
+**Organization:**
+
+- Group imports: `std` → external crates → internal (`crate::`)
+- Use `rustfmt` to automatically organize them: `make fmt`
+
+## Logging Style
+
+Always use the [Tracing crate](https://tracing.rs/tracing/)'s key/value style:
+
+**Correct:**
+
+```rust
+warn!(message = "Failed to merge value.", %error);
+info!(message = "Processing batch.", batch_size, internal_log_rate_secs = 1);
+```
+
+**Incorrect:**
+
+```rust
+warn!("Failed to merge value: {}.", err);  // Don't do this
+```
+
+**Rules:**
+
+- Events should be capitalized and end with a period
+- Use `error` (not `e` or `err`) for error values
+- Prefer Display over Debug: `%error` not `?error`
+- Key/value pairs provide structured logging
+
+## String Formatting
+
+Prefer inline variable syntax in format strings (Rust 1.58+).
+
+**Correct:**
+
+```rust
+format!("Error: {err}");
+println!("Processing {count} items");
+```
+
+**Incorrect:**
+
+```rust
+format!("Error: {}", err);      // Unnecessary positional argument
+println!("Processing {} items", count);
+```
+
+**Why:** Inline syntax is more readable and reduces mistakes with argument ordering.
+
+## Panics
+
+Code in Vector should **NOT** panic under normal circumstances.
+
+- Panics are only acceptable when assumptions about internal state are violated (indicating a bug)
+- All potential panics **MUST** be documented in function documentation
+- Prefer `Result<T, E>` and proper error handling
+
+## Feature Flags
+
+### Component Feature Flags
+
+New components (sources, sinks, transforms) must be behind feature flags:
+
+```bash
+# Build only specific component for faster iteration
+cargo test --lib --no-default-features --features sinks-console sinks::console
+```
+
+See `features` section in `Cargo.toml` for examples.
+
+### Cargo Dependency Feature Placement
+
+[Cargo features are additive](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification): once any crate in the dependency graph enables a feature, it is enabled for the entire build. This can be surprising — enabling a feature in one crate silently turns it on everywhere.
+
+Always set `default-features = false` in `[workspace.dependencies]`. For feature declarations, the rule is simple:
+
+- If only one crate needs a feature, declare it in that crate's own `Cargo.toml`.
+- If multiple crates need it, declare it in `[workspace.dependencies]`.
+
+Add a short comment near the dependency when the feature setup is non-obvious.
+
+**Auditing:** when unsure whether a feature is truly needed or only transitively enabled, verify with:
+
+```bash
+# Show the full feature tree for the workspace
+cargo tree -e features
+
+# Narrow down to a specific dependency
+cargo tree -e features -i <crate-name>
+```
+
+The `-i` flag shows which crates depend on `<crate-name>` and which features they activate, useful for tracing where a feature is coming from. If a feature only appears because another crate enables it, and your crate relies on that feature being present, declare it explicitly — otherwise your crate silently breaks if the other crate ever stops enabling it.

--- a/website/README.md
+++ b/website/README.md
@@ -6,7 +6,8 @@ This directory houses all the assets used to build Vector's website and document
 
 In order to run the site [locally](#run-the-site-locally), you need to have these installed:
 
-* The [Hugo] static site generator. Refer to https://gohugo.io/installation/ for instructions.
+* The [Hugo] static site generator (version 0.154.5 to match CI).
+  * Download the **extended** version for your platform from https://github.com/gohugoio/hugo/releases/tag/v0.154.5
 * The CLI tool for the [CUE] configuration and validation language.
 * [Node.js] and the [Yarn] package manager (for static assets and some scripting).
 * [htmltest] for link checking.
@@ -135,11 +136,39 @@ This builds all the necessary [prereqs](#prerequisites) for the site and starts 
 
 When you make changes to the Markdown sources, Sass/CSS, or JavaScript, the site re-builds and Hugo automatically reloads the page that you're on. If you make changes to the [structured data](#structured-data) sources, however, you need to stop the server and run `make serve` again.
 
+### Run the site with Docker
+
+If you don't want to install Hugo, CUE, or Node.js locally, you can use Docker instead. You still need Rust and [vdev] on the host for one step.
+
+> **Note:** This Docker setup is experimental and not currently enforced by CI. It may break as dependencies or the build process evolve.
+
+**Step 1:** Generate VRL function docs (required once; only re-run when VRL function signatures change):
+
+```shell
+make generate-vrl-docs
+```
+
+This generates CUE files into `cue/reference/remap/functions/` from the Rust source. These files are gitignored and must exist before the site can build.
+
+**Step 2:** Build and start the site:
+
+```shell
+cd website
+docker compose build
+docker compose up
+```
+
+Navigate to http://localhost:1313. The site source is mounted as a volume so Hugo's live-reload works for Markdown, CSS, and JavaScript changes. If you modify [structured data](#structured-data) sources, restart the container.
+
 ### Add a new version of Vector
 
-1. Add the new version to the `versions` list in [`cue/reference/versions.cue`](./cue/reference/versions.cue). Make sure to preserve reverse ordering.
-1. Generate a new CUE file for the release by running `make release-prepare` in the root directory of the Vector repo. This generates a CUE file at `cue/releases/{VERSION}.cue`.
-1. Add a new Markdown file to [`content/en/releases`](./content/en/releases), where the filename is `{version}.md` (e.g. `0.12.0.md`) and the file has metadata that looks like this:
+This is automated by `cargo vdev release prepare` (see the
+[release issue templates](../.github/ISSUE_TEMPLATE)). The steps it performs, listed
+here for reference:
+
+1. Add the new version to the `versions` list in [`cue/reference/versions.cue`](./cue/reference/versions.cue), preserving reverse ordering.
+2. Generate a new CUE file at `cue/reference/releases/{VERSION}.cue`.
+3. Add a new Markdown file to [`content/en/releases`](./content/en/releases), where the filename is `{version}.md` (e.g. `0.12.0.md`) and the file has metadata that looks like this:
 
     ```markdown
     ---


### PR DESCRIPTION
## Summary

  Establish consistent AI / contributor documentation in this fork by vendoring the conventions from
  `vectordotdev/vector` and layering Observo-specific guidance on top — and add the supporting docs that those

  ### Commits

  **1. `cecce2c6` — add upstream `AGENTS.md`, refactor `CLAUDE.md` as Observo overlay**

  - Vendor upstream `AGENTS.md` verbatim (build/lint/test commands, `cargo vdev`, integration tests,
  PR/conventional-commit conventions).
  - Refactor `CLAUDE.md` to load `AGENTS.md` via `@AGENTS.md` and contain only Observo-specific deltas:
    - Architecture depth not in `AGENTS.md` (EventArray, Fanout, Transform variants, backpressure, concurrency model)
    - Private-submodule workflow, `FEATURES=observo` build awareness, Observo crate inventory
    - VRL fork pin, `CheckpointStore` exception, Observo CI overview
  - Includes a sync-from-upstream playbook so future refreshes of `AGENTS.md` are a single `git checkout`.

  **2. `ed13e132` — sync upstream docs referenced by `AGENTS.md`**

  - Add 4 docs that `AGENTS.md` links to but were missing in this fork: `CONTRIBUTING.md`, `STYLE.md`,
  `docs/RUST_STYLE.md`, `.github/PULL_REQUEST_TEMPLATE.md`.
  - Refresh 3 stale docs: `docs/DEVELOPING.md`, `docs/DOCUMENTING.md`, `website/README.md`.
  - These are upstream-authored docs with no Observo customizations, so refreshing is safe.

  ## Why

  - AI coding assistants (Claude Code, Copilot, Cursor) auto-discover `AGENTS.md` and `CLAUDE.md` and use them as the primary context for a repo. 
  - Splitting upstream-generic vs. fork-specific lets us re-pull upstream's `AGENTS.md` cheaply on each sync, without losing our Observo-specific notes.
  - The previously broken doc links in `AGENTS.md` (CONTRIBUTING.md, STYLE.md, etc.) now resolve.

  ## Test plan

  - [ ] CI passes (triggers `dataplane-build` via `.github/workflows/observo.test.yml`)
  - [ ] `AGENTS.md` cross-references resolve (CONTRIBUTING.md, STYLE.md, `docs/RUST_STYLE.md`,
  `.github/PULL_REQUEST_TEMPLATE.md` now exist)
  - [ ] Verify the `@AGENTS.md` include in `CLAUDE.md` is picked up by Claude Code on a fresh session
  - [ ] No application code (`src/`, `lib/`, `vdev/`) is touched — docs-only PR

  ## Notes for reviewers

  - This PR does **not** touch `.gitmodules` (local modification unrelated to this work).
  - Information leakage about the private submodule (`lib/observo/private/`) was audited and surgically scrubbed from `CLAUDE.md` — crate purposes are kept generic, the `links.sh` workflow is delegated to the private submodule's own tooling, and the `CheckpointStore` type signature is no longer spelled out.
  - Future syncs of `AGENTS.md` from upstream: see the "Syncing AGENTS.md from Upstream" section at the bottom of `CLAUDE.md`.