### PR TITLE
metrics added for vector reload being stuck

### DIFF
--- a/src/internal_events/process.rs
+++ b/src/internal_events/process.rs
@@ -1,8 +1,15 @@
-use metrics::counter;
+use metrics::{counter, gauge};
 use vector_lib::internal_event::InternalEvent;
 use vector_lib::internal_event::{error_stage, error_type};
 
 use crate::{built_info, config};
+
+fn unix_now() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64()
+}
 
 #[derive(Debug)]
 pub struct VectorStarted;
@@ -18,6 +25,18 @@ impl InternalEvent for VectorStarted {
             revision = built_info::VECTOR_BUILD_DESC.unwrap_or(""),
         );
         counter!("started_total").increment(1);
+        gauge!("valid_config").set(1.0);
+    }
+}
+
+#[derive(Debug)]
+pub struct VectorReloadStarted;
+
+impl InternalEvent for VectorReloadStarted {
+    fn emit(self) {
+        debug!(target: "vector", message = "Vector is reloading configuration.");
+        gauge!("reload_in_progress").set(1.0);
+        gauge!("last_reload_started_timestamp_seconds").set(unix_now());
     }
 }
 
@@ -34,6 +53,8 @@ impl InternalEvent for VectorReloaded<'_> {
             path = ?self.config_paths
         );
         counter!("reloaded_total").increment(1);
+        gauge!("valid_config").set(1.0);
+        gauge!("reload_in_progress").set(0.0);
     }
 }
 
@@ -82,6 +103,8 @@ impl InternalEvent for VectorReloadError {
             "stage" => error_stage::PROCESSING,
         )
         .increment(1);
+        gauge!("valid_config").set(0.0);
+        gauge!("reload_in_progress").set(0.0);
     }
 }
 
@@ -104,6 +127,7 @@ impl InternalEvent for VectorConfigLoadError {
             "stage" => error_stage::PROCESSING,
         )
         .increment(1);
+        gauge!("valid_config").set(0.0);
     }
 }
 

--- a/src/internal_events/process.rs
+++ b/src/internal_events/process.rs
@@ -4,13 +4,6 @@ use vector_lib::internal_event::{error_stage, error_type};
 
 use crate::{built_info, config};
 
-fn unix_now() -> f64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs_f64()
-}
-
 #[derive(Debug)]
 pub struct VectorStarted;
 
@@ -36,7 +29,7 @@ impl InternalEvent for VectorReloadStarted {
     fn emit(self) {
         debug!(target: "vector", message = "Vector is reloading configuration.");
         gauge!("reload_in_progress").set(1.0);
-        gauge!("last_reload_started_timestamp_seconds").set(unix_now());
+        gauge!("last_reload_started_timestamp_seconds").set(chrono::Utc::now().timestamp() as f64);
     }
 }
 

--- a/src/internal_events/process.rs
+++ b/src/internal_events/process.rs
@@ -18,7 +18,7 @@ impl InternalEvent for VectorStarted {
             revision = built_info::VECTOR_BUILD_DESC.unwrap_or(""),
         );
         counter!("started_total").increment(1);
-        gauge!("valid_config").set(1.0);
+        gauge!("config_load_succeeded").set(1.0);
     }
 }
 
@@ -46,7 +46,7 @@ impl InternalEvent for VectorReloaded<'_> {
             path = ?self.config_paths
         );
         counter!("reloaded_total").increment(1);
-        gauge!("valid_config").set(1.0);
+        gauge!("config_load_succeeded").set(1.0);
         gauge!("reload_in_progress").set(0.0);
     }
 }
@@ -96,7 +96,7 @@ impl InternalEvent for VectorReloadError {
             "stage" => error_stage::PROCESSING,
         )
         .increment(1);
-        gauge!("valid_config").set(0.0);
+        gauge!("config_load_succeeded").set(0.0);
         gauge!("reload_in_progress").set(0.0);
     }
 }
@@ -120,7 +120,7 @@ impl InternalEvent for VectorConfigLoadError {
             "stage" => error_stage::PROCESSING,
         )
         .increment(1);
-        gauge!("valid_config").set(0.0);
+        gauge!("config_load_succeeded").set(0.0);
     }
 }
 

--- a/src/internal_events/process.rs
+++ b/src/internal_events/process.rs
@@ -4,6 +4,10 @@ use vector_lib::internal_event::{error_stage, error_type};
 
 use crate::{built_info, config};
 
+const CONFIG_LOAD_SUCCEEDED: &str = "config_load_succeeded";
+const RELOAD_IN_PROGRESS: &str = "reload_in_progress";
+const LAST_RELOAD_STARTED_TIMESTAMP_SECONDS: &str = "last_reload_started_timestamp_seconds";
+
 #[derive(Debug)]
 pub struct VectorStarted;
 
@@ -18,7 +22,7 @@ impl InternalEvent for VectorStarted {
             revision = built_info::VECTOR_BUILD_DESC.unwrap_or(""),
         );
         counter!("started_total").increment(1);
-        gauge!("config_load_succeeded").set(1.0);
+        gauge!(CONFIG_LOAD_SUCCEEDED).set(1.0);
     }
 }
 
