### PR TITLE
feat(OBE-9898): always require a token, read site_version from claim

### DIFF
--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -189,8 +189,8 @@ async fn healthcheck(
 
     // Build the request manually so we can attach the same authorization
     // header that `Service::call` attaches to `push_events`. Without this,
-    // a source configured with `require_token = true` would refuse this
-    // healthcheck even though the sink has valid credentials.
+    // a source that requires a token would refuse this healthcheck even
+    // though the sink has valid credentials.
     let mut request = tonic::Request::new(proto::HealthCheckRequest {});
     if let Some(auth) = service.auth() {
         let bearer = auth.bearer_token().map_err(|message| {

--- a/src/sources/util/jwt_auth.rs
+++ b/src/sources/util/jwt_auth.rs
@@ -33,6 +33,11 @@ pub(crate) const AUTH_FIELD_NAME_TAG: &str = "auth_field_name";
 /// Metric tag key for the auth field value.
 pub(crate) const AUTH_FIELD_VALUE_TAG: &str = "auth_field_value";
 
+/// JWT claim carrying the site's version at token-issue time (stamped by the
+/// manager's auth-service — OBE-9896). Read for telemetry / per-version policy;
+/// absent for older sites whose tokens predate the claim.
+const SITE_VERSION_CLAIM: &str = "site_version";
+
 /// Errors returned by [`Auth::authenticate`] (request-level).
 #[derive(Debug, PartialEq)]
 pub enum AuthError {
@@ -881,23 +886,6 @@ pub struct AuthConfig {
     /// filtered out. When absent, no per-event filtering is applied.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub value_path: Option<AuthValuePath>,
-
-    /// When `true`, requests without an `authorization` header are rejected
-    /// with `Unauthenticated`. Defaults to `true` (secure by default).
-    ///
-    /// Set to `false` to opt into the legacy fallback that accepts requests
-    /// without a token (useful during a staged migration where older agents
-    /// haven't been updated yet).
-    ///
-    /// Applies to both `push_events` and `health_check` RPCs so a sink with
-    /// auth misconfigured fails its healthcheck rather than silently
-    /// bypassing token validation.
-    #[serde(default = "default_require_token")]
-    pub require_token: bool,
-}
-
-fn default_require_token() -> bool {
-    true
 }
 
 /// Replace serde's flattened-enum error with an actionable message naming the
@@ -972,7 +960,6 @@ impl AuthConfig {
             jwks_validations,
             membership_claim,
             value_path,
-            require_token: self.require_token,
         })))
     }
 }
@@ -1003,7 +990,6 @@ struct Inner {
     jwks_validations: HashMap<Algorithm, Validation>,
     membership_claim: Option<MembershipClaim>,
     value_path: Option<CompiledValuePath>,
-    require_token: bool,
 }
 
 /// Per-request auth context returned by a successful [`Auth::authenticate`] call.
