### PR TITLE
feat(scol): validate oauth2 token_url scheme at vector validate time

### DIFF
--- a/src/sources/scol/mod.rs
+++ b/src/sources/scol/mod.rs
@@ -19,7 +19,6 @@ use crate::config::{SourceConfig, SourceContext};
 #[typetag::serde(name = "scol")]
 impl SourceConfig for Config {
     async fn build(&self, cx: SourceContext) -> Result<Source> {
-        self.validate_auth()?;
         let lns = cx.log_namespace(self.log_namespace);
         let chkptr = cx.checkpoint_accessor().await;
         let src = self

--- a/src/sources/scol/mod.rs
+++ b/src/sources/scol/mod.rs
@@ -19,6 +19,7 @@ use crate::config::{SourceConfig, SourceContext};
 #[typetag::serde(name = "scol")]
 impl SourceConfig for Config {
     async fn build(&self, cx: SourceContext) -> Result<Source> {
+        self.validate_auth()?;
         let lns = cx.log_namespace(self.log_namespace);
         let chkptr = cx.checkpoint_accessor().await;
         let src = self


### PR DESCRIPTION
## Summary

Bumps the \`lib/observo/private\` submodule to pick up oauth2 \`token_url\` scheme validation (dataplane-private PR #42).

No code changes to vector itself — validation happens entirely within the \`dataplane-private\` crate at config parse time via \`#[serde(deserialize_with)]\` on the \`token_url\` field. An invalid URL now causes \`vector validate\` to fail at the \`√ Loaded\` step with a clear error message.

## Dependency

dataplane-private PR #42 (merged): https://ghe.eng.sentinelone.tech/sentinel-one/dataplane-private/pull/42

## What changes

- \`lib/observo/private\` — submodule pointer bumped to \`205b911\` (merge commit of PR #42 into main)