@@ -28,8 +32,8 @@ pub struct VectorReloadStarted;
 impl InternalEvent for VectorReloadStarted {
     fn emit(self) {
         debug!(target: "vector", message = "Vector is reloading configuration.");
-        gauge!("reload_in_progress").set(1.0);
-        gauge!("last_reload_started_timestamp_seconds").set(chrono::Utc::now().timestamp() as f64);
+        gauge!(RELOAD_IN_PROGRESS).set(1.0);
+        gauge!(LAST_RELOAD_STARTED_TIMESTAMP_SECONDS).set(chrono::Utc::now().timestamp() as f64);
     }
 }
 
@@ -46,8 +50,8 @@ impl InternalEvent for VectorReloaded<'_> {
             path = ?self.config_paths
         );
         counter!("reloaded_total").increment(1);
-        gauge!("config_load_succeeded").set(1.0);
-        gauge!("reload_in_progress").set(0.0);
+        gauge!(CONFIG_LOAD_SUCCEEDED).set(1.0);
+        gauge!(RELOAD_IN_PROGRESS).set(0.0);
     }
 }
 
@@ -96,8 +100,8 @@ impl InternalEvent for VectorReloadError {
             "stage" => error_stage::PROCESSING,
         )
         .increment(1);
-        gauge!("config_load_succeeded").set(0.0);
-        gauge!("reload_in_progress").set(0.0);
+        gauge!(CONFIG_LOAD_SUCCEEDED).set(0.0);
+        gauge!(RELOAD_IN_PROGRESS).set(0.0);
     }
 }
 
@@ -120,7 +124,7 @@ impl InternalEvent for VectorConfigLoadError {
             "stage" => error_stage::PROCESSING,
         )
         .increment(1);
-        gauge!("config_load_succeeded").set(0.0);
+        gauge!(CONFIG_LOAD_SUCCEEDED).set(0.0);
     }
 }
 

--- a/src/topology/controller.rs
+++ b/src/topology/controller.rs
@@ -7,7 +7,7 @@ use tokio::sync::{Mutex, MutexGuard};
 #[cfg(feature = "api")]
 use crate::api;
 use crate::extra_context::ExtraContext;
-use crate::internal_events::{VectorRecoveryError, VectorReloadError, VectorReloaded};
+use crate::internal_events::{VectorRecoveryError, VectorReloadError, VectorReloaded, VectorReloadStarted};
 
 use crate::{config, signal::ShutdownError, topology::RunningTopology};
 
@@ -60,6 +60,7 @@ pub enum ReloadOutcome {
 
 impl TopologyController {
     pub async fn reload(&mut self, mut new_config: config::Config) -> ReloadOutcome {
+        emit!(VectorReloadStarted);
         new_config
             .healthchecks
             .set_require_healthy(self.require_healthy);


### PR DESCRIPTION
## Summary

Adds three internal gauge metrics to detect when a Vector pod has not reloaded its configuration — either because the reload is stuck (deadlock scenario) or because it loaded an invalid config.

**Context:** In our multi-pod deployment, the config file is updated by a sidecar and Vector watches it for changes. We observed that some pods occasionally fail to complete a reload after a config change. Investigation traced this to a known upstream deadlock ([vectordotdev/vector#24125](https://github.com/vectordotdev/vector/issues/24125)): when a sink has queued undeliverable events at reload time, a `Pause` sent to the upstream fanout creates a circular dependency that prevents the reload from ever completing. These metrics make that condition alertable without requiring a fix to the reload logic itself.

### Changes

**`src/internal_events/process.rs`**
- Adds `VectorReloadStarted` internal event, emitted at the start of every reload attempt
- Adds three gauge metrics across the existing lifecycle events (`VectorStarted`, `VectorReloaded`, `VectorReloadError`, `VectorConfigLoadError`)

**`src/topology/controller.rs`**
- Emits `VectorReloadStarted` at the top of `TopologyController::reload()`

---

## Metrics Reference

All three metrics are exposed via the `internal_metrics` source and scraped as `vector_<name>` in Prometheus.

### `vector_config_load_succeeded` (gauge: 0 or 1)

Tracks whether the currently running configuration is valid.

| Value | Meaning |
|---|---|
| `1` | Pod started successfully or last reload succeeded |
| `0` | Last reload failed (bad topology or unparseable config file) |

Set to `1` on `VectorStarted` and `VectorReloaded`. Set to `0` on `VectorReloadError` and `VectorConfigLoadError`.

**Alert — pod is running a bad config:**
```promql
vector_config_load_succeeded == 0
```

---

### `vector_reload_in_progress` (gauge: 0 or 1)

Tracks whether a reload is currently in flight. Set to `1` when a reload begins and back to `0` when it completes (success or failure). If it stays at `1`, the reload is stuck.

| Value | Meaning |
|---|---|
| `1` | A reload was triggered and has not yet completed |
| `0` | No reload in progress |

**Alert — reload is stuck (tune threshold to exceed your normal healthy reload time):**
```promql
vector_reload_in_progress == 1
  and
(time() - vector_last_reload_started_timestamp_seconds) > 120
```

---

### `vector_last_reload_started_timestamp_seconds` (gauge: Unix timestamp)

Records the Unix timestamp (seconds) of the most recent reload attempt. Used alongside `vector_reload_in_progress` to compute how long a reload has been in progress.

**Alert — pods diverged (some reloaded, some did not):**
```promql
stddev by (job) (vector_last_reload_started_timestamp_seconds) > 60
```
This fires when pods within the same job have reload timestamps more than 60 seconds apart, indicating some pods received the config change signal and others did not.

---