@@ -1146,25 +1132,21 @@ impl Auth {
     ///
     /// # Returns
     ///
-    /// * `Ok(None)` — `authorization` was absent and `require_token` is `false`; request is
-    ///   accepted without per-event filtering (legacy / migration mode).
     /// * `Ok(Some(ctx))` — token is valid. Use [`AuthContext::is_authorized`] for per-event
     ///   membership checks against the extracted allowed-values list.
-    /// * `Err(AuthError::InvalidToken)` — `authorization` was absent but required, the token
-    ///   is malformed/expired/bad-signature, wrong issuer/audience, unsupported algorithm,
-    ///   or the membership claim is missing.
+    /// * `Err(AuthError::InvalidToken)` — `authorization` was absent (a token is always
+    ///   required), or the token is malformed/expired/bad-signature, wrong issuer/audience,
+    ///   unsupported algorithm, or the membership claim is missing.
     pub async fn authenticate(
         &self,
         authorization: Option<&str>,
     ) -> Result<Option<AuthContext>, AuthError> {
         let Some(auth_value) = authorization else {
-            if self.0.require_token {
-                return Err(AuthError::InvalidToken(
-                    "authorization header is required",
-                ));
-            }
-            debug!(message = "No authorization header; allowing request.");
-            return Ok(None);
+            // A token is always required (OBE-9898 removed the legacy
+            // `require_token = false` bypass).
+            return Err(AuthError::InvalidToken(
+                "authorization header is required",
+            ));
         };
 
         let token = strip_bearer_prefix(auth_value)
@@ -1219,6 +1201,15 @@ impl Auth {
             }
         };
 
+        // Surface the site's version (the manager stamps `site_version` as a JWT
+        // claim — OBE-9896) for telemetry / future per-version policy. Absent for
+        // older sites whose tokens predate the claim.
+        if let Some(site_version) =
+            token_data.claims.get(SITE_VERSION_CLAIM).and_then(Value::as_str)
+        {
+            debug!(message = "Authenticated site push.", %site_version);
+        }
+
         let allowed_values = inner.membership_claim
             .as_ref()
             .map(|c| c.extract(&token_data.claims))
@@ -1272,8 +1263,8 @@ mod tests {
     };
 
     // Construct a baseline `AuthConfig` from the given authority, using the
-    // permissive defaults the tests below want (no issuer/audience/value_path,
-    // `require_token = false`). Individual tests override fields as needed.
+    // permissive defaults the tests below want (no issuer/audience/value_path).
+    // Individual tests override fields as needed.
     fn cfg_with(authority: Authority) -> AuthConfig {
         AuthConfig {
             authority,
@@ -1282,7 +1273,6 @@ mod tests {
             membership_claim: Some(MembershipClaimConfig::Identity("site_ids".to_string())),
             value_path: None,
             algorithms: None,
-            require_token: false,
         }
     }
 
@@ -1397,15 +1387,6 @@ mod tests {
     // parse time. See `authority_with_multiple_variants_in_toml_fails`.
 
     // ── Auth::authenticate ───────────────────────────────────────────────────
-
-    #[tokio::test]
-    async fn no_auth_header_allows_legacy_client_when_require_token_false() {
-        // The shared `build_auth` helper now matches production default
-        // (require_token = true), so explicitly opt out to test legacy mode.
-        let auth = build_auth_with_require_token(false).await;
-        let result = auth.authenticate(None).await;
-        assert!(matches!(result, Ok(None)));
-    }
 
     #[tokio::test]
     async fn valid_token_returns_allowed_values() {
@@ -1659,37 +1640,25 @@ mod tests {
         assert!(auth.authenticate(Some(&bearer(&token))).await.is_ok());
     }
 
-    // ── require_token enforcement ────────────────────────────────────────────
-
-    async fn build_auth_with_require_token(require: bool) -> Auth {
-        let mut cfg = cfg_with(inline_public_key());
-        cfg.require_token = require;
-        cfg.build().await.unwrap()
-    }
+    // ── token requirement (a token is always required) ───────────────────────
 
     #[tokio::test]
-    async fn require_token_false_allows_missing_authorization() {
-        let auth = build_auth_with_require_token(false).await;
-        assert!(matches!(auth.authenticate(None).await, Ok(None)));
-    }
-
-    #[tokio::test]
-    async fn require_token_true_rejects_missing_authorization() {
-        let auth = build_auth_with_require_token(true).await;
+    async fn missing_authorization_is_rejected() {
+        let auth = build_auth(None, None).await;
         let result = auth.authenticate(None).await;
         assert!(matches!(result, Err(AuthError::InvalidToken(_))));
     }
 
     #[tokio::test]
-    async fn require_token_true_accepts_valid_token() {
-        let auth = build_auth_with_require_token(true).await;
+    async fn valid_token_is_accepted() {
+        let auth = build_auth(None, None).await;
         let token = make_token(HashMap::new());
         assert!(auth.authenticate(Some(&bearer(&token))).await.is_ok());
     }
 
     #[tokio::test]
-    async fn require_token_true_still_rejects_invalid_token() {
-        let auth = build_auth_with_require_token(true).await;
+    async fn invalid_token_is_rejected() {
+        let auth = build_auth(None, None).await;
         let result = auth.authenticate(Some("Bearer not.a.jwt")).await;
         assert!(matches!(result, Err(AuthError::InvalidToken(_))));
     }
@@ -1729,7 +1698,6 @@ mod tests {
     async fn build_no_membership_auth() -> Auth {
         let mut cfg = cfg_with(inline_public_key());
         cfg.membership_claim = None;
-        cfg.require_token = true;
         cfg.build().await.unwrap()
     }
 
@@ -2085,7 +2053,6 @@ pub_key.type   = "inline"
 pub_key.value  = "pem"
 membership_claim  = "tenants"
 issuer            = "https://issuer.example.com/"
-require_token     = false
 "#;
         let cfg: AuthConfig = toml::from_str(toml).unwrap();
         assert!(matches!(
@@ -2094,7 +2061,6 @@ require_token     = false
         ));
         assert_eq!(cfg.membership_claim, Some(MembershipClaimConfig::Identity("tenants".to_string())));
         assert_eq!(cfg.issuer.as_deref(), Some("https://issuer.example.com/"));
-        assert!(!cfg.require_token);
     }
 
     // ── MembershipClaimConfig serde ──────────────────────────────────────────
@@ -2386,7 +2352,6 @@ pub_key.value = "pem"
             membership_claim: Some(MembershipClaimConfig::Identity("site_ids".to_string())),
             value_path: None,
             algorithms: None,
-            require_token: false,
         }
     }
 

--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -114,8 +114,8 @@ impl AuthBatchStats {
 impl Service {
     /// Run request-level JWT validation against an inbound gRPC request.
     ///
-    /// Shared between `push_events` and `health_check` so both RPCs honor the
-    /// same `require_token` enforcement and reject the same set of bad tokens.
+    /// Shared between `push_events` and `health_check` so both RPCs require a
+    /// valid token and reject the same set of bad tokens.
     async fn validate_auth_header<T>(
         &self,
         request: &Request<T>,
@@ -255,7 +255,7 @@ impl proto::Service for Service {
         request: Request<proto::HealthCheckRequest>,
     ) -> Result<Response<proto::HealthCheckResponse>, Status> {
         // Apply the same JWT validation as push_events — same auth posture,
-        // including `require_token` enforcement when configured.
+        // so a misconfigured/unauthenticated sink fails its healthcheck.
         self.validate_auth_header(&request).await?;
 
         let message = proto::HealthCheckResponse {
@@ -974,24 +974,6 @@ value = "{token}""#
         }
 
         #[tokio::test]
-        async fn legacy_sink_without_auth_is_accepted() {
-            // Source has auth configured with require_token=false (legacy mode);
-            // sink sends no token → request allowed through.
-            let source_auth = format!(
-                r#"[auth]
-pub_key.type  = "inline"
-pub_key.value = "{}"
-membership_claim = "site_ids"
-require_token    = false"#,
-                TEST_PUBLIC_KEY.replace('\n', "\\n")
-            );
-            assert_eq!(
-                run_auth_pair(&source_auth, "").await,
-                BatchStatus::Delivered
-            );
-        }
-
-        #[tokio::test]
         async fn invalid_token_is_rejected() {
             let source_auth = format!(
                 r#"[auth]
@@ -1044,27 +1026,7 @@ value = "{token}""#
             );
         }
 
-        #[tokio::test]
-        async fn legacy_sink_with_value_path_configured_is_accepted() {
-            // Source has value_path with require_token=false (legacy mode); sink sends
-            // no token → per-event filtering is skipped entirely, all events pass through.
-            let source_auth = format!(
-                r#"[auth]
-pub_key.type  = "inline"
-pub_key.value = "{}"
-membership_claim = "site_ids"
-require_token    = false
-[auth.value_path]
-default = "tenant_id""#,
-                TEST_PUBLIC_KEY.replace('\n', "\\n")
-            );
-            assert_eq!(
-                run_auth_pair(&source_auth, "").await,
-                BatchStatus::Delivered
-            );
-        }
-
-        // ── require_token + healthcheck integration ──────────────────────────
+        // ── healthcheck integration ──────────────────────────────────────────
 
         /// Build a source+sink pair and return the result of the sink's healthcheck.
         async fn run_healthcheck_pair(
@@ -1093,50 +1055,9 @@ default = "tenant_id""#,
         }
 
         #[tokio::test]
-        async fn require_token_source_rejects_unauthenticated_push() {
-            // Source: require_token = true (explicit); sink: no auth → rejected.
-            let source_auth = format!(
-                r#"[auth]
-pub_key.type  = "inline"
-pub_key.value = "{}"
-membership_claim = "site_ids"
-require_token    = true"#,
-                TEST_PUBLIC_KEY.replace('\n', "\\n")
-            );
-            assert_eq!(
-                run_auth_pair(&source_auth, "").await,
-                BatchStatus::Rejected
-            );
-        }
-
-        #[tokio::test]
-        async fn require_token_source_accepts_authenticated_push() {
-            // Source: require_token = true (explicit); sink: valid token → delivered.
-            let token = make_token(HashMap::new());
-            let source_auth = format!(
-                r#"[auth]
-pub_key.type  = "inline"
-pub_key.value = "{}"
-membership_claim = "site_ids"
-require_token    = true"#,
-                TEST_PUBLIC_KEY.replace('\n', "\\n")
-            );
-            let sink_auth = format!(
-                r#"[auth]
-[auth.token]
-type  = "inline"
-value = "{token}""#
-            );
-            assert_eq!(
-                run_auth_pair(&source_auth, &sink_auth).await,
-                BatchStatus::Delivered
-            );
-        }
-
-        #[tokio::test]
-        async fn default_require_token_rejects_request_without_token() {
-            // Source TOML omits `require_token` — the default is `true`,
-            // so a sink with no token must be rejected.
+        async fn source_rejects_request_without_token() {
+            // Auth is configured; a token is always required, so a sink with no
+            // token is rejected.
             let source_auth = format!(
                 r#"[auth]
 pub_key.type  = "inline"
@@ -1151,9 +1072,9 @@ membership_claim = "site_ids""#,
         }
 
         #[tokio::test]
-        async fn default_require_token_accepts_request_with_token() {
-            // Source TOML omits `require_token` — default `true`. Sink sends
-            // a valid token; request flows through.
+        async fn source_accepts_request_with_token() {
+            // Auth is configured; the sink sends a valid token, so the request
+            // flows through.
             let token = make_token(HashMap::new());
             let source_auth = format!(
                 r#"[auth]
@@ -1175,14 +1096,13 @@ value = "{token}""#
         }
 
         #[tokio::test]
-        async fn healthcheck_succeeds_when_sink_sends_token_to_require_token_source() {
+        async fn healthcheck_succeeds_when_sink_sends_token() {
             let token = make_token(HashMap::new());
             let source_auth = format!(
                 r#"[auth]
 pub_key.type  = "inline"
 pub_key.value = "{}"
-membership_claim = "site_ids"
-require_token    = true"#,
+membership_claim = "site_ids""#,
                 TEST_PUBLIC_KEY.replace('\n', "\\n")
             );
             let sink_auth = format!(
@@ -1195,13 +1115,12 @@ value = "{token}""#
         }
 
         #[tokio::test]
-        async fn healthcheck_fails_when_sink_omits_token_to_require_token_source() {
+        async fn healthcheck_fails_when_sink_omits_token() {
             let source_auth = format!(
                 r#"[auth]
 pub_key.type  = "inline"
 pub_key.value = "{}"
-membership_claim = "site_ids"
-require_token    = true"#,
+membership_claim = "site_ids""#,
                 TEST_PUBLIC_KEY.replace('\n', "\\n")
             );
             assert!(run_healthcheck_pair(&source_auth, "").await.is_err());

--- a/src/test_util/jwt_auth.rs
+++ b/src/test_util/jwt_auth.rs
@@ -112,7 +112,6 @@ pub async fn build_auth(issuer: Option<&str>, audience: Option<Vec<&str>>) -> Au
         membership_claim: Some(MembershipClaimConfig::Identity("site_ids".to_string())),
         value_path: None,
         algorithms: None,
-        require_token: true,
     }
     .build()
     .await


### PR DESCRIPTION
The vector source's auth drops the require_token config knob: a valid bearer token is now always required, removing the legacy require_token=false bypass that accepted unauthenticated pushes. The site's version is read from the validated JWT's site_version claim (stamped by the manager auth-service, OBE-9896) and logged for telemetry / future per-version policy.

- jwt_auth.rs: remove AuthConfig.require_token, default_require_token, Inner.require_token; authenticate() rejects a missing authorization header unconditionally; read SITE_VERSION_CLAIM from the decoded claims.
- sources/vector/mod.rs: delete the legacy and now-redundant require_token tests, rename the kept ones to the unconditional behavior.
- test_util/jwt_auth.rs: drop require_token from the shared build_auth helper.

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [ ] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
