### PR TITLE
feat(new source): add Windows Event Log source (cherry-pick #24305 + fork fixes)

### DIFF
--- a/.github/workflows/integration_windows.yml
+++ b/.github/workflows/integration_windows.yml
@@ -1,0 +1,56 @@
+name: Integration - Windows
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      windows: ${{ steps.filter.outputs.windows }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            windows:
+              - "src/sources/windows_event_log/**"
+              - "src/internal_events/windows_event_log.rs"
+              - "tests/integration/windows-event-log/**"
+              - ".github/workflows/integration_windows.yml"
+
+  run-test-integration-windows:
+    needs: changes
+    if: needs.changes.outputs.windows == 'true'
+    runs-on: windows-2025-8core
+    timeout-minutes: 60
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.10"
+
+      - run: .\scripts\environment\bootstrap-windows-2025.ps1
+
+      - name: Run Windows Event Log integration tests
+        run: make test-integration-windows-event-log
+
+  test-integration-windows:
+    if: always()
+    runs-on: ubuntu-latest
+    needs: run-test-integration-windows
+    steps:
+      - run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more jobs failed or were cancelled"
+            exit 1
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12425,6 +12425,7 @@ dependencies = [
  "bstr 1.11.0",
  "bytes 1.9.0",
  "bytesize",
+ "cfg-if",
  "chkpts",
  "chrono",
  "chrono-tz",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12515,6 +12515,7 @@ dependencies = [
  "prost-reflect",
  "prost-types 0.12.6",
  "pulsar",
+ "quick-xml 0.31.0",
  "quickcheck",
  "rand 0.8.6",
  "rand_distr",
@@ -12587,6 +12588,7 @@ dependencies = [
  "warp",
  "wasserglas",
  "wef",
+ "windows 0.58.0",
  "windows-service",
  "wiremock",
  "xxhash-rust",
@@ -13485,6 +13487,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13499,9 +13511,22 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings",
  "windows-targets 0.52.6",
 ]
 
@@ -13517,10 +13542,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2 1.0.92",
+ "quote 1.0.37",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2 1.0.92",
+ "quote 1.0.37",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.37",
@@ -13543,6 +13590,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-service"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13551,6 +13607,16 @@ dependencies = [
  "bitflags 2.11.1",
  "widestring 1.0.2",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -453,6 +453,8 @@ reqwest = { version = "0.11", features = ["json"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.7.0"
+windows = { version = "0.58", features = ["Win32_System_EventLog", "Win32_Foundation", "Win32_System_Com", "Win32_Security", "Win32_Security_Authorization", "Win32_System_Threading", "Win32_Storage_FileSystem"], optional = true }
+quick-xml = { version = "0.31", default-features = false, features = ["serialize"], optional = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.26.2", default-features = false, features = ["socket", "signal"] }
@@ -630,6 +632,7 @@ sources-logs = [
   "sources-syslog",
   "sources-vector",
   "sources-websocket",
+  "sources-windows_event_log",
 ]
 sources-metrics = [
   "dep:prost",
@@ -708,6 +711,8 @@ sources-utils-net-udp = ["listenfd", "vector-lib/sources-utils-net-udp"]
 sources-utils-net-unix = []
 sources-websocket = ["dep:tokio-tungstenite"]
 sources-wef = ["dep:wef"]
+sources-windows_event_log = ["dep:windows", "dep:quick-xml", "dep:governor"]
+sources-windows_event_log-integration-tests = ["sources-windows_event_log"]
 
 sources-vector = ["dep:prost", "dep:tonic", "dep:jsonwebtoken", "dep:arc-swap", "protobuf-build"]
 
@@ -924,6 +929,7 @@ all-integration-tests = [
   "splunk-integration-tests",
   "webhdfs-integration-tests",
   "websocket-integration-tests",
+  "windows-event-log-integration-tests",
 ]
 
 amqp-integration-tests = ["sources-amqp", "sinks-amqp"]
@@ -988,6 +994,7 @@ splunk-integration-tests = ["sinks-splunk_hec"]
 dnstap-integration-tests = ["sources-dnstap", "dep:bollard"]
 webhdfs-integration-tests = ["sinks-webhdfs"]
 websocket-integration-tests = ["sources-websocket", "dep:tokio-tungstenite"]
+windows-event-log-integration-tests = ["sources-windows_event_log-integration-tests"]
 disable-resolv-conf = []
 shutdown-tests = ["api", "sinks-blackhole", "sinks-console", "sinks-prometheus", "sources", "transforms-lua", "transforms-remap", "unix"]
 cli-tests = ["sinks-blackhole", "sinks-socket", "sources-demo_logs", "sources-file"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -712,7 +712,7 @@ sources-utils-net-udp = ["listenfd", "vector-lib/sources-utils-net-udp"]
 sources-utils-net-unix = []
 sources-websocket = ["dep:tokio-tungstenite"]
 sources-wef = ["dep:wef"]
-sources-windows_event_log = ["dep:windows", "dep:quick-xml", "dep:governor"]
+sources-windows_event_log = ["dep:windows", "dep:quick-xml", "dep:governor", "dep:lru"]
 sources-windows_event_log-integration-tests = ["sources-windows_event_log"]
 
 sources-vector = ["dep:prost", "dep:tonic", "dep:jsonwebtoken", "dep:arc-swap", "protobuf-build"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -360,6 +360,7 @@ bytes.workspace = true
 bytesize.workspace = true
 chrono.workspace = true
 chrono-tz.workspace = true
+cfg-if.workspace = true
 colored = { version = "3.0.0", default-features = false }
 csv = { version = "1.3", default-features = false }
 databend-client = { version = "0.22.2", default-features = false, features = ["rustls"], optional = true }

--- a/Makefile
+++ b/Makefile
@@ -384,6 +384,14 @@ test-integration: test-integration-nginx test-integration-opentelemetry test-int
 test-integration: test-integration-redis test-integration-splunk test-integration-dnstap test-integration-datadog-agent test-integration-datadog-logs test-integration-e2e-datadog-logs
 test-integration: test-integration-datadog-traces test-integration-shutdown
 
+.PHONY: test-integration-windows-event-log
+test-integration-windows-event-log: ## Runs Windows Event Log integration tests (Windows only)
+ifeq ($(OS),Windows_NT)
+	${MAYBE_ENVIRONMENT_EXEC} cargo test -p vector --no-default-features --features sources-windows_event_log-integration-tests windows_event_log::integration_tests
+else
+	@echo "Skipping windows-event-log integration tests (Windows only)"
+endif
+
 test-integration-%-cleanup:
 	cargo vdev --verbose integration stop $*
 

--- a/changelog.d/25194_windows_event_log_lost_wakeup.fix.md
+++ b/changelog.d/25194_windows_event_log_lost_wakeup.fix.md
@@ -1,0 +1,3 @@
+The `windows_event_log` source no longer freezes after periods of inactivity.
+
+authors: tot19

--- a/changelog.d/25332_windows_event_log_source_metadata.fix.md
+++ b/changelog.d/25332_windows_event_log_source_metadata.fix.md
@@ -1,0 +1,3 @@
+The `windows_event_log` source now adds standard source metadata, including `source_type`, to emitted log events.
+
+authors: tot19

--- a/changelog.d/25521_windows_event_log_span_propagation.fix.md
+++ b/changelog.d/25521_windows_event_log_span_propagation.fix.md
@@ -1,0 +1,3 @@
+The `windows_event_log` source now propagates the component tracing span into its spawned background tasks, so their internal logs and metrics are correctly tagged with the component.
+
+authors: tot19

--- a/changelog.d/windows_event_log_source.feature.md
+++ b/changelog.d/windows_event_log_source.feature.md
@@ -1,0 +1,3 @@
+Added a new `windows_event_log` source that collects logs from Windows Event Log channels using the native Windows Event Log API with pull-mode subscriptions, bookmark-based checkpointing, and configurable field filtering.
+
+authors: tot19

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -49,6 +49,12 @@ mod encoding_transcode;
 mod eventstoredb_metrics;
 #[cfg(feature = "sources-exec")]
 mod exec;
+#[cfg(any(
+    feature = "sources-file",
+    feature = "sources-kubernetes_logs",
+    feature = "sinks-file",
+))]
+mod file;
 #[cfg(any(feature = "sources-file_descriptor", feature = "sources-stdin"))]
 mod file_descriptor;
 #[cfg(feature = "transforms-filter")]
@@ -136,6 +142,8 @@ mod websocket;
     feature = "sinks-file",
 ))]
 mod file;
+#[cfg(all(windows, feature = "sources-windows_event_log"))]
+mod windows_event_log;
 mod windows;
 mod hash_replace;
 
@@ -271,6 +279,8 @@ pub(crate) use self::unix::*;
 pub(crate) use self::websocket::*;
 #[cfg(windows)]
 pub(crate) use self::windows::*;
+#[cfg(all(windows, feature = "sources-windows_event_log"))]
+pub(crate) use self::windows_event_log::*;
 pub use self::{
     adaptive_concurrency::*, batch::*, common::*, conditions::*, encoding_transcode::*,
     heartbeat::*, http::*, open::*, process::*, socket::*, tcp::*, template::*, udp::*,

--- a/src/internal_events/windows_event_log.rs
+++ b/src/internal_events/windows_event_log.rs
@@ -1,0 +1,125 @@
+use metrics::counter;
+use tracing::error;
+use vector_lib::{
+    NamedInternalEvent,
+    internal_event::{InternalEvent, error_stage, error_type},
+};
+
+#[derive(Debug, NamedInternalEvent)]
+pub struct WindowsEventLogParseError {
+    pub error: String,
+    pub channel: String,
+    pub event_id: Option<u32>,
+}
+
+impl InternalEvent for WindowsEventLogParseError {
+    fn emit(self) {
+        error!(
+            message = "Failed to parse Windows Event Log event.",
+            error = %self.error,
+            channel = %self.channel,
+            event_id = ?self.event_id,
+            error_code = "parse_failed",
+            error_type = error_type::PARSER_FAILED,
+            stage = error_stage::PROCESSING,
+            internal_log_rate_limit = true,
+        );
+        counter!(
+            "component_errors_total",
+            "error_code" => "parse_failed",
+            "error_type" => error_type::PARSER_FAILED,
+            "stage" => error_stage::PROCESSING,
+        )
+        .increment(1);
+    }
+}
+
+#[derive(Debug, NamedInternalEvent)]
+pub struct WindowsEventLogQueryError {
+    pub channel: String,
+    pub query: Option<String>,
+    pub error: String,
+}
+
+impl InternalEvent for WindowsEventLogQueryError {
+    fn emit(self) {
+        error!(
+            message = "Failed to query Windows Event Log.",
+            channel = %self.channel,
+            query = ?self.query,
+            error = %self.error,
+            error_code = "query_failed",
+            error_type = error_type::REQUEST_FAILED,
+            stage = error_stage::RECEIVING,
+            internal_log_rate_limit = true,
+        );
+        counter!(
+            "component_errors_total",
+            "error_code" => "query_failed",
+            "error_type" => error_type::REQUEST_FAILED,
+            "stage" => error_stage::RECEIVING,
+        )
+        .increment(1);
+    }
+}
+
+#[derive(Debug, NamedInternalEvent)]
+pub struct WindowsEventLogBookmarkError {
+    pub channel: String,
+    pub error: String,
+}
+
+impl InternalEvent for WindowsEventLogBookmarkError {
+    fn emit(self) {
+        error!(
+            message = "Failed to save bookmark for Windows Event Log channel.",
+            channel = %self.channel,
+            error = %self.error,
+            error_code = "bookmark_failed",
+            error_type = error_type::REQUEST_FAILED,
+            stage = error_stage::PROCESSING,
+            internal_log_rate_limit = true,
+        );
+        counter!(
+            "component_errors_total",
+            "error_code" => "bookmark_failed",
+            "error_type" => error_type::REQUEST_FAILED,
+            "stage" => error_stage::PROCESSING,
+        )
+        .increment(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_error() {
+        let event = WindowsEventLogParseError {
+            error: "Test error".to_string(),
+            channel: "System".to_string(),
+            event_id: Some(1000),
+        };
+        event.emit();
+    }
+
+    #[test]
+    fn test_query_error() {
+        let event = WindowsEventLogQueryError {
+            channel: "System".to_string(),
+            query: Some("*[System]".to_string()),
+            error: "Operation timed out".to_string(),
+        };
+        event.emit();
+    }
+
+    #[test]
+    fn test_bookmark_error() {
+        let event = WindowsEventLogBookmarkError {
+            channel: "System".to_string(),
+            error: "Failed to save bookmark".to_string(),
+        };
+        event.emit();
+    }
+}

--- a/src/internal_events/windows_event_log.rs
+++ b/src/internal_events/windows_event_log.rs
@@ -1,11 +1,8 @@
 use metrics::counter;
 use tracing::error;
-use vector_lib::{
-    NamedInternalEvent,
-    internal_event::{InternalEvent, error_stage, error_type},
-};
+use vector_lib::internal_event::{InternalEvent, error_stage, error_type};
 
-#[derive(Debug, NamedInternalEvent)]
+#[derive(Debug)]
 pub struct WindowsEventLogParseError {
     pub error: String,
     pub channel: String,
@@ -13,6 +10,10 @@ pub struct WindowsEventLogParseError {
 }
 
 impl InternalEvent for WindowsEventLogParseError {
+    fn name(&self) -> Option<&'static str> {
+        Some("WindowsEventLogParseError")
+    }
+
     fn emit(self) {
         error!(
             message = "Failed to parse Windows Event Log event.",
@@ -34,7 +35,7 @@ impl InternalEvent for WindowsEventLogParseError {
     }
 }
 
-#[derive(Debug, NamedInternalEvent)]
+#[derive(Debug)]
 pub struct WindowsEventLogQueryError {
     pub channel: String,
     pub query: Option<String>,
@@ -42,6 +43,10 @@ pub struct WindowsEventLogQueryError {
 }
 
 impl InternalEvent for WindowsEventLogQueryError {
+    fn name(&self) -> Option<&'static str> {
+        Some("WindowsEventLogQueryError")
+    }
+
     fn emit(self) {
         error!(
             message = "Failed to query Windows Event Log.",
@@ -63,13 +68,17 @@ impl InternalEvent for WindowsEventLogQueryError {
     }
 }
 
-#[derive(Debug, NamedInternalEvent)]
+#[derive(Debug)]
 pub struct WindowsEventLogBookmarkError {
     pub channel: String,
     pub error: String,
 }
 
 impl InternalEvent for WindowsEventLogBookmarkError {
+    fn name(&self) -> Option<&'static str> {
+        Some("WindowsEventLogBookmarkError")
+    }
+
     fn emit(self) {
         error!(
             message = "Failed to save bookmark for Windows Event Log channel.",

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -98,6 +98,8 @@ pub mod vector;
 pub mod wef;
 #[cfg(feature = "sources-websocket")]
 pub mod websocket;
+#[cfg(feature = "sources-windows_event_log")]
+pub mod windows_event_log;
 
 pub mod util;
 

--- a/src/sources/windows_event_log/bookmark.rs
+++ b/src/sources/windows_event_log/bookmark.rs
@@ -1,0 +1,297 @@
+//! Windows Event Log Bookmark Management
+//!
+//! Provides bookmark-based checkpointing for Windows Event Log subscriptions.
+//! Bookmarks survive channel clears and log rotations, and provide O(1) seeking.
+
+use tracing::{debug, error};
+use windows::{
+    Win32::System::EventLog::{
+        EVT_HANDLE, EvtClose, EvtCreateBookmark, EvtRender, EvtRenderBookmark, EvtUpdateBookmark,
+    },
+    core::HSTRING,
+};
+
+use super::error::WindowsEventLogError;
+
+/// Maximum size for rendered bookmark XML (1 MB should be more than enough)
+const MAX_BOOKMARK_XML_SIZE: usize = 1024 * 1024;
+
+/// Manages a Windows Event Log bookmark for checkpoint tracking
+///
+/// Bookmarks provide robust, Windows-managed position tracking in event logs.
+/// They are opaque handles that can be serialized to XML for persistence.
+#[derive(Debug)]
+pub struct BookmarkManager {
+    handle: EVT_HANDLE,
+}
+
+impl BookmarkManager {
+    /// Creates a new bookmark (not associated with any event yet)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the Windows API fails to create the bookmark.
+    pub fn new() -> Result<Self, WindowsEventLogError> {
+        unsafe {
+            let handle = EvtCreateBookmark(None).map_err(|e| {
+                error!(message = "Failed to create bookmark.", error = %e);
+                WindowsEventLogError::CreateSubscriptionError { source: e }
+            })?;
+
+            debug!(message = "Created new bookmark.", handle = ?handle);
+
+            Ok(Self { handle })
+        }
+    }
+
+    /// Creates a bookmark from serialized XML
+    ///
+    /// This is used when resuming from a checkpoint.
+    ///
+    /// # Arguments
+    ///
+    /// * `xml` - The XML string representation of a bookmark
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the XML is invalid or the Windows API fails.
+    pub fn from_xml(xml: &str) -> Result<Self, WindowsEventLogError> {
+        if xml.is_empty() {
+            return Self::new(); // Empty XML = fresh bookmark
+        }
+
+        unsafe {
+            let xml_hstring = HSTRING::from(xml);
+            match EvtCreateBookmark(&xml_hstring) {
+                Ok(handle) => {
+                    debug!(message = "Created bookmark from XML.", handle = ?handle);
+                    Ok(Self { handle })
+                }
+                Err(e) => {
+                    // Propagate the error so the caller can decide how to handle it
+                    // (e.g., fall back to a fresh bookmark with has_valid_checkpoint = false)
+                    Err(WindowsEventLogError::CreateSubscriptionError { source: e })
+                }
+            }
+        }
+    }
+
+    /// Updates the bookmark to point to the given event
+    ///
+    /// Call this after successfully processing an event to update the checkpoint position.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_handle` - Handle to the event to bookmark
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the Windows API fails to update the bookmark.
+    pub fn update(&mut self, event_handle: EVT_HANDLE) -> Result<(), WindowsEventLogError> {
+        unsafe {
+            EvtUpdateBookmark(self.handle, event_handle).map_err(|e| {
+                error!(message = "Failed to update bookmark.", error = %e);
+                WindowsEventLogError::SubscriptionError { source: e }
+            })?;
+
+            debug!(message = "Updated bookmark.", event_handle = ?event_handle);
+            Ok(())
+        }
+    }
+
+    /// Serializes the bookmark to XML for persistence
+    ///
+    /// The returned XML string can be saved to a checkpoint file and later
+    /// restored using `from_xml()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the Windows API fails to render the bookmark.
+    ///
+    /// Note: For lock-free serialization, prefer `serialize_handle()` which
+    /// allows copying the handle out of a lock before serializing.
+    #[cfg(test)]
+    pub fn to_xml(&self) -> Result<String, WindowsEventLogError> {
+        unsafe {
+            // EvtRender params: Context, Fragment, Flags, BufferSize, Buffer, BufferUsed, PropertyCount
+            // BufferUsed (6th param) receives the required size in bytes
+            // PropertyCount (7th param) receives the number of properties
+            let mut required_size: u32 = 0;
+            let mut property_count: u32 = 0;
+
+            // First call with null buffer to get required size
+            // ERROR_INSUFFICIENT_BUFFER (122 / 0x7A) is expected
+            let _ = EvtRender(
+                None,
+                self.handle,
+                EvtRenderBookmark.0,
+                0,
+                None,
+                &mut required_size,
+                &mut property_count,
+            );
+
+            if required_size == 0 {
+                // Bookmark hasn't been updated with any events yet - return empty string
+                // This is normal for fresh bookmarks before first event
+                debug!(message = "Bookmark not yet updated, skipping serialization.");
+                return Ok(String::new());
+            }
+
+            if required_size > MAX_BOOKMARK_XML_SIZE as u32 {
+                return Err(WindowsEventLogError::RenderError {
+                    message: format!("Bookmark buffer size too large: {}", required_size),
+                });
+            }
+
+            // Allocate buffer and render bookmark XML
+            let mut buffer = vec![0u16; (required_size / 2) as usize];
+            let mut actual_used: u32 = 0;
+
+            EvtRender(
+                None,
+                self.handle,
+                EvtRenderBookmark.0,
+                required_size,
+                Some(buffer.as_mut_ptr() as *mut _),
+                &mut actual_used,
+                &mut property_count,
+            )
+            .map_err(|e| WindowsEventLogError::RenderError {
+                message: format!("Failed to render bookmark XML: {}", e),
+            })?;
+
+            // Convert UTF-16 buffer to String
+            let xml = String::from_utf16_lossy(&buffer[0..((actual_used / 2) as usize)]);
+
+            debug!(
+                message = "Serialized bookmark to XML.",
+                xml_length = xml.len()
+            );
+
+            Ok(xml.trim_end_matches('\0').to_string())
+        }
+    }
+
+    /// Returns the raw Windows handle for use with EvtSubscribe
+    ///
+    /// # Safety
+    ///
+    /// The returned handle is only valid as long as this BookmarkManager exists.
+    pub const fn as_handle(&self) -> EVT_HANDLE {
+        self.handle
+    }
+
+    /// Serialize an EVT_HANDLE directly to XML without needing a BookmarkManager reference
+    ///
+    /// This is useful for serializing bookmarks outside of a lock - you can copy the handle
+    /// (just an integer) while holding the lock, then call this method after releasing it.
+    ///
+    /// # Safety
+    ///
+    /// The handle must be a valid bookmark handle that hasn't been closed.
+    /// Windows EVT_HANDLEs are thread-safe kernel objects, so concurrent
+    /// EvtUpdateBookmark and EvtRender calls on the same handle are safe.
+    pub fn serialize_handle(handle: EVT_HANDLE) -> Result<String, WindowsEventLogError> {
+        unsafe {
+            // First call to get required buffer size
+            // EvtRender params: Context, Fragment, Flags, BufferSize, Buffer, BufferUsed, PropertyCount
+            // BufferUsed (param 6) receives the required size when buffer is too small
+            // PropertyCount (param 7) receives number of properties
+            let mut buffer_used: u32 = 0;
+            let mut property_count: u32 = 0;
+
+            // First call with null buffer to get required size (ERROR_INSUFFICIENT_BUFFER expected)
+            let _ = EvtRender(
+                None,
+                handle,
+                EvtRenderBookmark.0,
+                0,
+                None,
+                &mut buffer_used,
+                &mut property_count,
+            );
+
+            // buffer_used now contains the required size in bytes
+            if buffer_used == 0 {
+                // Bookmark hasn't been updated with any events yet
+                return Ok(String::new());
+            }
+
+            if buffer_used > MAX_BOOKMARK_XML_SIZE as u32 {
+                return Err(WindowsEventLogError::RenderError {
+                    message: format!("Bookmark buffer size too large: {}", buffer_used),
+                });
+            }
+
+            // Allocate buffer (buffer_used is in bytes, UTF-16 chars are 2 bytes each)
+            let mut buffer = vec![0u16; (buffer_used / 2) as usize + 1];
+
+            let mut actual_used: u32 = 0;
+            EvtRender(
+                None,
+                handle,
+                EvtRenderBookmark.0,
+                buffer_used,
+                Some(buffer.as_mut_ptr() as *mut _),
+                &mut actual_used,
+                &mut property_count,
+            )
+            .map_err(|e| WindowsEventLogError::RenderError {
+                message: format!("Failed to render bookmark XML: {}", e),
+            })?;
+
+            let xml = String::from_utf16_lossy(&buffer[0..((actual_used / 2) as usize)]);
+            Ok(xml.trim_end_matches('\0').to_string())
+        }
+    }
+
+    /// Closes the bookmark handle
+    ///
+    /// This is called automatically when the BookmarkManager is dropped.
+    fn close(&mut self) {
+        if self.handle.0 != 0 {
+            unsafe {
+                let _ = EvtClose(self.handle);
+                debug!(message = "Closed bookmark handle.", handle = ?self.handle);
+                self.handle = EVT_HANDLE(0);
+            }
+        }
+    }
+}
+
+impl Drop for BookmarkManager {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bookmark_lifecycle() {
+        // Test creating a new bookmark
+        let bookmark = BookmarkManager::new();
+        assert!(bookmark.is_ok());
+
+        // Test serialization (should work even without updating)
+        let xml = bookmark.unwrap().to_xml();
+        assert!(xml.is_ok());
+    }
+
+    #[test]
+    fn test_bookmark_from_empty_xml() {
+        // Empty XML should create a fresh bookmark
+        let bookmark = BookmarkManager::from_xml("");
+        assert!(bookmark.is_ok());
+    }
+
+    #[test]
+    fn test_bookmark_handle() {
+        let bookmark = BookmarkManager::new().unwrap();
+        let handle = bookmark.as_handle();
+        assert!(!handle.is_invalid(), "Bookmark handle should be valid");
+    }
+}

--- a/src/sources/windows_event_log/checkpoint.rs
+++ b/src/sources/windows_event_log/checkpoint.rs
@@ -1,0 +1,569 @@
+use std::{
+    collections::HashMap,
+    io::{self, ErrorKind},
+    path::{Path, PathBuf},
+};
+
+use serde::{Deserialize, Serialize};
+use tokio::{
+    fs::{self, OpenOptions},
+    io::AsyncWriteExt,
+    sync::Mutex,
+};
+use tracing::{debug, error, info, warn};
+use windows::Win32::Storage::FileSystem::ReplaceFileW;
+use windows::core::HSTRING;
+
+use super::error::WindowsEventLogError;
+
+const CHECKPOINT_FILENAME: &str = "windows_event_log_checkpoints.json";
+
+/// Checkpoint data for a single Windows Event Log channel
+///
+/// Uses Windows Event Log bookmarks for robust position tracking that survives
+/// channel clears, log rotations, and provides O(1) seeking.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ChannelCheckpoint {
+    /// The channel name (e.g., "System", "Application", "Security")
+    pub channel: String,
+    /// Windows Event Log bookmark XML for position tracking
+    pub bookmark_xml: String,
+    /// Timestamp when this checkpoint was last updated (for debugging)
+    #[serde(default)]
+    pub updated_at: String,
+}
+
+/// Container for all channel checkpoints
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct CheckpointState {
+    /// Version for future compatibility
+    version: u32,
+    /// Map of channel name to checkpoint
+    channels: HashMap<String, ChannelCheckpoint>,
+}
+
+impl Default for CheckpointState {
+    fn default() -> Self {
+        Self {
+            version: 1, // Version 1: bookmark-based checkpointing
+            channels: HashMap::new(),
+        }
+    }
+}
+
+/// Manages checkpoint persistence for Windows Event Log subscriptions
+///
+/// Uses Windows Event Log bookmarks (opaque XML handles) to track position in
+/// each channel. Bookmarks are more robust than record IDs as they survive
+/// channel clears, log rotations, and provide O(1) seeking on restart.
+pub struct Checkpointer {
+    checkpoint_path: PathBuf,
+    state: Mutex<CheckpointState>,
+}
+
+impl Checkpointer {
+    /// Create a new checkpointer for the given data directory
+    pub async fn new(data_dir: &Path) -> Result<Self, WindowsEventLogError> {
+        let checkpoint_path = data_dir.join(CHECKPOINT_FILENAME);
+
+        // Ensure the data directory exists
+        if let Err(e) = fs::create_dir_all(data_dir).await
+            && e.kind() != ErrorKind::AlreadyExists
+        {
+            return Err(WindowsEventLogError::IoError { source: e });
+        }
+
+        // Load existing checkpoint state or create new
+        let state = Self::load_from_disk(&checkpoint_path).await?;
+
+        info!(
+            message = "Windows Event Log checkpointer initialized.",
+            checkpoint_path = %checkpoint_path.display(),
+            channels = state.channels.len()
+        );
+
+        Ok(Self {
+            checkpoint_path,
+            state: Mutex::new(state),
+        })
+    }
+
+    /// Get the last checkpoint for a specific channel
+    pub async fn get(&self, channel: &str) -> Option<ChannelCheckpoint> {
+        let state = self.state.lock().await;
+        state.channels.get(channel).cloned()
+    }
+
+    /// Update the checkpoint for a specific channel using bookmark XML
+    ///
+    /// Bookmarks provide robust position tracking that survives channel clears,
+    /// log rotations, and provides O(1) seeking on restart.
+    ///
+    /// Note: For better performance with multiple channels, prefer `set_batch()`
+    /// which writes all checkpoints in a single disk operation.
+    #[cfg(test)]
+    pub async fn set(
+        &self,
+        channel: String,
+        bookmark_xml: String,
+    ) -> Result<(), WindowsEventLogError> {
+        let mut state = self.state.lock().await;
+
+        let checkpoint = ChannelCheckpoint {
+            channel: channel.clone(),
+            bookmark_xml,
+            updated_at: chrono::Utc::now().to_rfc3339(),
+        };
+
+        state.channels.insert(channel.clone(), checkpoint);
+
+        // Persist to disk immediately for reliability
+        self.save_to_disk(&state).await?;
+
+        debug!(
+            message = "Updated checkpoint for channel.",
+            channel = %channel
+        );
+
+        Ok(())
+    }
+
+    /// Update multiple channel checkpoints in a single atomic disk write
+    ///
+    /// This is much more efficient than calling `set()` multiple times because:
+    /// - Single file write instead of N writes
+    /// - Single fsync instead of N fsyncs
+    /// - Atomic - either all channels update or none do
+    ///
+    /// Batching checkpoint updates is standard practice for event log collectors
+    /// and avoids per-event disk I/O overhead.
+    pub async fn set_batch(
+        &self,
+        updates: Vec<(String, String)>,
+    ) -> Result<(), WindowsEventLogError> {
+        if updates.is_empty() {
+            return Ok(());
+        }
+
+        let mut state = self.state.lock().await;
+        let timestamp = chrono::Utc::now().to_rfc3339();
+
+        for (channel, bookmark_xml) in &updates {
+            let checkpoint = ChannelCheckpoint {
+                channel: channel.clone(),
+                bookmark_xml: bookmark_xml.clone(),
+                updated_at: timestamp.clone(),
+            };
+            state.channels.insert(channel.clone(), checkpoint);
+        }
+
+        // Single disk write for all channels
+        self.save_to_disk(&state).await?;
+
+        debug!(
+            message = "Batch updated checkpoints.",
+            channels_updated = updates.len()
+        );
+
+        Ok(())
+    }
+
+    /// Load checkpoint state from disk
+    async fn load_from_disk(path: &Path) -> Result<CheckpointState, WindowsEventLogError> {
+        match fs::read(path).await {
+            Ok(contents) => match serde_json::from_slice::<CheckpointState>(&contents) {
+                Ok(state) => {
+                    info!(
+                        message = "Loaded existing checkpoints.",
+                        channels = state.channels.len(),
+                        path = %path.display()
+                    );
+                    Ok(state)
+                }
+                Err(e) => {
+                    warn!(
+                        message = "Failed to parse checkpoint file, starting fresh.",
+                        error = %e,
+                        path = %path.display()
+                    );
+                    Ok(CheckpointState::default())
+                }
+            },
+            Err(e) if e.kind() == ErrorKind::NotFound => {
+                debug!(
+                    message = "No existing checkpoint file, starting fresh.",
+                    path = %path.display()
+                );
+                Ok(CheckpointState::default())
+            }
+            Err(e) => {
+                error!(
+                    message = "Failed to read checkpoint file.",
+                    error = %e,
+                    path = %path.display()
+                );
+                Err(WindowsEventLogError::IoError { source: e })
+            }
+        }
+    }
+
+    /// Save checkpoint state to disk atomically
+    async fn save_to_disk(&self, state: &CheckpointState) -> Result<(), WindowsEventLogError> {
+        // Use atomic write: write to temp file, then rename
+        let temp_path = self.checkpoint_path.with_extension("tmp");
+
+        // Serialize state
+        let contents = match serde_json::to_vec_pretty(state) {
+            Ok(c) => c,
+            Err(e) => {
+                error!(
+                    message = "Failed to serialize checkpoint state.",
+                    error = %e
+                );
+                return Err(WindowsEventLogError::IoError {
+                    source: io::Error::new(ErrorKind::InvalidData, e),
+                });
+            }
+        };
+
+        // Write to temp file
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&temp_path)
+            .await
+            .map_err(|e| WindowsEventLogError::IoError { source: e })?;
+
+        file.write_all(&contents)
+            .await
+            .map_err(|e| WindowsEventLogError::IoError { source: e })?;
+
+        file.sync_all()
+            .await
+            .map_err(|e| WindowsEventLogError::IoError { source: e })?;
+
+        drop(file);
+
+        // Use ReplaceFileW for atomic replacement on Windows; fall back to
+        // rename when the destination doesn't exist yet (first run).
+        #[cfg(windows)]
+        {
+            let dst = HSTRING::from(self.checkpoint_path.to_string_lossy().as_ref());
+            let src = HSTRING::from(temp_path.to_string_lossy().as_ref());
+            let replaced = unsafe {
+                ReplaceFileW(
+                    &dst,
+                    &src,
+                    None,
+                    windows::Win32::Storage::FileSystem::REPLACE_FILE_FLAGS(0),
+                    None,
+                    None,
+                )
+            };
+            if replaced.is_err() {
+                // Destination may not exist yet — fall back to rename
+                fs::rename(&temp_path, &self.checkpoint_path)
+                    .await
+                    .map_err(|e| WindowsEventLogError::IoError { source: e })?;
+            }
+        }
+        #[cfg(not(windows))]
+        {
+            fs::rename(&temp_path, &self.checkpoint_path)
+                .await
+                .map_err(|e| WindowsEventLogError::IoError { source: e })?;
+        }
+
+        Ok(())
+    }
+
+    /// Remove checkpoint for a channel (useful for testing or reset)
+    #[cfg(test)]
+    pub async fn remove(&self, channel: &str) -> Result<(), WindowsEventLogError> {
+        let mut state = self.state.lock().await;
+        state.channels.remove(channel);
+        self.save_to_disk(&state).await?;
+
+        info!(
+            message = "Removed checkpoint for channel.",
+            channel = %channel
+        );
+
+        Ok(())
+    }
+
+    /// Get all channel checkpoints (useful for debugging)
+    #[cfg(test)]
+    pub async fn list(&self) -> Vec<ChannelCheckpoint> {
+        let state = self.state.lock().await;
+        state.channels.values().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Helper to create test bookmark XML
+    fn test_bookmark_xml(channel: &str, record_id: u64) -> String {
+        format!(
+            r#"<BookmarkList><Bookmark Channel="{}" RecordId="{}" IsCurrent="True"/></BookmarkList>"#,
+            channel, record_id
+        )
+    }
+
+    async fn create_test_checkpointer() -> (Checkpointer, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        let checkpointer = Checkpointer::new(temp_dir.path()).await.unwrap();
+        (checkpointer, temp_dir)
+    }
+
+    #[tokio::test]
+    async fn test_checkpoint_basic_operations() {
+        let (checkpointer, _temp_dir) = create_test_checkpointer().await;
+
+        // Initially empty
+        assert!(checkpointer.get("System").await.is_none());
+
+        // Set checkpoint
+        let bookmark = test_bookmark_xml("System", 12345);
+        checkpointer
+            .set("System".to_string(), bookmark.clone())
+            .await
+            .unwrap();
+
+        // Retrieve checkpoint
+        let checkpoint = checkpointer.get("System").await.unwrap();
+        assert_eq!(checkpoint.channel, "System");
+        assert_eq!(checkpoint.bookmark_xml, bookmark);
+    }
+
+    #[tokio::test]
+    async fn test_checkpoint_persistence() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let system_bookmark = test_bookmark_xml("System", 100);
+        let app_bookmark = test_bookmark_xml("Application", 200);
+
+        // Create first checkpointer and set values
+        {
+            let checkpointer = Checkpointer::new(temp_dir.path()).await.unwrap();
+            checkpointer
+                .set("System".to_string(), system_bookmark.clone())
+                .await
+                .unwrap();
+            checkpointer
+                .set("Application".to_string(), app_bookmark.clone())
+                .await
+                .unwrap();
+        }
+
+        // Create new checkpointer (simulating restart) and verify persistence
+        {
+            let checkpointer = Checkpointer::new(temp_dir.path()).await.unwrap();
+            let system_checkpoint = checkpointer.get("System").await.unwrap();
+            assert_eq!(system_checkpoint.bookmark_xml, system_bookmark);
+
+            let app_checkpoint = checkpointer.get("Application").await.unwrap();
+            assert_eq!(app_checkpoint.bookmark_xml, app_bookmark);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_checkpoint_update() {
+        let (checkpointer, _temp_dir) = create_test_checkpointer().await;
+
+        // Set initial value
+        let bookmark1 = test_bookmark_xml("System", 100);
+        checkpointer
+            .set("System".to_string(), bookmark1)
+            .await
+            .unwrap();
+
+        // Update value
+        let bookmark2 = test_bookmark_xml("System", 200);
+        checkpointer
+            .set("System".to_string(), bookmark2.clone())
+            .await
+            .unwrap();
+
+        // Verify updated value
+        let checkpoint = checkpointer.get("System").await.unwrap();
+        assert_eq!(checkpoint.bookmark_xml, bookmark2);
+    }
+
+    #[tokio::test]
+    async fn test_checkpoint_multiple_channels() {
+        let (checkpointer, _temp_dir) = create_test_checkpointer().await;
+
+        let system_bookmark = test_bookmark_xml("System", 100);
+        let app_bookmark = test_bookmark_xml("Application", 200);
+        let security_bookmark = test_bookmark_xml("Security", 300);
+
+        checkpointer
+            .set("System".to_string(), system_bookmark.clone())
+            .await
+            .unwrap();
+        checkpointer
+            .set("Application".to_string(), app_bookmark.clone())
+            .await
+            .unwrap();
+        checkpointer
+            .set("Security".to_string(), security_bookmark.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            checkpointer.get("System").await.unwrap().bookmark_xml,
+            system_bookmark
+        );
+        assert_eq!(
+            checkpointer.get("Application").await.unwrap().bookmark_xml,
+            app_bookmark
+        );
+        assert_eq!(
+            checkpointer.get("Security").await.unwrap().bookmark_xml,
+            security_bookmark
+        );
+    }
+
+    #[tokio::test]
+    async fn test_checkpoint_remove() {
+        let (checkpointer, _temp_dir) = create_test_checkpointer().await;
+
+        let bookmark = test_bookmark_xml("System", 100);
+        checkpointer
+            .set("System".to_string(), bookmark)
+            .await
+            .unwrap();
+        assert!(checkpointer.get("System").await.is_some());
+
+        checkpointer.remove("System").await.unwrap();
+        assert!(checkpointer.get("System").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_checkpoint_list() {
+        let (checkpointer, _temp_dir) = create_test_checkpointer().await;
+
+        let system_bookmark = test_bookmark_xml("System", 100);
+        let app_bookmark = test_bookmark_xml("Application", 200);
+
+        checkpointer
+            .set("System".to_string(), system_bookmark)
+            .await
+            .unwrap();
+        checkpointer
+            .set("Application".to_string(), app_bookmark)
+            .await
+            .unwrap();
+
+        let checkpoints = checkpointer.list().await;
+        assert_eq!(checkpoints.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_corrupted_checkpoint_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let checkpoint_path = temp_dir.path().join(CHECKPOINT_FILENAME);
+
+        // Write corrupted data
+        fs::write(&checkpoint_path, b"invalid json {{{")
+            .await
+            .unwrap();
+
+        // Should handle gracefully and start fresh
+        let checkpointer = Checkpointer::new(temp_dir.path()).await.unwrap();
+        assert!(checkpointer.get("System").await.is_none());
+
+        // Should be able to write new checkpoints
+        let bookmark = test_bookmark_xml("System", 100);
+        checkpointer
+            .set("System".to_string(), bookmark.clone())
+            .await
+            .unwrap();
+        assert_eq!(
+            checkpointer.get("System").await.unwrap().bookmark_xml,
+            bookmark
+        );
+    }
+
+    #[tokio::test]
+    async fn test_checkpoint_batch_update() {
+        let (checkpointer, _temp_dir) = create_test_checkpointer().await;
+
+        let system_bookmark = test_bookmark_xml("System", 100);
+        let app_bookmark = test_bookmark_xml("Application", 200);
+        let security_bookmark = test_bookmark_xml("Security", 300);
+
+        // Batch update all channels at once
+        checkpointer
+            .set_batch(vec![
+                ("System".to_string(), system_bookmark.clone()),
+                ("Application".to_string(), app_bookmark.clone()),
+                ("Security".to_string(), security_bookmark.clone()),
+            ])
+            .await
+            .unwrap();
+
+        // Verify all channels were updated
+        assert_eq!(
+            checkpointer.get("System").await.unwrap().bookmark_xml,
+            system_bookmark
+        );
+        assert_eq!(
+            checkpointer.get("Application").await.unwrap().bookmark_xml,
+            app_bookmark
+        );
+        assert_eq!(
+            checkpointer.get("Security").await.unwrap().bookmark_xml,
+            security_bookmark
+        );
+    }
+
+    #[tokio::test]
+    async fn test_checkpoint_batch_empty() {
+        let (checkpointer, _temp_dir) = create_test_checkpointer().await;
+
+        // Empty batch should succeed without writing
+        checkpointer.set_batch(vec![]).await.unwrap();
+
+        // No checkpoints should exist
+        assert!(checkpointer.list().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_checkpoint_batch_persistence() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let system_bookmark = test_bookmark_xml("System", 100);
+        let app_bookmark = test_bookmark_xml("Application", 200);
+
+        // Create first checkpointer and batch update
+        {
+            let checkpointer = Checkpointer::new(temp_dir.path()).await.unwrap();
+            checkpointer
+                .set_batch(vec![
+                    ("System".to_string(), system_bookmark.clone()),
+                    ("Application".to_string(), app_bookmark.clone()),
+                ])
+                .await
+                .unwrap();
+        }
+
+        // Create new checkpointer (simulating restart) and verify persistence
+        {
+            let checkpointer = Checkpointer::new(temp_dir.path()).await.unwrap();
+            assert_eq!(
+                checkpointer.get("System").await.unwrap().bookmark_xml,
+                system_bookmark
+            );
+            assert_eq!(
+                checkpointer.get("Application").await.unwrap().bookmark_xml,
+                app_bookmark
+            );
+        }
+    }
+}

--- a/src/sources/windows_event_log/checkpoint.rs
+++ b/src/sources/windows_event_log/checkpoint.rs
@@ -67,10 +67,10 @@ impl Checkpointer {
         let checkpoint_path = data_dir.join(CHECKPOINT_FILENAME);
 
         // Ensure the data directory exists
-        if let Err(e) = fs::create_dir_all(data_dir).await
-            && e.kind() != ErrorKind::AlreadyExists
-        {
-            return Err(WindowsEventLogError::IoError { source: e });
+        if let Err(e) = fs::create_dir_all(data_dir).await {
+            if e.kind() != ErrorKind::AlreadyExists {
+                return Err(WindowsEventLogError::IoError { source: e });
+            }
         }
 
         // Load existing checkpoint state or create new

--- a/src/sources/windows_event_log/config.rs
+++ b/src/sources/windows_event_log/config.rs
@@ -1,0 +1,759 @@
+use std::{collections::HashMap, path::PathBuf};
+
+use vector_config::component::GenerateConfig;
+use vector_lib::configurable::configurable_component;
+
+use crate::{config::SourceAcknowledgementsConfig, serde::bool_or_struct};
+
+// Validation constants
+const MAX_CHANNEL_NAME_LENGTH: usize = 256;
+const MAX_XPATH_QUERY_LENGTH: usize = 4096;
+const MAX_FIELD_NAME_LENGTH: usize = 128;
+const MAX_FIELD_COUNT: usize = 100;
+const MAX_EVENT_ID_LIST_SIZE: usize = 1000;
+const MAX_CHANNELS: usize = 63; // MAXIMUM_WAIT_OBJECTS (64) minus 1 for shutdown event
+const MAX_CONNECTION_TIMEOUT_SECS: u64 = 3600;
+const MAX_EVENT_TIMEOUT_MS: u64 = 60000;
+const MAX_BATCH_SIZE: u32 = 10000;
+
+/// Configuration for the `windows_event_log` source.
+#[configurable_component(source(
+    "windows_event_log",
+    "Collect logs from Windows Event Log channels using the Windows Event Log API."
+))]
+#[derive(Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct WindowsEventLogConfig {
+    /// A comma-separated list of channels to read from.
+    ///
+    /// Common channels include "System", "Application", "Security", "Windows PowerShell".
+    /// Use Windows Event Viewer to discover available channels.
+    #[configurable(metadata(docs::examples = "System,Application,Security"))]
+    #[configurable(metadata(docs::examples = "System"))]
+    pub channels: Vec<String>,
+
+    /// The XPath query for filtering events.
+    ///
+    /// Allows filtering events using XML Path Language queries.
+    /// If not specified, all events from the specified channels will be collected.
+    #[configurable(metadata(docs::examples = "*[System[Level=1 or Level=2 or Level=3]]"))]
+    #[configurable(metadata(
+        docs::examples = "*[System[(Level=1 or Level=2 or Level=3) and TimeCreated[timediff(@SystemTime) <= 86400000]]]"
+    ))]
+    pub event_query: Option<String>,
+
+    /// Connection timeout in seconds for event subscription.
+    ///
+    /// This controls how long to wait for event subscription connection.
+    #[serde(default = "default_connection_timeout_secs")]
+    #[configurable(metadata(docs::examples = 30))]
+    #[configurable(metadata(docs::examples = 60))]
+    pub connection_timeout_secs: u64,
+
+    /// Whether to read existing events or only new events.
+    ///
+    /// When set to `true`, the source will read all existing events from the channels.
+    /// When set to `false` (default), only new events will be read.
+    #[serde(default = "default_read_existing_events")]
+    pub read_existing_events: bool,
+
+    /// Batch size for event processing.
+    ///
+    /// This controls how many events are processed in a single batch.
+    #[serde(default = "default_batch_size")]
+    #[configurable(metadata(docs::examples = 10))]
+    #[configurable(metadata(docs::examples = 100))]
+    pub batch_size: u32,
+
+    /// Whether to include raw XML data in the output.
+    ///
+    /// When enabled, the raw XML representation of the event is included
+    /// in the `xml` field of the output event.
+    #[serde(default = "default_include_xml")]
+    pub include_xml: bool,
+
+    /// Custom event data formatting options.
+    ///
+    /// Maps event field names to custom formatting options.
+    #[serde(default)]
+    #[configurable(metadata(
+        docs::additional_props_description = "An individual event data format override."
+    ))]
+    pub event_data_format: HashMap<String, EventDataFormat>,
+
+    /// Ignore specific event IDs.
+    ///
+    /// Events with these IDs will be filtered out and not sent downstream.
+    #[serde(default)]
+    #[configurable(metadata(docs::examples = 4624))]
+    #[configurable(metadata(docs::examples = 4625))]
+    #[configurable(metadata(docs::examples = 4634))]
+    pub ignore_event_ids: Vec<u32>,
+
+    /// Only include specific event IDs.
+    ///
+    /// If specified, only events with these IDs will be processed.
+    /// Takes precedence over `ignore_event_ids`.
+    #[configurable(metadata(docs::examples = 1000))]
+    #[configurable(metadata(docs::examples = 1001))]
+    #[configurable(metadata(docs::examples = 1002))]
+    pub only_event_ids: Option<Vec<u32>>,
+
+    /// Maximum age of events to process (in seconds).
+    ///
+    /// Events older than this value will be ignored. If not specified,
+    /// all events will be processed regardless of age.
+    #[configurable(metadata(docs::examples = 86400))]
+    #[configurable(metadata(docs::examples = 604800))]
+    pub max_event_age_secs: Option<u64>,
+
+    /// Timeout in milliseconds for waiting for new events.
+    ///
+    /// Controls the maximum time `WaitForMultipleObjects` blocks before
+    /// returning to check for shutdown signals. Lower values increase
+    /// shutdown responsiveness at the cost of more frequent wake-ups.
+    #[serde(default = "default_event_timeout_ms")]
+    #[configurable(metadata(docs::examples = 5000))]
+    #[configurable(metadata(docs::examples = 10000))]
+    pub event_timeout_ms: u64,
+
+    /// The namespace to use for logs. This overrides the global setting.
+    #[configurable(metadata(docs::hidden))]
+    #[serde(default)]
+    pub log_namespace: Option<bool>,
+
+    /// Event field inclusion/exclusion patterns.
+    ///
+    /// Controls which event fields are included in the output.
+    #[serde(default)]
+    pub field_filter: FieldFilter,
+
+    /// The directory where checkpoint data is stored.
+    ///
+    /// By default, the [global `data_dir` option][global_data_dir] is used.
+    /// Make sure the running user has write permissions to this directory.
+    ///
+    /// [global_data_dir]: https://vector.dev/docs/reference/configuration/global-options/#data_dir
+    #[serde(default)]
+    #[configurable(metadata(docs::examples = "/var/lib/vector"))]
+    #[configurable(metadata(docs::examples = "C:\\ProgramData\\vector"))]
+    #[configurable(metadata(docs::human_name = "Data Directory"))]
+    pub data_dir: Option<PathBuf>,
+
+    /// Maximum number of events to process per second.
+    ///
+    /// When set to a non-zero value, Vector will rate-limit event processing
+    /// to prevent overwhelming downstream systems. A value of 0 (default) means
+    /// no rate limiting is applied.
+    #[serde(default = "default_events_per_second")]
+    #[configurable(metadata(docs::examples = 100))]
+    #[configurable(metadata(docs::examples = 1000))]
+    #[configurable(metadata(docs::examples = 5000))]
+    pub events_per_second: u32,
+
+    /// Maximum length for event data field values.
+    ///
+    /// Event data values longer than this will be truncated with "...\[truncated\]" appended.
+    /// Set to 0 for no limit.
+    #[serde(default = "default_max_event_data_length")]
+    #[configurable(metadata(docs::examples = 1024))]
+    #[configurable(metadata(docs::examples = 4096))]
+    pub max_event_data_length: usize,
+
+    /// Interval in seconds between periodic checkpoint flushes.
+    ///
+    /// Controls how often bookmarks are persisted to disk in synchronous mode.
+    /// Lower values reduce the window of events that may be re-processed after
+    /// a crash, at the cost of more frequent disk writes.
+    #[serde(default = "default_checkpoint_interval_secs")]
+    #[configurable(metadata(docs::examples = 5))]
+    #[configurable(metadata(docs::examples = 1))]
+    #[configurable(metadata(docs::examples = 30))]
+    pub checkpoint_interval_secs: u64,
+
+    /// Whether to render human-readable event messages.
+    ///
+    /// When enabled (default), Vector will use the Windows EvtFormatMessage API
+    /// to render localized, human-readable event messages with parameter
+    /// substitution. This matches the behavior of Windows Event Viewer.
+    ///
+    /// Provider DLL handles are cached per provider, so the performance cost
+    /// is limited to the first event from each provider. Disable only if you
+    /// do not need rendered messages and want to eliminate the DLL loads entirely.
+    #[serde(default = "default_render_message")]
+    pub render_message: bool,
+
+    /// Controls how acknowledgements are handled for this source.
+    ///
+    /// When enabled, the source will wait for downstream sinks to acknowledge
+    /// receipt of events before updating checkpoints. This provides exactly-once
+    /// delivery guarantees at the cost of potential duplicate events on restart
+    /// if acknowledgements are pending.
+    ///
+    /// When disabled (default), checkpoints are updated immediately after reading
+    /// events, which may result in data loss if Vector crashes before events are
+    /// delivered to sinks.
+    #[configurable(derived)]
+    #[serde(default, deserialize_with = "bool_or_struct")]
+    pub acknowledgements: SourceAcknowledgementsConfig,
+}
+
+/// Event data formatting options for custom field type conversion.
+///
+/// These options control how specific event fields are formatted in the output.
+/// Use `event_data_format` config to map field names to their desired format.
+#[configurable_component]
+#[derive(Clone, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum EventDataFormat {
+    /// Format the field value as a string.
+    String,
+    /// Parse and format the field value as an integer.
+    Integer,
+    /// Parse and format the field value as a floating-point number.
+    Float,
+    /// Parse and format the field value as a boolean.
+    /// Recognizes "true", "1", "yes", "on" as true (case-insensitive).
+    Boolean,
+    /// Keep the original format unchanged (passthrough).
+    /// The field value will not be converted or modified.
+    Auto,
+}
+
+/// Field filtering configuration.
+#[configurable_component]
+#[derive(Clone, Debug)]
+pub struct FieldFilter {
+    /// Fields to include in the output.
+    ///
+    /// If specified, only these fields will be included.
+    pub include_fields: Option<Vec<String>>,
+
+    /// Fields to exclude from the output.
+    ///
+    /// These fields will be removed from the event data.
+    pub exclude_fields: Option<Vec<String>>,
+
+    /// Whether to include system fields.
+    ///
+    /// System fields include metadata like Computer, TimeCreated, etc.
+    #[serde(default = "default_include_system_fields")]
+    pub include_system_fields: bool,
+
+    /// Whether to include event data fields.
+    ///
+    /// Event data fields contain application-specific data.
+    #[serde(default = "default_include_event_data")]
+    pub include_event_data: bool,
+
+    /// Whether to include user data fields.
+    ///
+    /// User data fields contain additional custom data.
+    #[serde(default = "default_include_user_data")]
+    pub include_user_data: bool,
+}
+
+impl Default for FieldFilter {
+    fn default() -> Self {
+        Self {
+            include_fields: None,
+            exclude_fields: None,
+            include_system_fields: default_include_system_fields(),
+            include_event_data: default_include_event_data(),
+            include_user_data: default_include_user_data(),
+        }
+    }
+}
+
+impl Default for WindowsEventLogConfig {
+    fn default() -> Self {
+        Self {
+            channels: vec!["System".to_string(), "Application".to_string()],
+            event_query: None,
+            connection_timeout_secs: default_connection_timeout_secs(),
+            read_existing_events: default_read_existing_events(),
+            batch_size: default_batch_size(),
+            include_xml: default_include_xml(),
+            event_data_format: HashMap::new(),
+            ignore_event_ids: Vec::new(),
+            only_event_ids: None,
+            max_event_age_secs: None,
+            event_timeout_ms: default_event_timeout_ms(),
+            log_namespace: None,
+            field_filter: FieldFilter::default(),
+            data_dir: None,
+            events_per_second: default_events_per_second(),
+            max_event_data_length: default_max_event_data_length(),
+            checkpoint_interval_secs: default_checkpoint_interval_secs(),
+            render_message: default_render_message(),
+            acknowledgements: Default::default(),
+        }
+    }
+}
+
+impl GenerateConfig for WindowsEventLogConfig {
+    fn generate_config() -> toml::Value {
+        toml::Value::try_from(WindowsEventLogConfig::default()).unwrap()
+    }
+}
+
+impl WindowsEventLogConfig {
+    /// Validate the configuration.
+    pub fn validate(&self) -> Result<(), crate::Error> {
+        if self.channels.is_empty() {
+            return Err("At least one channel must be specified".into());
+        }
+
+        // WaitForMultipleObjects supports up to MAXIMUM_WAIT_OBJECTS (64) handles.
+        // One handle is reserved for the shutdown event, leaving 63 for channels.
+        if self.channels.len() > MAX_CHANNELS {
+            return Err(format!(
+                "Too many channels: {} specified, maximum is {} \
+                 (limited by WaitForMultipleObjects)",
+                self.channels.len(),
+                MAX_CHANNELS
+            )
+            .into());
+        }
+
+        // Enhanced security validation for connection timeout to prevent DoS
+        if self.connection_timeout_secs == 0
+            || self.connection_timeout_secs > MAX_CONNECTION_TIMEOUT_SECS
+        {
+            return Err(format!(
+                "Connection timeout must be between 1 and {} seconds",
+                MAX_CONNECTION_TIMEOUT_SECS
+            )
+            .into());
+        }
+
+        // Validate event timeout
+        if self.event_timeout_ms == 0 || self.event_timeout_ms > MAX_EVENT_TIMEOUT_MS {
+            return Err(format!(
+                "Event timeout must be between 1 and {} milliseconds",
+                MAX_EVENT_TIMEOUT_MS
+            )
+            .into());
+        }
+
+        // Validate checkpoint interval
+        if self.checkpoint_interval_secs == 0 || self.checkpoint_interval_secs > 3600 {
+            return Err("Checkpoint interval must be between 1 and 3600 seconds".into());
+        }
+
+        // Prevent resource exhaustion via excessive batch sizes
+        if self.batch_size == 0 || self.batch_size > MAX_BATCH_SIZE {
+            return Err(format!("Batch size must be between 1 and {}", MAX_BATCH_SIZE).into());
+        }
+
+        // Enhanced channel name validation with security checks
+        for channel in &self.channels {
+            if channel.trim().is_empty() {
+                return Err("Channel names cannot be empty".into());
+            }
+
+            // Prevent excessively long channel names
+            if channel.len() > MAX_CHANNEL_NAME_LENGTH {
+                return Err(format!(
+                    "Channel name '{}' exceeds maximum length of {} characters",
+                    channel, MAX_CHANNEL_NAME_LENGTH
+                )
+                .into());
+            }
+
+            // Reject wildcard patterns - they cause heap corruption issues with many channels
+            if is_channel_pattern(channel) {
+                return Err(format!(
+                    "Channel name '{}' contains wildcard characters (*, ?, [). \
+                     Wildcard patterns are not supported. Please specify exact channel names.",
+                    channel
+                )
+                .into());
+            }
+
+            // Reject control characters and null bytes. Actual channel name
+            // validation is handled by EvtOpenChannelConfig at subscription time,
+            // so we only block characters that could cause issues before that check.
+            if channel.chars().any(|c| c.is_control()) {
+                return Err(
+                    format!("Channel name '{}' contains control characters", channel).into(),
+                );
+            }
+        }
+
+        // Enhanced XPath query validation with injection protection
+        if let Some(ref query) = self.event_query {
+            if query.trim().is_empty() {
+                return Err("Event query cannot be empty".into());
+            }
+
+            // Prevent excessively long XPath queries
+            if query.len() > MAX_XPATH_QUERY_LENGTH {
+                return Err(format!(
+                    "Event query exceeds maximum length of {} characters",
+                    MAX_XPATH_QUERY_LENGTH
+                )
+                .into());
+            }
+
+            // Check for unbalanced brackets and parentheses
+            let mut bracket_count = 0i32;
+            let mut paren_count = 0i32;
+
+            for ch in query.chars() {
+                match ch {
+                    '[' => bracket_count += 1,
+                    ']' => bracket_count -= 1,
+                    '(' => paren_count += 1,
+                    ')' => paren_count -= 1,
+                    _ => {}
+                }
+
+                // Check for negative counts (more closing than opening)
+                if bracket_count < 0 || paren_count < 0 {
+                    return Err("Event query contains unbalanced brackets or parentheses".into());
+                }
+            }
+
+            // Check for unmatched opening brackets/parentheses
+            if bracket_count != 0 || paren_count != 0 {
+                return Err("Event query contains unbalanced brackets or parentheses".into());
+            }
+
+            // Check for potentially dangerous patterns that could indicate XPath injection.
+            // Note: We exclude "http:" and "https:" as they are legitimate in XML namespace URIs.
+            let dangerous_patterns = [
+                "javascript:",
+                "vbscript:",
+                "file://", // Changed from "file:" to be more specific
+                "ftp:",
+                "<script",
+                "</script",
+            ];
+
+            let query_lower = query.to_lowercase();
+            for pattern in &dangerous_patterns {
+                if query_lower.contains(pattern) {
+                    return Err(format!(
+                        "Event query contains potentially unsafe pattern: '{}'",
+                        pattern
+                    )
+                    .into());
+                }
+            }
+        }
+
+        // Validate event ID filter lists to prevent resource exhaustion
+        if let Some(ref event_ids) = self.only_event_ids {
+            if event_ids.is_empty() {
+                return Err("Only event IDs list cannot be empty when specified".into());
+            }
+
+            if event_ids.len() > MAX_EVENT_ID_LIST_SIZE {
+                return Err(format!(
+                    "Only event IDs list cannot contain more than {} entries",
+                    MAX_EVENT_ID_LIST_SIZE
+                )
+                .into());
+            }
+        }
+
+        if self.ignore_event_ids.len() > MAX_EVENT_ID_LIST_SIZE {
+            return Err(format!(
+                "Ignore event IDs list cannot contain more than {} entries",
+                MAX_EVENT_ID_LIST_SIZE
+            )
+            .into());
+        }
+
+        // Validate field filter settings
+        if let Some(ref include_fields) = self.field_filter.include_fields {
+            if include_fields.is_empty() {
+                return Err("Include fields list cannot be empty when specified".into());
+            }
+
+            if include_fields.len() > MAX_FIELD_COUNT {
+                return Err(format!(
+                    "Include fields list cannot contain more than {} entries",
+                    MAX_FIELD_COUNT
+                )
+                .into());
+            }
+
+            for field in include_fields {
+                if field.trim().is_empty() || field.len() > MAX_FIELD_NAME_LENGTH {
+                    return Err(format!("Invalid field name: '{}'", field).into());
+                }
+
+                // Enhanced security validation for field names
+                if field.contains('\0')
+                    || field.contains('\r')
+                    || field.contains('\n')
+                    || field.contains('<')
+                    || field.contains('>')
+                {
+                    return Err(format!(
+                        "Invalid field name contains dangerous characters: '{}'",
+                        field
+                    )
+                    .into());
+                }
+            }
+        }
+
+        if let Some(ref exclude_fields) = self.field_filter.exclude_fields {
+            if exclude_fields.is_empty() {
+                return Err("Exclude fields list cannot be empty when specified".into());
+            }
+
+            if exclude_fields.len() > MAX_FIELD_COUNT {
+                return Err(format!(
+                    "Exclude fields list cannot contain more than {} entries",
+                    MAX_FIELD_COUNT
+                )
+                .into());
+            }
+
+            for field in exclude_fields {
+                if field.trim().is_empty() || field.len() > MAX_FIELD_NAME_LENGTH {
+                    return Err(format!("Invalid field name: '{}'", field).into());
+                }
+
+                // Enhanced security validation for field names
+                if field.contains('\0')
+                    || field.contains('\r')
+                    || field.contains('\n')
+                    || field.contains('<')
+                    || field.contains('>')
+                {
+                    return Err(format!(
+                        "Invalid field name contains dangerous characters: '{}'",
+                        field
+                    )
+                    .into());
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Check if a channel name contains glob pattern characters
+pub fn is_channel_pattern(name: &str) -> bool {
+    name.contains('*') || name.contains('?') || name.contains('[')
+}
+
+// Default value functions
+const fn default_connection_timeout_secs() -> u64 {
+    30
+}
+
+const fn default_event_timeout_ms() -> u64 {
+    5000
+}
+
+const fn default_read_existing_events() -> bool {
+    false
+}
+
+const fn default_batch_size() -> u32 {
+    100
+}
+
+const fn default_include_xml() -> bool {
+    false
+}
+
+const fn default_include_system_fields() -> bool {
+    true
+}
+
+const fn default_include_event_data() -> bool {
+    true
+}
+
+const fn default_include_user_data() -> bool {
+    true
+}
+
+const fn default_events_per_second() -> u32 {
+    0 // 0 means no rate limiting
+}
+
+const fn default_max_event_data_length() -> usize {
+    0 // 0 means no truncation
+}
+
+const fn default_checkpoint_interval_secs() -> u64 {
+    5
+}
+
+const fn default_render_message() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = WindowsEventLogConfig::default();
+        assert_eq!(config.channels, vec!["System", "Application"]);
+        assert_eq!(config.connection_timeout_secs, 30);
+        assert_eq!(config.event_timeout_ms, 5000);
+        assert!(!config.read_existing_events);
+        assert_eq!(config.batch_size, 100);
+        assert!(!config.include_xml);
+        assert!(config.render_message);
+    }
+
+    #[test]
+    fn test_config_validation() {
+        let mut config = WindowsEventLogConfig::default();
+
+        // Valid configuration should pass
+        assert!(config.validate().is_ok());
+
+        // Empty channels should fail
+        config.channels = vec![];
+        assert!(config.validate().is_err());
+
+        // Reset channels
+        config.channels = vec!["System".to_string()];
+        assert!(config.validate().is_ok());
+
+        // Zero connection timeout should fail
+        config.connection_timeout_secs = 0;
+        assert!(config.validate().is_err());
+
+        // Reset connection timeout
+        config.connection_timeout_secs = 30;
+        assert!(config.validate().is_ok());
+
+        // Zero batch size should fail
+        config.batch_size = 0;
+        assert!(config.validate().is_err());
+
+        // Reset batch size
+        config.batch_size = 10;
+        assert!(config.validate().is_ok());
+
+        // Empty channel name should fail
+        config.channels = vec!["".to_string()];
+        assert!(config.validate().is_err());
+
+        // Empty query should fail
+        config.channels = vec!["System".to_string()];
+        config.event_query = Some("".to_string());
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_field_filter_default() {
+        let filter = FieldFilter::default();
+        assert!(filter.include_system_fields);
+        assert!(filter.include_event_data);
+        assert!(filter.include_user_data);
+        assert!(filter.include_fields.is_none());
+        assert!(filter.exclude_fields.is_none());
+    }
+
+    #[test]
+    fn test_serialization() {
+        let config = WindowsEventLogConfig {
+            channels: vec!["System".to_string(), "Application".to_string()],
+            event_query: Some("*[System[Level=1]]".to_string()),
+            connection_timeout_secs: 30,
+            read_existing_events: true,
+            batch_size: 50,
+            include_xml: true,
+            event_data_format: HashMap::new(),
+            ignore_event_ids: vec![4624, 4625],
+            only_event_ids: Some(vec![1000, 1001]),
+            max_event_age_secs: Some(86400),
+            event_timeout_ms: 5000,
+            log_namespace: Some(true),
+            field_filter: FieldFilter::default(),
+            data_dir: Some(PathBuf::from("/test/data")),
+            events_per_second: 1000,
+            max_event_data_length: 0,
+            checkpoint_interval_secs: 5,
+            render_message: true,
+            acknowledgements: SourceAcknowledgementsConfig::from(true),
+        };
+
+        // Should serialize and deserialize without errors
+        let serialized = serde_json::to_string(&config).expect("serialization should succeed");
+        let deserialized: WindowsEventLogConfig =
+            serde_json::from_str(&serialized).expect("deserialization should succeed");
+
+        assert_eq!(config.channels, deserialized.channels);
+        assert_eq!(config.event_query, deserialized.event_query);
+        assert_eq!(
+            config.connection_timeout_secs,
+            deserialized.connection_timeout_secs
+        );
+        assert_eq!(
+            config.read_existing_events,
+            deserialized.read_existing_events
+        );
+        assert_eq!(config.batch_size, deserialized.batch_size);
+        assert_eq!(config.render_message, deserialized.render_message);
+    }
+
+    #[test]
+    fn test_is_channel_pattern() {
+        // Exact channel names are not patterns
+        assert!(!is_channel_pattern("System"));
+        assert!(!is_channel_pattern("Application"));
+        assert!(!is_channel_pattern("Microsoft-Windows-Sysmon/Operational"));
+
+        // Wildcard patterns
+        assert!(is_channel_pattern("Microsoft-Windows-*"));
+        assert!(is_channel_pattern("*"));
+        assert!(is_channel_pattern("Microsoft-Windows-Sysmon/*"));
+
+        // Single character wildcard
+        assert!(is_channel_pattern("System?"));
+        assert!(is_channel_pattern("Microsoft-Windows-???"));
+
+        // Character class patterns
+        assert!(is_channel_pattern("Microsoft-Windows-[A-Z]*"));
+        assert!(is_channel_pattern("[Ss]ystem"));
+    }
+
+    #[test]
+    fn test_config_validation_rejects_wildcards() {
+        let mut config = WindowsEventLogConfig {
+            channels: vec!["Microsoft-Windows-*".to_string()],
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("wildcard"));
+
+        // Single character wildcards should be rejected
+        config.channels = vec!["System?".to_string()];
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("wildcard"));
+
+        // Character classes should be rejected
+        config.channels = vec!["[Ss]ystem".to_string()];
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("wildcard"));
+
+        // Mixed valid and wildcard should be rejected
+        config.channels = vec!["System".to_string(), "Microsoft-Windows-*".to_string()];
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("wildcard"));
+
+        // Exact channel names should still work
+        config.channels = vec![
+            "System".to_string(),
+            "Application".to_string(),
+            "Microsoft-Windows-Sysmon/Operational".to_string(),
+        ];
+        assert!(config.validate().is_ok());
+    }
+}

--- a/src/sources/windows_event_log/error.rs
+++ b/src/sources/windows_event_log/error.rs
@@ -1,0 +1,249 @@
+use snafu::Snafu;
+
+/// Errors that can occur when working with Windows Event Logs.
+#[derive(Debug, Snafu)]
+pub enum WindowsEventLogError {
+    #[snafu(display("Failed to open event log channel '{}': {}", channel, source))]
+    OpenChannelError {
+        channel: String,
+        source: windows::core::Error,
+    },
+
+    #[snafu(display("Failed to create event subscription: {}", source))]
+    CreateSubscriptionError { source: windows::core::Error },
+
+    #[snafu(display("Failed to query events: {}", source))]
+    QueryEventsError { source: windows::core::Error },
+
+    #[snafu(display("Failed to read event: {}", source))]
+    ReadEventError { source: windows::core::Error },
+
+    #[snafu(display("Failed to render event message: {}", source))]
+    RenderMessageError { source: windows::core::Error },
+
+    #[snafu(display("Failed to parse event XML: {}", source))]
+    ParseXmlError { source: quick_xml::Error },
+
+    #[snafu(display("Invalid XPath query '{}': {}", query, message))]
+    InvalidXPathQuery { query: String, message: String },
+
+    #[snafu(display(
+        "Access denied to channel '{}'. Administrator privileges may be required",
+        channel
+    ))]
+    AccessDeniedError { channel: String },
+
+    #[snafu(display("Channel '{}' not found", channel))]
+    ChannelNotFoundError { channel: String },
+
+    #[snafu(display("I/O error: {}", source))]
+    IoError { source: std::io::Error },
+
+    #[snafu(display("Event filtering error: {}", message))]
+    FilterError { message: String },
+
+    #[snafu(display("Configuration error: {}", message))]
+    ConfigError { message: String },
+
+    #[snafu(display("System resource exhausted: {}", message))]
+    ResourceExhaustedError { message: String },
+
+    #[snafu(display("Operation timeout after {} seconds", timeout_secs))]
+    TimeoutError { timeout_secs: u64 },
+
+    #[snafu(display("Failed to create render context: {}", source))]
+    CreateRenderContextError { source: windows::core::Error },
+
+    #[snafu(display("Failed to format message: {}", message))]
+    FormatMessageError { message: String },
+
+    #[snafu(display("Failed to render event: {}", message))]
+    RenderError { message: String },
+
+    #[snafu(display("Failed to create subscription: {}", source))]
+    SubscriptionError { source: windows::core::Error },
+
+    #[snafu(display("Failed to seek events: {}", source))]
+    SeekEventsError { source: windows::core::Error },
+
+    #[snafu(display("Failed to load publisher metadata for '{}': {}", provider, source))]
+    LoadPublisherMetadataError {
+        provider: String,
+        source: windows::core::Error,
+    },
+
+    #[snafu(display("Failed to pull events from channel '{}': {}", channel, source))]
+    PullEventsError {
+        channel: String,
+        source: windows::core::Error,
+    },
+}
+
+impl WindowsEventLogError {
+    /// Check if the error is recoverable and the operation should be retried.
+    pub const fn is_recoverable(&self) -> bool {
+        match self {
+            // Network/connection issues are typically recoverable
+            Self::QueryEventsError { .. }
+            | Self::ReadEventError { .. }
+            | Self::ResourceExhaustedError { .. }
+            | Self::TimeoutError { .. }
+            | Self::SeekEventsError { .. }
+            | Self::PullEventsError { .. } => true,
+
+            // Configuration and permission issues are not recoverable
+            Self::OpenChannelError { .. }
+            | Self::CreateSubscriptionError { .. }
+            | Self::SubscriptionError { .. }
+            | Self::AccessDeniedError { .. }
+            | Self::ChannelNotFoundError { .. }
+            | Self::InvalidXPathQuery { .. }
+            | Self::ConfigError { .. }
+            | Self::CreateRenderContextError { .. }
+            | Self::LoadPublisherMetadataError { .. } => false,
+
+            // Parsing errors might be recoverable depending on the specific error
+            Self::ParseXmlError { .. }
+            | Self::RenderMessageError { .. }
+            | Self::FormatMessageError { .. }
+            | Self::RenderError { .. } => false,
+
+            // I/O errors could be temporary
+            Self::IoError { .. } => true,
+
+            Self::FilterError { .. } => false,
+        }
+    }
+
+    /// Get a user-friendly error message for logging.
+    pub fn user_message(&self) -> String {
+        match self {
+            Self::AccessDeniedError { channel } => {
+                format!(
+                    "Access denied to event log channel '{}'. Try running Vector as Administrator.",
+                    channel
+                )
+            }
+            Self::ChannelNotFoundError { channel } => {
+                format!(
+                    "Event log channel '{}' not found. Check the channel name and ensure the service is installed.",
+                    channel
+                )
+            }
+            Self::InvalidXPathQuery { query, .. } => {
+                format!("Invalid XPath query '{}'. Check the query syntax.", query)
+            }
+            Self::ResourceExhaustedError { .. } => {
+                "System resources exhausted. Consider reducing batch_size or poll_interval_secs."
+                    .to_string()
+            }
+            Self::TimeoutError { timeout_secs } => {
+                format!(
+                    "Operation timed out after {} seconds. Consider increasing timeout values.",
+                    timeout_secs
+                )
+            }
+            _ => self.to_string(),
+        }
+    }
+}
+
+impl From<quick_xml::Error> for WindowsEventLogError {
+    fn from(error: quick_xml::Error) -> Self {
+        Self::ParseXmlError { source: error }
+    }
+}
+
+// Bookmark persistence is handled via the checkpoint module (JSON-based)
+
+impl From<std::io::Error> for WindowsEventLogError {
+    fn from(error: std::io::Error) -> Self {
+        Self::IoError { source: error }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_recoverability() {
+        let recoverable_errors = vec![
+            WindowsEventLogError::ResourceExhaustedError {
+                message: "test".to_string(),
+            },
+            WindowsEventLogError::TimeoutError { timeout_secs: 30 },
+            WindowsEventLogError::IoError {
+                source: std::io::Error::new(std::io::ErrorKind::TimedOut, "timeout"),
+            },
+        ];
+
+        for error in recoverable_errors {
+            assert!(
+                error.is_recoverable(),
+                "Error should be recoverable: {}",
+                error
+            );
+        }
+
+        let non_recoverable_errors = vec![
+            WindowsEventLogError::AccessDeniedError {
+                channel: "Security".to_string(),
+            },
+            WindowsEventLogError::ChannelNotFoundError {
+                channel: "NonExistent".to_string(),
+            },
+            WindowsEventLogError::InvalidXPathQuery {
+                query: "invalid".to_string(),
+                message: "syntax error".to_string(),
+            },
+            WindowsEventLogError::ConfigError {
+                message: "invalid config".to_string(),
+            },
+        ];
+
+        for error in non_recoverable_errors {
+            assert!(
+                !error.is_recoverable(),
+                "Error should not be recoverable: {}",
+                error
+            );
+        }
+    }
+
+    #[test]
+    fn test_user_messages() {
+        let error = WindowsEventLogError::AccessDeniedError {
+            channel: "Security".to_string(),
+        };
+        assert!(error.user_message().contains("Administrator"));
+
+        let error = WindowsEventLogError::ChannelNotFoundError {
+            channel: "NonExistent".to_string(),
+        };
+        assert!(error.user_message().contains("not found"));
+
+        let error = WindowsEventLogError::InvalidXPathQuery {
+            query: "*[invalid]".to_string(),
+            message: "syntax error".to_string(),
+        };
+        assert!(error.user_message().contains("XPath query"));
+
+        let error = WindowsEventLogError::TimeoutError { timeout_secs: 30 };
+        assert!(error.user_message().contains("timed out"));
+    }
+
+    #[test]
+    fn test_error_conversions() {
+        let xml_error = quick_xml::Error::UnexpectedEof("test".to_string());
+        let converted: WindowsEventLogError = xml_error.into();
+        assert!(matches!(
+            converted,
+            WindowsEventLogError::ParseXmlError { .. }
+        ));
+
+        let io_error = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "test");
+        let converted: WindowsEventLogError = io_error.into();
+        assert!(matches!(converted, WindowsEventLogError::IoError { .. }));
+    }
+}

--- a/src/sources/windows_event_log/integration_tests.rs
+++ b/src/sources/windows_event_log/integration_tests.rs
@@ -1,0 +1,1686 @@
+#![cfg(feature = "sources-windows_event_log-integration-tests")]
+#![cfg(test)]
+
+use std::collections::HashSet;
+use std::process::Command;
+use std::time::Duration;
+
+use futures::StreamExt;
+use tokio::fs;
+
+use super::*;
+use crate::config::{SourceAcknowledgementsConfig, SourceConfig, SourceContext};
+use crate::test_util::components::run_and_assert_source_compliance;
+use vector_lib::event::EventStatus;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Emit a test event into the Application log via `eventcreate.exe`.
+///
+/// Each test should use a unique `source` name (e.g. `"VT_stress"`) to
+/// prevent cross-test pollution when tests run in parallel. The source
+/// name is used as the Provider/@Name in the event, which tests then
+/// filter on via XPath.
+///
+/// Requires administrator privileges. Panics with a clear message if
+/// `eventcreate` is missing or the call fails.
+fn emit_event(source: &str, event_type: &str, event_id: u32, description: &str) {
+    // Retry a few times because eventcreate can transiently fail with exit
+    // code 1 when multiple tests invoke it concurrently (registry contention).
+    let max_retries = 3;
+    for attempt in 0..=max_retries {
+        let status = Command::new("eventcreate")
+            .args([
+                "/L",
+                "Application",
+                "/T",
+                event_type,
+                "/ID",
+                &event_id.to_string(),
+                "/SO",
+                source,
+                "/D",
+                description,
+            ])
+            .status()
+            .unwrap_or_else(|e| {
+                panic!(
+                    "failed to start eventcreate (error: {e}); \
+                     ensure it is on PATH and tests run as Administrator"
+                )
+            });
+
+        if status.success() {
+            return;
+        }
+
+        if attempt < max_retries {
+            std::thread::sleep(Duration::from_millis(200 * (attempt as u64 + 1)));
+        } else {
+            panic!(
+                "eventcreate exited with {status} after {max_retries} retries; \
+                 run tests as Administrator"
+            );
+        }
+    }
+}
+
+fn temp_data_dir() -> tempfile::TempDir {
+    tempfile::tempdir().expect("failed to create temp data_dir for test")
+}
+
+/// XPath query that matches events from a specific test source.
+fn test_query(source: &str) -> String {
+    format!("*[System[Provider[@Name='{source}'] and EventID=1000]]")
+}
+
+/// Build a config targeting Application + a specific test source.
+fn test_config(source: &str, data_dir: &std::path::Path) -> WindowsEventLogConfig {
+    WindowsEventLogConfig {
+        data_dir: Some(data_dir.to_path_buf()),
+        channels: vec!["Application".to_string()],
+        event_query: Some(test_query(source)),
+        read_existing_events: true,
+        batch_size: 100,
+        event_timeout_ms: 2000,
+        ..Default::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Basic ingestion
+// ---------------------------------------------------------------------------
+
+/// Verify the source can subscribe and receive at least one event with all
+/// expected top-level fields present.
+#[tokio::test]
+async fn test_basic_event_ingestion() {
+    let data_dir = temp_data_dir();
+    emit_event("VT_basic", "INFORMATION", 1000, "basic ingestion test");
+
+    let config = WindowsEventLogConfig {
+        data_dir: Some(data_dir.path().to_path_buf()),
+        channels: vec!["System".to_string(), "Application".to_string()],
+        read_existing_events: true,
+        batch_size: 10,
+        ..Default::default()
+    };
+
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
+    assert!(
+        !events.is_empty(),
+        "Expected at least one event from System or Application, got 0. \
+         Verify the Windows Event Log service is running."
+    );
+
+    let log = events[0].as_log();
+    for field in [
+        "timestamp",
+        "message",
+        "provider_name",
+        "channel",
+        "event_id",
+        "level",
+    ] {
+        assert!(
+            log.contains(field),
+            "Event is missing required field '{field}'. \
+             Full event keys: {:?}",
+            log.keys().into_iter().flatten().collect::<Vec<_>>()
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Drain loop / backlog handling
+// ---------------------------------------------------------------------------
+
+/// Emit N events, verify all N arrive with no duplicates.
+/// This exercises the EvtNext drain loop across multiple batches.
+#[tokio::test]
+async fn test_backlog_drain_no_duplicates() {
+    let data_dir = temp_data_dir();
+    let n = 50;
+
+    for i in 0..n {
+        emit_event(
+            "VT_backlog",
+            "INFORMATION",
+            1000,
+            &format!("backlog-drain-test-event-{i}"),
+        );
+    }
+
+    let config = test_config("VT_backlog", data_dir.path());
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(10), &[]).await;
+
+    assert!(
+        events.len() >= n,
+        "Expected at least {n} events, got {}. \
+         The drain loop may not be exhausting the channel. \
+         Check pull_events batch limit and signal management.",
+        events.len()
+    );
+
+    // Check for duplicates via record_id
+    let mut record_ids = HashSet::new();
+    let mut duplicate_count = 0;
+    for event in &events {
+        if let Some(rid) = event.as_log().get("record_id") {
+            if !record_ids.insert(rid.to_string_lossy()) {
+                duplicate_count += 1;
+            }
+        }
+    }
+    assert_eq!(
+        duplicate_count,
+        0,
+        "Found {duplicate_count} duplicate record_ids out of {} events. \
+         Bookmark advancement or checkpoint logic may be broken.",
+        events.len()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Checkpoint / resume
+// ---------------------------------------------------------------------------
+
+/// Run the source, stop it, emit new events, run again with the same
+/// data_dir. The second run should see ONLY the new events.
+#[tokio::test]
+async fn test_checkpoint_resume_no_redelivery() {
+    let data_dir = temp_data_dir();
+
+    // Phase 1: emit and consume
+    emit_event("VT_ckptres", "INFORMATION", 1000, "checkpoint-test-phase1");
+    let config = test_config("VT_ckptres", data_dir.path());
+    let first_run = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
+    assert!(
+        !first_run.is_empty(),
+        "Phase 1 produced 0 events. Cannot test checkpoint resume."
+    );
+    // Let checkpoint flush to disk
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Phase 2: emit one more, reuse same data_dir
+    emit_event("VT_ckptres", "INFORMATION", 1000, "checkpoint-test-phase2");
+    let config = test_config("VT_ckptres", data_dir.path());
+    let second_run = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
+
+    // Phase 1 event should NOT be redelivered (checkpoint should have advanced past it)
+    let has_phase1 = second_run.iter().any(|e| {
+        e.as_log()
+            .get("message")
+            .map(|m| m.to_string_lossy().contains("checkpoint-test-phase1"))
+            .unwrap_or(false)
+    });
+    assert!(
+        !has_phase1,
+        "Phase 1 event was redelivered in phase 2 — checkpoint did not advance. \
+         Check checkpoint persistence in data_dir: {:?}",
+        data_dir.path()
+    );
+
+    // The new phase 2 event should be present
+    let has_phase2 = second_run.iter().any(|e| {
+        e.as_log()
+            .get("message")
+            .map(|m| m.to_string_lossy().contains("checkpoint-test-phase2"))
+            .unwrap_or(false)
+    });
+    assert!(
+        has_phase2,
+        "Phase 2 event not found in second run — checkpoint may have advanced past it. \
+         Got {} events.",
+        second_run.len()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Channel filtering
+// ---------------------------------------------------------------------------
+
+/// Subscribe to System only, verify no Application events leak through.
+#[tokio::test]
+async fn test_channel_isolation() {
+    let data_dir = temp_data_dir();
+    emit_event("VT_chaniso", "INFORMATION", 1000, "channel isolation test"); // goes to Application
+
+    let config = WindowsEventLogConfig {
+        data_dir: Some(data_dir.path().to_path_buf()),
+        channels: vec!["System".to_string()],
+        read_existing_events: true,
+        batch_size: 20,
+        ..Default::default()
+    };
+
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(3), &[]).await;
+
+    for event in &events {
+        if let Some(channel) = event.as_log().get("channel") {
+            let ch = channel.to_string_lossy();
+            assert_eq!(
+                ch, "System",
+                "Got event from channel '{ch}' but only subscribed to System. \
+                 Channel filtering in EvtSubscribe may be broken."
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Event ID filtering
+// ---------------------------------------------------------------------------
+
+/// Verify only_event_ids includes only matching events.
+/// Note: eventcreate.exe only supports IDs 1-1000, so we use 999 and 1000.
+#[tokio::test]
+async fn test_only_event_ids_filter() {
+    let data_dir = temp_data_dir();
+    emit_event("VT_onlyid", "INFORMATION", 999, "only-filter-exclude");
+    emit_event("VT_onlyid", "INFORMATION", 1000, "only-filter-include");
+
+    let config = WindowsEventLogConfig {
+        data_dir: Some(data_dir.path().to_path_buf()),
+        channels: vec!["Application".to_string()],
+        read_existing_events: true,
+        only_event_ids: Some(vec![1000]),
+        event_query: Some("*[System[Provider[@Name='VT_onlyid']]]".to_string()),
+        ..Default::default()
+    };
+
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
+
+    for event in &events {
+        if let Some(eid) = event.as_log().get("event_id") {
+            let id: i64 = match eid {
+                vrl::value::Value::Integer(i) => *i,
+                other => other.to_string_lossy().parse().unwrap_or(-1),
+            };
+            assert_eq!(
+                id, 1000,
+                "only_event_ids=[1000] but got event_id={id}. \
+                 Event ID filtering in parse_event_xml may be broken."
+            );
+        }
+    }
+}
+
+/// Verify ignore_event_ids excludes matching events.
+#[tokio::test]
+async fn test_ignore_event_ids_filter() {
+    let data_dir = temp_data_dir();
+    emit_event("VT_ignid", "INFORMATION", 1000, "ignore-filter-test");
+
+    let config = WindowsEventLogConfig {
+        data_dir: Some(data_dir.path().to_path_buf()),
+        channels: vec!["Application".to_string()],
+        read_existing_events: true,
+        ignore_event_ids: vec![1000],
+        event_query: Some("*[System[Provider[@Name='VT_ignid']]]".to_string()),
+        ..Default::default()
+    };
+
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(3), &[]).await;
+
+    for event in &events {
+        if let Some(eid) = event.as_log().get("event_id") {
+            let id: i64 = match eid {
+                vrl::value::Value::Integer(i) => *i,
+                other => other.to_string_lossy().parse().unwrap_or(-1),
+            };
+            assert_ne!(
+                id, 1000,
+                "ignore_event_ids=[1000] but event_id=1000 was not filtered. \
+                 Check ignore_event_ids logic in parse_event_xml."
+            );
+        }
+    }
+}
+
+/// Verify that only_event_ids generates an XPath filter when no explicit
+/// event_query is set. The existing `test_only_event_ids_filter` always sets
+/// both `only_event_ids` AND `event_query`, so the auto-generated XPath path
+/// in `build_xpath_query()` was never exercised — that is how the original
+/// performance bug shipped.
+///
+/// This test sets only_event_ids=[1000] WITHOUT event_query, so the source
+/// must auto-generate `*[System[EventID=1000]]` and only receive matching
+/// events from the Windows API.
+#[tokio::test]
+async fn test_only_event_ids_generates_xpath_filter() {
+    let data_dir = temp_data_dir();
+
+    // Emit events with different IDs. Only ID 1000 should be returned.
+    emit_event("VT_xpathid", "INFORMATION", 999, "xpath-filter-exclude");
+    emit_event("VT_xpathid", "INFORMATION", 1000, "xpath-filter-include");
+    emit_event("VT_xpathid", "INFORMATION", 998, "xpath-filter-exclude-2");
+
+    let config = WindowsEventLogConfig {
+        data_dir: Some(data_dir.path().to_path_buf()),
+        channels: vec!["Application".to_string()],
+        read_existing_events: true,
+        only_event_ids: Some(vec![1000]),
+        // Intentionally NOT setting event_query — this forces
+        // build_xpath_query() to auto-generate the XPath from only_event_ids.
+        ..Default::default()
+    };
+
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
+
+    // We must receive at least one event (the 1000 we emitted).
+    assert!(
+        !events.is_empty(),
+        "Expected at least one event with ID 1000 from XPath-filtered subscription"
+    );
+
+    // Every event must have event_id == 1000.
+    for event in &events {
+        if let Some(eid) = event.as_log().get("event_id") {
+            let id: i64 = match eid {
+                vrl::value::Value::Integer(i) => *i,
+                other => other.to_string_lossy().parse().unwrap_or(-1),
+            };
+            assert_eq!(
+                id, 1000,
+                "only_event_ids=[1000] (without event_query) but got event_id={id}. \
+                 XPath generation in build_xpath_query may be broken."
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Event level / type variety
+// ---------------------------------------------------------------------------
+
+/// eventcreate supports INFORMATION, WARNING, ERROR. Verify all three produce
+/// events with correct level names.
+#[tokio::test]
+async fn test_multiple_event_levels() {
+    let data_dir = temp_data_dir();
+    emit_event("VT_levels", "INFORMATION", 1000, "level-test-info");
+    emit_event("VT_levels", "WARNING", 1000, "level-test-warn");
+    emit_event("VT_levels", "ERROR", 1000, "level-test-error");
+
+    let config = test_config("VT_levels", data_dir.path());
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
+
+    let mut levels_seen: HashSet<String> = HashSet::new();
+    for event in &events {
+        if let Some(level) = event.as_log().get("level") {
+            levels_seen.insert(level.to_string_lossy().to_string());
+        }
+    }
+
+    for expected in ["Information", "Warning", "Error"] {
+        assert!(
+            levels_seen.contains(expected),
+            "Expected level '{expected}' in output but only saw: {levels_seen:?}. \
+             level_name() mapping or EvtRender may not be extracting Level correctly."
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rendered message
+// ---------------------------------------------------------------------------
+
+/// With render_message enabled (the default), the message field should contain
+/// the actual event description, not the generic fallback.
+#[tokio::test]
+async fn test_rendered_message_content() {
+    let data_dir = temp_data_dir();
+    let marker = "rendered-message-test-unique-string-12345";
+    emit_event("VT_render", "INFORMATION", 1000, marker);
+
+    let mut config = test_config("VT_render", data_dir.path());
+    config.render_message = true;
+
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
+
+    let found = events.iter().any(|e| {
+        e.as_log()
+            .get("message")
+            .map(|m| m.to_string_lossy().contains(marker))
+            .unwrap_or(false)
+    });
+
+    assert!(
+        found,
+        "render_message=true but no event message contains the marker '{marker}'. \
+         EvtFormatMessage may be failing or the message field is using the generic fallback. \
+         Got {} events, first message: {:?}",
+        events.len(),
+        events
+            .first()
+            .and_then(|e| e.as_log().get("message"))
+            .map(|m| m.to_string_lossy())
+    );
+}
+
+/// With render_message disabled, events should still have a message field
+/// (the generic fallback).
+#[tokio::test]
+async fn test_render_message_disabled_fallback() {
+    let data_dir = temp_data_dir();
+    emit_event("VT_noren", "INFORMATION", 1000, "render disabled test");
+
+    let mut config = test_config("VT_noren", data_dir.path());
+    config.render_message = false;
+
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
+
+    if !events.is_empty() {
+        let log = events[0].as_log();
+        assert!(
+            log.contains("message"),
+            "render_message=false should still produce a message field (generic fallback). \
+             Event keys: {:?}",
+            log.keys().into_iter().flatten().collect::<Vec<_>>()
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// XML inclusion
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_include_xml_well_formed() {
+    let data_dir = temp_data_dir();
+    emit_event("VT_xmlinc", "INFORMATION", 1000, "xml inclusion test");
+
+    let mut config = test_config("VT_xmlinc", data_dir.path());
+    config.include_xml = true;
+
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
+    assert!(
+        !events.is_empty(),
+        "Got 0 events, cannot verify XML inclusion."
+    );
+
+    let log = events[0].as_log();
+    let xml = log.get("xml").expect(
+        "include_xml=true but 'xml' field missing. \
+         Check raw_xml population in parse_event_xml.",
+    );
+    let xml_str = xml.to_string_lossy();
+    assert!(
+        xml_str.contains("<Event") && xml_str.contains("</Event>"),
+        "XML field should contain well-formed <Event>...</Event>, got: {}",
+        &xml_str[..xml_str.len().min(200)]
+    );
+}
+
+/// When include_xml is false (default), no xml field should be present.
+#[tokio::test]
+async fn test_exclude_xml_by_default() {
+    let data_dir = temp_data_dir();
+    emit_event("VT_xmlexc", "INFORMATION", 1000, "xml exclusion test");
+
+    let mut config = test_config("VT_xmlexc", data_dir.path());
+    config.include_xml = false;
+
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
+
+    for event in &events {
+        assert!(
+            !event.as_log().contains("xml"),
+            "include_xml=false but 'xml' field is present."
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Field filtering
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_field_filter_exclude_event_data() {
+    let data_dir = temp_data_dir();
+
+    let config = WindowsEventLogConfig {
+        data_dir: Some(data_dir.path().to_path_buf()),
+        channels: vec!["System".to_string()],
+        read_existing_events: true,
+        field_filter: FieldFilter {
+            include_system_fields: true,
+            include_event_data: false,
+            include_user_data: false,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(3), &[]).await;
+
+    for event in events.iter().take(10) {
+        let log = event.as_log();
+        assert!(
+            !log.contains("event_data"),
+            "include_event_data=false but 'event_data' field is present."
+        );
+        assert!(
+            !log.contains("user_data"),
+            "include_user_data=false but 'user_data' field is present."
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Resilience
+// ---------------------------------------------------------------------------
+
+/// Short timeouts should not crash or panic.
+#[tokio::test]
+async fn test_short_timeouts_no_crash() {
+    let data_dir = temp_data_dir();
+    let config = WindowsEventLogConfig {
+        data_dir: Some(data_dir.path().to_path_buf()),
+        channels: vec!["System".to_string(), "Application".to_string()],
+        connection_timeout_secs: 5,
+        event_timeout_ms: 500,
+        batch_size: 5,
+        ..Default::default()
+    };
+
+    // If this panics, the test fails with a clear backtrace.
+    let _events = run_and_assert_source_compliance(config, Duration::from_secs(2), &[]).await;
+}
+
+/// Invalid channel name should not crash — the source should skip it or
+/// return a clear error.
+#[tokio::test]
+async fn test_nonexistent_channel_graceful_handling() {
+    let data_dir = temp_data_dir();
+    let config = WindowsEventLogConfig {
+        data_dir: Some(data_dir.path().to_path_buf()),
+        channels: vec![
+            "Application".to_string(),
+            "ThisChannelDoesNotExist12345".to_string(),
+        ],
+        event_timeout_ms: 2000,
+        ..Default::default()
+    };
+
+    // Should not panic. May produce events from Application only, or may
+    // error on the bad channel — either is acceptable.
+    let _result = run_and_assert_source_compliance(config, Duration::from_secs(3), &[]).await;
+}
+
+// ---------------------------------------------------------------------------
+// Event structure completeness
+// ---------------------------------------------------------------------------
+
+/// Verify all Windows Event Log fields that SOC/SIEM analysts depend on are
+/// present and have reasonable values.
+#[tokio::test]
+async fn test_event_field_completeness() {
+    let data_dir = temp_data_dir();
+    emit_event("VT_fields", "INFORMATION", 1000, "field completeness test");
+
+    let mut config = test_config("VT_fields", data_dir.path());
+    config.include_xml = true;
+
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
+    assert!(
+        !events.is_empty(),
+        "Got 0 events, cannot verify field completeness."
+    );
+
+    let log = events[0].as_log();
+
+    // Fields that must always be present
+    let required = [
+        "timestamp",
+        "message",
+        "event_id",
+        "level",
+        "level_value",
+        "channel",
+        "provider_name",
+        "computer",
+        "record_id",
+        "process_id",
+        "thread_id",
+    ];
+
+    let mut missing = Vec::new();
+    for field in &required {
+        if !log.contains(*field) {
+            missing.push(*field);
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "Event is missing required fields: {missing:?}. \
+         Present fields: {:?}. \
+         This breaks SOC/SIEM ingestion pipelines that depend on these fields.",
+        log.keys().into_iter().flatten().collect::<Vec<_>>()
+    );
+
+    // Verify event_id is a positive integer
+    if let Some(eid) = log.get("event_id") {
+        match eid {
+            vrl::value::Value::Integer(i) => {
+                assert!(*i > 0, "event_id should be a positive integer, got {i}")
+            }
+            other => panic!(
+                "event_id should be an integer, got: {other:?}. \
+                 Check parser set_windows_fields."
+            ),
+        }
+    }
+
+    // Verify record_id is a positive integer
+    if let Some(rid) = log.get("record_id") {
+        match rid {
+            vrl::value::Value::Integer(i) => {
+                assert!(*i > 0, "record_id should be a positive integer, got {i}")
+            }
+            other => panic!("record_id should be an integer, got: {other:?}."),
+        }
+    }
+
+    // Verify level is a human-readable string
+    if let Some(level) = log.get("level") {
+        let level_str = level.to_string_lossy();
+        assert!(
+            ["Information", "Warning", "Error", "Critical", "Verbose"]
+                .contains(&level_str.as_ref()),
+            "level should be a human-readable name, got '{level_str}'. \
+             Check level_name() mapping."
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rate limiting
+// ---------------------------------------------------------------------------
+
+/// With events_per_second set, events should still arrive but the source
+/// should not exceed the configured rate over a sustained period.
+#[tokio::test]
+async fn test_rate_limiting() {
+    let data_dir = temp_data_dir();
+
+    // Emit a burst of events
+    for i in 0..20 {
+        emit_event(
+            "VT_rate",
+            "INFORMATION",
+            1000,
+            &format!("rate-limit-test-{i}"),
+        );
+    }
+
+    let config = WindowsEventLogConfig {
+        data_dir: Some(data_dir.path().to_path_buf()),
+        channels: vec!["Application".to_string()],
+        event_query: Some(test_query("VT_rate")),
+        read_existing_events: true,
+        events_per_second: 50,
+        batch_size: 100,
+        event_timeout_ms: 2000,
+        ..Default::default()
+    };
+
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
+
+    // With rate limiting enabled, we should still get events — the limiter
+    // throttles batch throughput, not total count over the run duration.
+    assert!(
+        !events.is_empty(),
+        "events_per_second=50 should still produce events, got 0. \
+         Rate limiter may be blocking all batches."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Event data truncation
+// ---------------------------------------------------------------------------
+
+/// With max_event_data_length set, long event data values should be truncated.
+#[tokio::test]
+async fn test_event_data_truncation() {
+    let data_dir = temp_data_dir();
+
+    // eventcreate puts the description into the event message, not EventData.
+    // We verify truncation indirectly: the source should not crash and events
+    // should still arrive with the field present.
+    let long_desc = "A".repeat(500);
+    emit_event("VT_trunc", "INFORMATION", 1000, &long_desc);
+
+    let mut config = test_config("VT_trunc", data_dir.path());
+    config.max_event_data_length = 100;
+    config.include_xml = false;
+
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
+
+    assert!(
+        !events.is_empty(),
+        "max_event_data_length=100 should not prevent event ingestion."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Max event age filtering
+// ---------------------------------------------------------------------------
+
+/// With max_event_age_secs set to a very low value, old events should be
+/// filtered out.
+#[tokio::test]
+async fn test_max_event_age_filtering() {
+    let data_dir = temp_data_dir();
+
+    // Emit event, then configure a very short max age so it's already "old"
+    // by the time we read it.
+    emit_event("VT_maxage", "INFORMATION", 1000, "age-filter-test");
+
+    // Sleep so the event ages past the max_event_age_secs threshold.
+    // Use a generous buffer to avoid flakes from clock jitter on slow CI.
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    let config = WindowsEventLogConfig {
+        data_dir: Some(data_dir.path().to_path_buf()),
+        channels: vec!["Application".to_string()],
+        event_query: Some(test_query("VT_maxage")),
+        read_existing_events: true,
+        max_event_age_secs: Some(3), // 3 seconds — our event is already ~5s old
+        event_timeout_ms: 2000,
+        ..Default::default()
+    };
+
+    // This may produce 0 events (filtered) or some events from other sources.
+    // The key assertion: the source should not crash.
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(3), &[]).await;
+
+    // If we got events, verify none of them are our old test event
+    for event in &events {
+        if let Some(msg) = event.as_log().get("message") {
+            assert!(
+                !msg.to_string_lossy().contains("age-filter-test"),
+                "max_event_age_secs=3 but old event was not filtered out. \
+                 Check age filtering in build_event."
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Event data format coercion
+// ---------------------------------------------------------------------------
+
+/// With event_data_format configured, specific fields should be coerced
+/// to the requested type.
+#[tokio::test]
+async fn test_event_data_format_coercion() {
+    let data_dir = temp_data_dir();
+    emit_event("VT_format", "INFORMATION", 1000, "format coercion test");
+
+    let mut config = test_config("VT_format", data_dir.path());
+    config.field_filter.include_event_data = true;
+    // event_id is a system field set as Integer by the parser, so test
+    // that event_data_format can convert it to a string
+    config.event_data_format.insert(
+        "event_id".to_string(),
+        super::config::EventDataFormat::String,
+    );
+
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
+
+    assert!(
+        !events.is_empty(),
+        "event_data_format config should not prevent event ingestion."
+    );
+
+    // event_id should be converted to string by the custom formatter
+    let log = events[0].as_log();
+    if let Some(eid) = log.get("event_id") {
+        assert!(
+            matches!(eid, vrl::value::Value::Bytes(_)),
+            "event_data_format set event_id to String but got {:?}. \
+             Check apply_custom_formatting in parser.",
+            eid
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Multi-channel simultaneous ingestion
+// ---------------------------------------------------------------------------
+
+/// Subscribe to both System and Application, verify events arrive from
+/// both channels.
+#[tokio::test]
+async fn test_multi_channel_ingestion() {
+    let data_dir = temp_data_dir();
+    emit_event("VT_multi", "INFORMATION", 1000, "multi channel test"); // Goes to Application
+
+    let config = WindowsEventLogConfig {
+        data_dir: Some(data_dir.path().to_path_buf()),
+        channels: vec!["System".to_string(), "Application".to_string()],
+        read_existing_events: true,
+        batch_size: 50,
+        event_timeout_ms: 2000,
+        ..Default::default()
+    };
+
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
+
+    let mut channels_seen: HashSet<String> = HashSet::new();
+    for event in &events {
+        if let Some(channel) = event.as_log().get("channel") {
+            channels_seen.insert(channel.to_string_lossy().to_string());
+        }
+    }
+
+    // System always has events on any running Windows machine
+    assert!(
+        channels_seen.contains("System"),
+        "Subscribed to System but got no System events. \
+         Channels seen: {channels_seen:?}"
+    );
+    assert!(
+        channels_seen.contains("Application"),
+        "Subscribed to Application and emitted a test event but got no Application events. \
+         Channels seen: {channels_seen:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Error path / metrics compliance
+// ---------------------------------------------------------------------------
+
+/// When ALL channels are invalid, the source should exit gracefully
+/// without panicking and produce no events.
+#[tokio::test]
+async fn test_all_channels_invalid_no_panic() {
+    let data_dir = temp_data_dir();
+    let config = WindowsEventLogConfig {
+        data_dir: Some(data_dir.path().to_path_buf()),
+        channels: vec!["ThisChannelDoesNotExist99999".to_string()],
+        event_timeout_ms: 1000,
+        ..Default::default()
+    };
+
+    // Build and run the source directly — don't use run_and_assert_source_compliance
+    // since with 0 valid channels we expect 0 events and no compliance metrics.
+    let (tx, _rx) = SourceSender::new_test();
+    let cx = SourceContext::new_test(tx, None);
+    let source = config.build(cx).await.expect("source should build");
+
+    let timeout = tokio::time::timeout(Duration::from_secs(3), source).await;
+
+    // Source should complete (Ok or Err) within the timeout, not hang.
+    assert!(
+        timeout.is_ok(),
+        "Source with all invalid channels should exit promptly, not hang."
+    );
+}
+
+/// Verify that when events are successfully ingested, the standard
+/// component metrics (component_received_events_total,
+/// component_received_bytes_total, etc.) are emitted correctly.
+/// This is the happy-path compliance check with explicit metric verification.
+#[tokio::test]
+async fn test_source_compliance_metrics() {
+    let data_dir = temp_data_dir();
+    emit_event("VT_comply", "INFORMATION", 1000, "compliance metrics test");
+
+    let config = WindowsEventLogConfig {
+        data_dir: Some(data_dir.path().to_path_buf()),
+        channels: vec!["Application".to_string()],
+        read_existing_events: true,
+        batch_size: 50,
+        event_timeout_ms: 2000,
+        ..Default::default()
+    };
+
+    // run_and_assert_source_compliance validates:
+    // - BytesReceived, EventsReceived, EventsSent internal events
+    // - component_received_bytes_total (tagged with protocol)
+    // - component_received_events_total
+    // - component_received_event_bytes_total
+    // - component_sent_events_total
+    // - component_sent_event_bytes_total
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
+
+    assert!(
+        !events.is_empty(),
+        "Compliance test requires at least one event to validate metrics."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Security validation
+// ---------------------------------------------------------------------------
+
+/// Wildcard channel patterns must be rejected at config validation time,
+/// not passed to EvtSubscribe where they can cause heap corruption with
+/// many matching channels.
+#[tokio::test]
+async fn test_wildcard_channels_rejected() {
+    let wildcards = vec!["Microsoft-Windows-*", "*", "System?", "[Ss]ystem"];
+
+    for pattern in wildcards {
+        let config = WindowsEventLogConfig {
+            channels: vec![pattern.to_string()],
+            ..Default::default()
+        };
+
+        let result = config.validate();
+        assert!(
+            result.is_err(),
+            "Wildcard pattern '{pattern}' should be rejected by config validation."
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("wildcard"),
+            "Error for '{pattern}' should mention wildcards, got: {err}"
+        );
+    }
+}
+
+/// XPath injection attempts must be rejected at config validation time.
+#[tokio::test]
+async fn test_xpath_injection_rejected() {
+    let attacks = vec![
+        "javascript:alert('xss')",
+        "*[javascript:eval('code')]",
+        "file:///etc/passwd",
+        "<script>alert(1)</script>",
+    ];
+
+    for attack in attacks {
+        let config = WindowsEventLogConfig {
+            channels: vec!["System".to_string()],
+            event_query: Some(attack.to_string()),
+            ..Default::default()
+        };
+
+        let result = config.validate();
+        assert!(
+            result.is_err(),
+            "XPath injection '{attack}' should be rejected by config validation."
+        );
+    }
+}
+
+/// Channel names with control characters or null bytes must be rejected.
+#[tokio::test]
+async fn test_dangerous_channel_names_rejected() {
+    let dangerous = vec!["System\0", "System\r\nEvil", "System\n"];
+
+    for name in dangerous {
+        let config = WindowsEventLogConfig {
+            channels: vec![name.to_string()],
+            ..Default::default()
+        };
+
+        let result = config.validate();
+        assert!(
+            result.is_err(),
+            "Dangerous channel name '{}' should be rejected.",
+            name.escape_debug()
+        );
+    }
+}
+
+/// Unbalanced XPath brackets/parentheses must be rejected.
+#[tokio::test]
+async fn test_unbalanced_xpath_rejected() {
+    let unbalanced = vec![
+        "*[System[Level=1]",   // missing closing ]
+        "*[System[(Level=1]]", // mismatched
+    ];
+
+    for query in &unbalanced {
+        let config = WindowsEventLogConfig {
+            channels: vec!["System".to_string()],
+            event_query: Some(query.to_string()),
+            ..Default::default()
+        };
+
+        let result = config.validate();
+        assert!(
+            result.is_err(),
+            "Unbalanced XPath '{query}' should be rejected."
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Acknowledgement / checkpoint integrity
+// ---------------------------------------------------------------------------
+
+/// With acknowledgements enabled, checkpoints should only advance after
+/// events are delivered downstream. This is the at-least-once guarantee:
+/// if Vector crashes before the sink acks, the checkpoint hasn't moved,
+/// so events are re-read on restart.
+///
+/// Test approach: run source with acks enabled and EventStatus::Delivered,
+/// then restart with the same data_dir — the second run should skip
+/// already-delivered events (proving checkpoint advanced after ack).
+#[tokio::test]
+async fn test_acknowledgements_checkpoint_after_delivery() {
+    let data_dir = temp_data_dir();
+
+    // Phase 1: emit event, run with acks enabled + Delivered status
+    emit_event("VT_ackdel", "INFORMATION", 1000, "ack-test-phase1");
+
+    {
+        let (tx, mut rx) = SourceSender::new_test_finalize(EventStatus::Delivered);
+        let config = WindowsEventLogConfig {
+            data_dir: Some(data_dir.path().to_path_buf()),
+            channels: vec!["Application".to_string()],
+            event_query: Some(test_query("VT_ackdel")),
+            read_existing_events: true,
+            batch_size: 100,
+            event_timeout_ms: 2000,
+            acknowledgements: SourceAcknowledgementsConfig::from(true),
+            ..Default::default()
+        };
+
+        let cx = SourceContext::new_test(tx, None);
+        let source = config.build(cx).await.expect("source should build");
+
+        let handle = tokio::spawn(source);
+
+        // Collect events for a few seconds
+        let mut event_count = 0;
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            tokio::select! {
+                event = rx.next() => {
+                    if event.is_some() {
+                        event_count += 1;
+                    } else {
+                        break;
+                    }
+                }
+                _ = tokio::time::sleep_until(deadline) => {
+                    break;
+                }
+            }
+        }
+
+        // Abort the source (simulates shutdown)
+        handle.abort();
+        let _ = handle.await;
+
+        assert!(
+            event_count > 0,
+            "Phase 1 with acks=true should produce events."
+        );
+    }
+
+    // Wait for checkpoint flush
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Verify checkpoint file exists
+    // Note: SourceContext::new_test uses ComponentKey "default", and
+    // resolve_and_make_data_subdir appends the component ID as a subdirectory.
+    let checkpoint_path = data_dir
+        .path()
+        .join("default")
+        .join("windows_event_log_checkpoints.json");
+    assert!(
+        checkpoint_path.exists(),
+        "Checkpoint file should exist after acknowledged delivery. \
+         Path: {:?}",
+        checkpoint_path
+    );
+
+    // Phase 2: emit a NEW event, run with same data_dir
+    emit_event("VT_ackdel", "INFORMATION", 1000, "ack-test-phase2");
+    let config = test_config("VT_ackdel", data_dir.path());
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
+
+    // Should NOT see phase1 event again (checkpoint advanced)
+    let has_phase1 = events.iter().any(|e| {
+        e.as_log()
+            .get("message")
+            .map(|m| m.to_string_lossy().contains("ack-test-phase1"))
+            .unwrap_or(false)
+    });
+    assert!(
+        !has_phase1,
+        "Phase 1 events should not be redelivered after acknowledgement. \
+         Checkpoint may not have advanced after ack."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Checkpoint corruption recovery
+// ---------------------------------------------------------------------------
+
+/// If the checkpoint file is corrupted (e.g., power loss mid-write),
+/// the source should start fresh gracefully rather than crash-loop.
+/// This tests the atomic-write recovery path.
+#[tokio::test]
+async fn test_checkpoint_corruption_recovery() {
+    let data_dir = temp_data_dir();
+
+    // Write garbage to the checkpoint file.
+    // Note: SourceContext::new_test uses ComponentKey "default", and
+    // resolve_and_make_data_subdir appends the component ID as a subdirectory.
+    let checkpoint_dir = data_dir.path().join("default");
+    fs::create_dir_all(&checkpoint_dir)
+        .await
+        .expect("should be able to create checkpoint directory");
+    let checkpoint_path = checkpoint_dir.join("windows_event_log_checkpoints.json");
+    fs::write(&checkpoint_path, b"{{{{corrupted json garbage!!! \x00\xff")
+        .await
+        .expect("should be able to write corrupted checkpoint");
+
+    // Emit a test event
+    emit_event(
+        "VT_corrupt",
+        "INFORMATION",
+        1000,
+        "corruption recovery test",
+    );
+
+    let config = WindowsEventLogConfig {
+        data_dir: Some(data_dir.path().to_path_buf()),
+        channels: vec!["Application".to_string()],
+        event_query: Some(test_query("VT_corrupt")),
+        read_existing_events: true,
+        batch_size: 100,
+        event_timeout_ms: 2000,
+        ..Default::default()
+    };
+
+    // Source should start despite corrupted checkpoint and read events
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
+
+    assert!(
+        !events.is_empty(),
+        "Source should recover from corrupted checkpoint and ingest events. \
+         Got 0 events — checkpoint corruption may be causing a crash."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Rejected acknowledgement — checkpoint must NOT advance
+// ---------------------------------------------------------------------------
+
+/// With acknowledgements enabled and EventStatus::Rejected, checkpoints
+/// should NOT advance. This is the other half of at-least-once: if the
+/// sink rejects events, the source must re-read them on restart.
+#[tokio::test]
+async fn test_rejected_ack_does_not_advance_checkpoint() {
+    let data_dir = temp_data_dir();
+
+    // Emit a distinctive event
+    emit_event("VT_rejack", "INFORMATION", 1000, "rejected-ack-test-marker");
+
+    // Phase 1: Run with acks enabled but Rejected status — checkpoint should NOT advance
+    {
+        let (tx, mut rx) = SourceSender::new_test_finalize(EventStatus::Rejected);
+        let config = WindowsEventLogConfig {
+            data_dir: Some(data_dir.path().to_path_buf()),
+            channels: vec!["Application".to_string()],
+            event_query: Some(test_query("VT_rejack")),
+            read_existing_events: true,
+            batch_size: 100,
+            event_timeout_ms: 2000,
+            acknowledgements: SourceAcknowledgementsConfig::from(true),
+            ..Default::default()
+        };
+
+        let cx = SourceContext::new_test(tx, None);
+        let source = config.build(cx).await.expect("source should build");
+        let handle = tokio::spawn(source);
+
+        // Drain events for a few seconds
+        let mut phase1_count = 0;
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            tokio::select! {
+                event = rx.next() => {
+                    if event.is_some() {
+                        phase1_count += 1;
+                    } else {
+                        break;
+                    }
+                }
+                _ = tokio::time::sleep_until(deadline) => {
+                    break;
+                }
+            }
+        }
+
+        handle.abort();
+        let _ = handle.await;
+
+        assert!(
+            phase1_count > 0,
+            "Phase 1 should produce events even with Rejected status."
+        );
+    }
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Phase 2: Run again with same data_dir — should see the SAME events
+    // because checkpoint should not have advanced after rejection
+    let config = test_config("VT_rejack", data_dir.path());
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
+
+    let has_marker = events.iter().any(|e| {
+        let log = e.as_log();
+        // Check message field (rendered message or string_inserts fallback)
+        let in_message = log
+            .get("message")
+            .map(|m| m.to_string_lossy().contains("rejected-ack-test-marker"))
+            .unwrap_or(false);
+        // Also check string_inserts directly in case EvtFormatMessage is unavailable
+        // on this CI runner and the fallback doesn't surface the description.
+        let in_inserts = log
+            .get("string_inserts")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .any(|v| v.to_string_lossy().contains("rejected-ack-test-marker"))
+            })
+            .unwrap_or(false);
+        in_message || in_inserts
+    });
+    assert!(
+        has_marker,
+        "Events should be redelivered after rejected acknowledgement. \
+         Checkpoint may have advanced despite rejection — at-least-once violated. \
+         Got {} events in phase 2.",
+        events.len()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent stress test
+// ---------------------------------------------------------------------------
+
+/// Emit a burst of events and verify all arrive without drops or corruption.
+/// Exercises buffer resizing, batch draining, and checkpoint batching under
+/// heavier load than the basic backlog test.
+#[tokio::test]
+async fn test_stress_burst_ingestion() {
+    let data_dir = temp_data_dir();
+    let n = 200;
+
+    for i in 0..n {
+        emit_event(
+            "VT_stress",
+            "INFORMATION",
+            1000,
+            &format!("stress-test-event-{i}"),
+        );
+    }
+
+    let config = WindowsEventLogConfig {
+        data_dir: Some(data_dir.path().to_path_buf()),
+        channels: vec!["Application".to_string()],
+        event_query: Some(test_query("VT_stress")),
+        read_existing_events: true,
+        batch_size: 50, // Multiple batches required
+        event_timeout_ms: 2000,
+        ..Default::default()
+    };
+
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(15), &[]).await;
+
+    assert!(
+        events.len() >= n,
+        "Expected at least {n} events under burst load, got {}. \
+         Drain loop may be exiting early or losing events under pressure.",
+        events.len()
+    );
+
+    // Verify no duplicates
+    let mut record_ids = HashSet::new();
+    let mut dups = 0;
+    for event in &events {
+        if let Some(rid) = event.as_log().get("record_id") {
+            if !record_ids.insert(rid.to_string_lossy()) {
+                dups += 1;
+            }
+        }
+    }
+    assert_eq!(
+        dups, 0,
+        "Found {dups} duplicate record_ids in {n}-event stress test."
+    );
+
+    // Verify no event has empty/missing critical fields (corruption check)
+    for event in events.iter().take(50) {
+        let log = event.as_log();
+        for field in ["event_id", "record_id", "channel", "provider_name"] {
+            assert!(
+                log.contains(field),
+                "Stress test event missing field '{field}' — possible render corruption."
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Resubscribe after log clear
+// ---------------------------------------------------------------------------
+
+/// Helper: write an event to a custom log channel via PowerShell Write-EventLog.
+fn write_custom_log_event(log_name: &str, source: &str, event_id: u32, message: &str) {
+    let status = Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-Command",
+            &format!(
+                "Write-EventLog -LogName '{}' -Source '{}' -EventId {} -EntryType Information -Message '{}'",
+                log_name, source, event_id, message
+            ),
+        ])
+        .status()
+        .expect("failed to run powershell Write-EventLog");
+    assert!(status.success(), "Write-EventLog failed with {status}");
+}
+
+/// Clear a dedicated custom event log mid-run, verify the source recovers
+/// via resubscription and continues ingesting new events.
+///
+/// Uses a temporary custom log channel (created via PowerShell New-EventLog)
+/// instead of Application, so clearing it doesn't destroy events that other
+/// parallel tests depend on.
+///
+/// Requires Administrator privileges.
+#[tokio::test]
+async fn test_resubscribe_after_log_clear() {
+    let log_name = "VectorTestResub";
+    let source_name = "VT_resub";
+
+    // Create dedicated log channel for this test
+    let create_result = Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-Command",
+            &format!(
+                "if (-not [System.Diagnostics.EventLog]::SourceExists('{source_name}')) {{ \
+                     New-EventLog -LogName '{log_name}' -Source '{source_name}' \
+                 }}"
+            ),
+        ])
+        .status();
+
+    match create_result {
+        Ok(status) if status.success() => {}
+        _ => {
+            // Can't create custom log — skip gracefully
+            return;
+        }
+    }
+
+    // Ensure cleanup on all exit paths
+    struct CleanupGuard {
+        log_name: &'static str,
+    }
+    impl Drop for CleanupGuard {
+        fn drop(&mut self) {
+            let _ = Command::new("powershell")
+                .args([
+                    "-NoProfile",
+                    "-Command",
+                    &format!(
+                        "Remove-EventLog -LogName '{}' -ErrorAction SilentlyContinue",
+                        self.log_name
+                    ),
+                ])
+                .status();
+        }
+    }
+    let _cleanup = CleanupGuard {
+        log_name: "VectorTestResub",
+    };
+
+    let data_dir = temp_data_dir();
+
+    // Emit an initial event into our dedicated channel
+    write_custom_log_event(log_name, source_name, 1000, "pre-clear-event");
+
+    let (tx, mut rx) = SourceSender::new_test_finalize(EventStatus::Delivered);
+    let config = WindowsEventLogConfig {
+        data_dir: Some(data_dir.path().to_path_buf()),
+        channels: vec![log_name.to_string()],
+        read_existing_events: true,
+        batch_size: 100,
+        event_timeout_ms: 1000,
+        acknowledgements: SourceAcknowledgementsConfig::from(true),
+        ..Default::default()
+    };
+
+    let cx = SourceContext::new_test(tx, None);
+    let source = config.build(cx).await.expect("source should build");
+    let handle = tokio::spawn(source);
+
+    // Wait for initial events to be consumed
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    loop {
+        tokio::select! {
+            event = rx.next() => {
+                if event.is_none() {
+                    break;
+                }
+            }
+            _ = tokio::time::sleep_until(deadline) => {
+                break;
+            }
+        }
+    }
+
+    // Clear our dedicated log — does NOT affect Application or other tests
+    let clear_result = Command::new("wevtutil").args(["cl", log_name]).status();
+
+    match clear_result {
+        Ok(status) if status.success() => {
+            // Log was cleared. Emit a new event and verify it arrives.
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            write_custom_log_event(log_name, source_name, 1000, "post-clear-event");
+
+            let mut found_post_clear = false;
+            let deadline = tokio::time::Instant::now() + Duration::from_secs(8);
+            loop {
+                tokio::select! {
+                    event = rx.next() => {
+                        if let Some(event) = event {
+                            if let Some(msg) = event.as_log().get("message") {
+                                if msg.to_string_lossy().contains("post-clear-event") {
+                                    found_post_clear = true;
+                                    break;
+                                }
+                            }
+                        } else {
+                            break;
+                        }
+                    }
+                    _ = tokio::time::sleep_until(deadline) => {
+                        break;
+                    }
+                }
+            }
+
+            handle.abort();
+            let _ = handle.await;
+
+            assert!(
+                found_post_clear,
+                "After log clear, the source should resubscribe and receive new events. \
+                 The post-clear event was not received — resubscribe_channel may be broken."
+            );
+        }
+        _ => {
+            // wevtutil cl failed — skip gracefully
+            handle.abort();
+            let _ = handle.await;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Custom metrics — indirect verification
+// ---------------------------------------------------------------------------
+
+/// Verify that reading events produces the expected checkpoint file,
+/// proving the full data path (EvtNext -> render -> parse -> emit ->
+/// checkpoint) works end-to-end including the metric-instrumented code paths.
+///
+/// Note: Direct custom metric assertions (windows_event_log_events_read_total
+/// etc.) are not feasible without adding metrics-util/debugging as a
+/// dependency. Instead, we verify the observable side effects: events arrive,
+/// checkpoint file is written, and compliance metrics pass.
+#[tokio::test]
+async fn test_full_data_path_produces_checkpoint() {
+    let data_dir = temp_data_dir();
+
+    for i in 0..5 {
+        emit_event(
+            "VT_fullck",
+            "INFORMATION",
+            1000,
+            &format!("checkpoint-path-test-{i}"),
+        );
+    }
+
+    let config = test_config("VT_fullck", data_dir.path());
+    let events = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
+
+    assert!(
+        events.len() >= 5,
+        "Expected at least 5 events, got {}.",
+        events.len()
+    );
+
+    // Wait for checkpoint flush
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Note: SourceContext::new_test uses ComponentKey "default", and
+    // resolve_and_make_data_subdir appends the component ID as a subdirectory.
+    let checkpoint_path = data_dir
+        .path()
+        .join("default")
+        .join("windows_event_log_checkpoints.json");
+    assert!(
+        checkpoint_path.exists(),
+        "Checkpoint file should be written after successful event processing. \
+         This proves the full path: EvtNext -> render -> parse -> emit -> checkpoint."
+    );
+
+    // Verify checkpoint file is valid JSON with expected structure
+    let contents = fs::read_to_string(&checkpoint_path)
+        .await
+        .expect("should read checkpoint file");
+    assert!(
+        contents.contains("\"version\"") && contents.contains("\"channels\""),
+        "Checkpoint file should contain valid JSON with version and channels. \
+         Got: {}",
+        &contents[..contents.len().min(200)]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Checkpoint resume: no duplicate record IDs across runs
+// ---------------------------------------------------------------------------
+
+/// Run the source twice with the same data_dir, emitting distinct events
+/// before each run. Assert that the record_id sets from run 1 and run 2
+/// do not overlap, proving the bookmark/checkpoint correctly prevents
+/// re-delivery.
+#[tokio::test]
+async fn test_checkpoint_resume_no_duplicate_record_ids() {
+    let data_dir = temp_data_dir();
+
+    // Phase 1: emit events and collect record IDs
+    for i in 0..5 {
+        emit_event(
+            "VT_ckptdup",
+            "INFORMATION",
+            1000,
+            &format!("ckpt-dup-test-phase1-{i}"),
+        );
+    }
+
+    let config = test_config("VT_ckptdup", data_dir.path());
+    let first_run = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
+    assert!(
+        !first_run.is_empty(),
+        "Phase 1 produced 0 events. Cannot test checkpoint resume."
+    );
+
+    let first_ids: HashSet<String> = first_run
+        .iter()
+        .filter_map(|e| {
+            e.as_log()
+                .get("record_id")
+                .map(|v| v.to_string_lossy().into_owned())
+        })
+        .collect();
+    assert!(
+        !first_ids.is_empty(),
+        "Phase 1 events have no record_id field. Cannot verify uniqueness."
+    );
+
+    // Let checkpoint flush to disk
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Phase 2: emit new events, reuse same data_dir
+    for i in 0..5 {
+        emit_event(
+            "VT_ckptdup",
+            "INFORMATION",
+            1000,
+            &format!("ckpt-dup-test-phase2-{i}"),
+        );
+    }
+
+    let config = test_config("VT_ckptdup", data_dir.path());
+    let second_run = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
+
+    let second_ids: HashSet<String> = second_run
+        .iter()
+        .filter_map(|e| {
+            e.as_log()
+                .get("record_id")
+                .map(|v| v.to_string_lossy().into_owned())
+        })
+        .collect();
+
+    // Allow a small overlap: the test harness uses a timeout-based shutdown that
+    // can fire between send_batch (events collected) and finalize (checkpoint
+    // written). On multi-core runners, the last in-flight batch may be sent but
+    // not checkpointed, causing re-delivery of up to batch_size events.
+    // The important invariant is that the checkpoint prevents FULL re-delivery.
+    let batch_size = 100; // matches test_config
+    let overlap: HashSet<_> = first_ids.intersection(&second_ids).collect();
+    assert!(
+        overlap.len() <= batch_size,
+        "Found {} duplicate record_ids between run 1 and run 2 (max allowed: {}): {:?}. \
+         Bookmark checkpoint is not preventing re-delivery. \
+         Run 1 had {} IDs, run 2 had {} IDs.",
+        overlap.len(),
+        batch_size,
+        overlap,
+        first_ids.len(),
+        second_ids.len()
+    );
+
+    // But we should still see meaningful checkpoint progress — run 2 must not
+    // re-deliver the entire run 1 set.
+    if !first_ids.is_empty() {
+        assert!(
+            second_ids.len() < first_ids.len() + 10,
+            "Run 2 returned {} events vs run 1's {} — checkpoint may not be advancing at all.",
+            second_ids.len(),
+            first_ids.len()
+        );
+    }
+}

--- a/src/sources/windows_event_log/metadata.rs
+++ b/src/sources/windows_event_log/metadata.rs
@@ -1,0 +1,234 @@
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+
+use lru::LruCache;
+use metrics::Counter;
+use windows::Win32::System::EventLog::{
+    EVT_HANDLE, EvtFormatMessage, EvtFormatMessageEvent, EvtFormatMessageKeyword,
+    EvtFormatMessageOpcode, EvtFormatMessageTask, EvtOpenPublisherMetadata,
+};
+use windows::core::HSTRING;
+
+use super::subscription::{FORMAT_CACHE_CAPACITY, PublisherHandle};
+
+/// Resolves task, opcode, and keyword names from provider metadata via EvtFormatMessage.
+pub fn resolve_event_metadata(
+    publisher_cache: &mut LruCache<String, PublisherHandle>,
+    format_cache: &mut HashMap<String, LruCache<(u32, u64), Option<String>>>,
+    cache_hits_counter: &Counter,
+    cache_misses_counter: &Counter,
+    event_handle: EVT_HANDLE,
+    provider_name: &str,
+    task: u64,
+    opcode: u64,
+    keywords: u64,
+) -> (Option<String>, Option<String>, Vec<String>) {
+    let raw_handle = get_or_open_publisher(publisher_cache, provider_name);
+
+    if raw_handle == 0 {
+        return (None, None, Vec::new());
+    }
+
+    let metadata_handle = EVT_HANDLE(raw_handle);
+
+    let task_flag = EvtFormatMessageTask.0 as u32;
+    let opcode_flag = EvtFormatMessageOpcode.0 as u32;
+    let keyword_flag = EvtFormatMessageKeyword.0 as u32;
+
+    let task_name = cached_format(
+        format_cache,
+        cache_hits_counter,
+        cache_misses_counter,
+        metadata_handle,
+        event_handle,
+        provider_name,
+        task_flag,
+        task,
+    );
+    let opcode_name = cached_format(
+        format_cache,
+        cache_hits_counter,
+        cache_misses_counter,
+        metadata_handle,
+        event_handle,
+        provider_name,
+        opcode_flag,
+        opcode,
+    );
+    let keyword_str = cached_format(
+        format_cache,
+        cache_hits_counter,
+        cache_misses_counter,
+        metadata_handle,
+        event_handle,
+        provider_name,
+        keyword_flag,
+        keywords,
+    );
+
+    let keyword_names = keyword_str
+        .map(|s| {
+            s.split(';')
+                .map(|k| k.trim().to_string())
+                .filter(|k| !k.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    (task_name, opcode_name, keyword_names)
+}
+
+fn get_or_open_publisher(
+    cache: &mut LruCache<String, PublisherHandle>,
+    provider_name: &str,
+) -> isize {
+    if let Some(handle) = cache.get(provider_name) {
+        return handle.0;
+    }
+
+    let provider_hstring = HSTRING::from(provider_name);
+    let raw = unsafe {
+        EvtOpenPublisherMetadata(None, &provider_hstring, None, 0, 0)
+            .map(|h| h.0)
+            .unwrap_or(0)
+    };
+
+    cache.put(provider_name.to_string(), PublisherHandle(raw));
+    raw
+}
+
+/// Two-level cache lookup: outer HashMap keyed by `&str` (zero allocation),
+/// inner LRU keyed by `(flag, field_value)`.
+fn cached_format(
+    cache: &mut HashMap<String, LruCache<(u32, u64), Option<String>>>,
+    cache_hits_counter: &Counter,
+    cache_misses_counter: &Counter,
+    metadata_handle: EVT_HANDLE,
+    event_handle: EVT_HANDLE,
+    provider: &str,
+    flag: u32,
+    field_value: u64,
+) -> Option<String> {
+    let inner_key = (flag, field_value);
+
+    // Fast path: borrowed &str lookup on outer HashMap — zero allocation.
+    // peek() intentionally skips LRU promotion — get() requires &mut which
+    // would need get_mut() on the outer HashMap. The put() on every miss
+    // already handles insertion/promotion, so peek is correct here.
+    if let Some(inner) = cache.get(provider) {
+        if let Some(cached) = inner.peek(&inner_key) {
+            cache_hits_counter.increment(1);
+            return cached.clone();
+        }
+    }
+
+    // Slow path: call API and populate cache
+    cache_misses_counter.increment(1);
+    let result = format_metadata_field(metadata_handle, event_handle, flag);
+    let inner = cache
+        .entry(provider.to_string())
+        .or_insert_with(|| LruCache::new(NonZeroUsize::new(FORMAT_CACHE_CAPACITY).unwrap()));
+    inner.put(inner_key, result.clone());
+    result
+}
+
+fn format_metadata_field(
+    metadata_handle: EVT_HANDLE,
+    event_handle: EVT_HANDLE,
+    flags: u32,
+) -> Option<String> {
+    let mut buffer_used: u32 = 0;
+    let _ = unsafe {
+        EvtFormatMessage(
+            metadata_handle,
+            event_handle,
+            0,
+            None,
+            flags,
+            None,
+            &mut buffer_used,
+        )
+    };
+
+    if buffer_used == 0 || buffer_used > 4096 {
+        return None;
+    }
+
+    let mut buffer = vec![0u16; buffer_used as usize];
+    let mut actual_used: u32 = 0;
+    let result = unsafe {
+        EvtFormatMessage(
+            metadata_handle,
+            event_handle,
+            0,
+            None,
+            flags,
+            Some(&mut buffer),
+            &mut actual_used,
+        )
+    };
+
+    if result.is_err() {
+        return None;
+    }
+
+    let len = buffer.iter().position(|&c| c == 0).unwrap_or(buffer.len());
+    let s = String::from_utf16_lossy(&buffer[..len]);
+    if s.is_empty() { None } else { Some(s) }
+}
+
+/// Renders a human-readable event message using the Windows EvtFormatMessage API.
+pub fn format_event_message(
+    publisher_cache: &mut LruCache<String, PublisherHandle>,
+    event_handle: EVT_HANDLE,
+    provider_name: &str,
+) -> Option<String> {
+    let raw_handle = get_or_open_publisher(publisher_cache, provider_name);
+
+    if raw_handle == 0 {
+        return None;
+    }
+
+    let metadata_handle = EVT_HANDLE(raw_handle);
+    let flags = EvtFormatMessageEvent.0 as u32;
+    let max_size = 64 * 1024;
+
+    let mut buffer_used: u32 = 0;
+    let _ = unsafe {
+        EvtFormatMessage(
+            metadata_handle,
+            event_handle,
+            0,
+            None,
+            flags,
+            None,
+            &mut buffer_used,
+        )
+    };
+
+    if buffer_used == 0 || buffer_used as usize > max_size {
+        return None;
+    }
+
+    let mut buffer = vec![0u16; buffer_used as usize];
+    let mut actual_used: u32 = 0;
+    let result = unsafe {
+        EvtFormatMessage(
+            metadata_handle,
+            event_handle,
+            0,
+            None,
+            flags,
+            Some(&mut buffer),
+            &mut actual_used,
+        )
+    };
+
+    if result.is_err() {
+        return None;
+    }
+
+    let len = buffer.iter().position(|&c| c == 0).unwrap_or(buffer.len());
+    let s = String::from_utf16_lossy(&buffer[..len]);
+    if s.is_empty() { None } else { Some(s) }
+}

--- a/src/sources/windows_event_log/mod.rs
+++ b/src/sources/windows_event_log/mod.rs
@@ -1,0 +1,593 @@
+use async_trait::async_trait;
+use vector_lib::config::LogNamespace;
+use vrl::value::{Kind, kind::Collection};
+
+use vector_config::component::SourceDescription;
+
+use crate::config::{DataType, SourceConfig, SourceContext, SourceOutput};
+
+// Cross-platform: config types (pure serde structs, no Windows dependencies)
+mod config;
+pub use self::config::*;
+
+cfg_if::cfg_if! {
+    if #[cfg(windows)] {
+        mod bookmark;
+        mod checkpoint;
+        pub mod error;
+        mod metadata;
+        mod parser;
+        mod render;
+        mod sid_resolver;
+        mod subscription;
+        mod xml_parser;
+
+        use std::path::PathBuf;
+        use std::sync::Arc;
+
+        use futures::StreamExt;
+        use vector_lib::EstimatedJsonEncodedSizeOf;
+        use vector_lib::finalizer::OrderedFinalizer;
+        use vector_lib::internal_event::{
+            ByteSize, BytesReceived, CountByteSize, InternalEventHandle as _, Protocol,
+        };
+        use windows::Win32::Foundation::{DUPLICATE_SAME_ACCESS, DuplicateHandle, HANDLE};
+        use windows::Win32::System::Threading::GetCurrentProcess;
+
+        use crate::{
+            SourceSender,
+            event::{BatchNotifier, BatchStatus, BatchStatusReceiver},
+            internal_events::{
+                EventsReceived, StreamClosedError, WindowsEventLogParseError, WindowsEventLogQueryError,
+            },
+            shutdown::ShutdownSignal,
+        };
+
+        use self::{
+            checkpoint::Checkpointer,
+            error::WindowsEventLogError,
+            parser::EventLogParser,
+            subscription::{EventLogSubscription, WaitResult},
+        };
+    }
+}
+
+#[cfg(all(test, windows))]
+mod tests;
+
+// Integration tests are feature-gated to avoid requiring Windows Event Log service.
+// To run integration tests on Windows: cargo test --features sources-windows_event_log-integration-tests
+#[cfg(all(test, windows, feature = "sources-windows_event_log-integration-tests"))]
+mod integration_tests;
+
+cfg_if::cfg_if! {
+if #[cfg(windows)] {
+
+/// Entry for the acknowledgment finalizer containing checkpoint information.
+/// Each entry represents a batch of events that need to be acknowledged before
+/// the checkpoint can be safely updated. Contains all channel bookmarks from
+/// the batch since a single batch may span multiple channels.
+#[derive(Debug, Clone)]
+struct FinalizerEntry {
+    /// Channel bookmarks: (channel_name, bookmark_xml) pairs
+    bookmarks: Vec<(String, String)>,
+}
+
+/// Shared checkpointer type for use with the finalizer
+type SharedCheckpointer = Arc<Checkpointer>;
+
+/// Finalizer for handling acknowledgments.
+/// Supports both synchronous (immediate checkpoint) and asynchronous (deferred checkpoint) modes.
+enum Finalizer {
+    /// Synchronous mode: checkpoints are updated immediately after reading events.
+    /// Used when acknowledgements are disabled.
+    Sync(SharedCheckpointer),
+    /// Asynchronous mode: checkpoints are updated only after downstream sinks acknowledge receipt.
+    /// Used when acknowledgements are enabled.
+    Async(OrderedFinalizer<FinalizerEntry>),
+}
+
+impl Finalizer {
+    /// Create a new finalizer based on acknowledgement configuration.
+    fn new(
+        acknowledgements: bool,
+        checkpointer: SharedCheckpointer,
+        shutdown: ShutdownSignal,
+    ) -> Self {
+        if acknowledgements {
+            let (finalizer, mut ack_stream) =
+                OrderedFinalizer::<FinalizerEntry>::new(Some(shutdown.clone()));
+
+            // Spawn background task to process acknowledgments and update checkpoints
+            tokio::spawn(async move {
+                while let Some((status, entry)) = ack_stream.next().await {
+                    if status == BatchStatus::Delivered {
+                        if let Err(e) = checkpointer.set_batch(entry.bookmarks.clone()).await {
+                            warn!(
+                                message = "Failed to update checkpoint after acknowledgement.",
+                                error = %e
+                            );
+                        } else {
+                            debug!(
+                                message = "Checkpoint updated after acknowledgement.",
+                                channels = entry.bookmarks.len()
+                            );
+                        }
+                    } else {
+                        debug!(
+                            message = "Events not delivered, checkpoint not updated.",
+                            status = ?status
+                        );
+                    }
+                }
+                debug!(message = "Acknowledgement stream completed.");
+            });
+
+            Self::Async(finalizer)
+        } else {
+            Self::Sync(checkpointer)
+        }
+    }
+
+    /// Finalize a batch of events.
+    /// In sync mode, immediately updates the checkpoint.
+    /// In async mode, registers the entry for deferred checkpoint update.
+    async fn finalize(&self, entry: FinalizerEntry, receiver: Option<BatchStatusReceiver>) {
+        match (self, receiver) {
+            (Self::Sync(checkpointer), None) => {
+                if let Err(e) = checkpointer.set_batch(entry.bookmarks.clone()).await {
+                    warn!(
+                        message = "Failed to update checkpoint.",
+                        error = %e
+                    );
+                }
+            }
+            (Self::Async(finalizer), Some(receiver)) => {
+                finalizer.add(entry, receiver);
+            }
+            (Self::Sync(_), Some(_)) => {
+                warn!(message = "Received acknowledgement receiver in sync mode, ignoring.");
+            }
+            (Self::Async(_), None) => {
+                warn!(
+                    message = "No acknowledgement receiver in async mode, checkpoint may be lost."
+                );
+            }
+        }
+    }
+}
+
+/// Windows Event Log source implementation
+pub struct WindowsEventLogSource {
+    config: WindowsEventLogConfig,
+    data_dir: PathBuf,
+    acknowledgements: bool,
+    log_namespace: LogNamespace,
+}
+
+impl WindowsEventLogSource {
+    pub fn new(
+        config: WindowsEventLogConfig,
+        data_dir: PathBuf,
+        acknowledgements: bool,
+        log_namespace: LogNamespace,
+    ) -> crate::Result<Self> {
+        config.validate()?;
+
+        Ok(Self {
+            config,
+            data_dir,
+            acknowledgements,
+            log_namespace,
+        })
+    }
+
+    async fn run_internal(
+        &mut self,
+        mut out: SourceSender,
+        shutdown: ShutdownSignal,
+    ) -> Result<(), WindowsEventLogError> {
+        let checkpointer = Arc::new(Checkpointer::new(&self.data_dir).await?);
+
+        let finalizer = Finalizer::new(
+            self.acknowledgements,
+            Arc::clone(&checkpointer),
+            shutdown.clone(),
+        );
+
+        let mut subscription = EventLogSubscription::new(
+            &self.config,
+            Arc::clone(&checkpointer),
+            self.acknowledgements,
+        )
+        .await?;
+        let parser = EventLogParser::new(&self.config, self.log_namespace);
+
+        let events_received = register!(EventsReceived);
+        let bytes_received = register!(BytesReceived::from(Protocol::from("windows_event_log")));
+
+        let timeout_ms = self.config.event_timeout_ms as u32;
+        let batch_size = self.config.batch_size as usize;
+        let acknowledgements = self.acknowledgements;
+
+        info!(
+            message = "Starting Windows Event Log source (pull mode).",
+            acknowledgements = acknowledgements,
+        );
+
+        // Spawn async shutdown watcher that signals the Windows shutdown event
+        // when the Vector shutdown signal fires. This wakes WaitForMultipleObjects
+        // while subscription is moved into spawn_blocking.
+        //
+        // We duplicate the handle so the watcher owns an independent kernel reference.
+        // This prevents use-after-close if the subscription panics and drops before
+        // the watcher fires — the duplicate remains valid until explicitly closed.
+        let (watcher_handle_raw, watcher_owns_handle): (isize, bool) = {
+            unsafe {
+                let src = HANDLE(subscription.shutdown_event_raw());
+                let process = GetCurrentProcess();
+                let mut dup = HANDLE::default();
+                if DuplicateHandle(
+                    process,
+                    src,
+                    process,
+                    &mut dup,
+                    0,
+                    false,
+                    DUPLICATE_SAME_ACCESS,
+                )
+                .is_ok()
+                {
+                    (dup.0 as isize, true)
+                } else {
+                    // Fallback: use the original handle without ownership.
+                    // The watcher will signal but NOT close — EventLogSubscription::drop
+                    // owns the handle and will close it.
+                    warn!(
+                        message = "Failed to duplicate shutdown event handle, falling back to shared handle."
+                    );
+                    (src.0 as isize, false)
+                }
+            }
+        };
+        let shutdown_watcher = shutdown.clone();
+        tokio::spawn(async move {
+            shutdown_watcher.await;
+            unsafe {
+                let handle =
+                    windows::Win32::Foundation::HANDLE(watcher_handle_raw as *mut std::ffi::c_void);
+                let _ = windows::Win32::System::Threading::SetEvent(handle);
+                if watcher_owns_handle {
+                    let _ = windows::Win32::Foundation::CloseHandle(handle);
+                }
+            }
+        });
+
+        // Track when we last flushed checkpoints
+        let mut last_checkpoint = std::time::Instant::now();
+        let checkpoint_interval =
+            std::time::Duration::from_secs(self.config.checkpoint_interval_secs);
+
+        // Exponential backoff on consecutive recoverable errors
+        let mut error_backoff = std::time::Duration::from_millis(100);
+        const MAX_ERROR_BACKOFF: std::time::Duration = std::time::Duration::from_secs(5);
+
+        // Health heartbeat: log every ~30s regardless of checkpoint interval
+        let mut timeout_count: u32 = 0;
+        let health_interval_timeouts = (30_000 / self.config.event_timeout_ms).max(1) as u32;
+
+        loop {
+            // Move subscription into blocking thread for WaitForMultipleObjects.
+            // Ownership transfer ensures no data races between the blocking thread
+            // and async code. The shutdown watcher uses a raw HANDLE value (just an
+            // integer) to signal shutdown without needing access to the subscription.
+            let (returned_sub, wait_result) = tokio::task::spawn_blocking({
+                let sub = subscription;
+                move || {
+                    let result = sub.wait_for_events_blocking(timeout_ms);
+                    (sub, result)
+                }
+            })
+            .await
+            .map_err(|e| WindowsEventLogError::ConfigError {
+                message: format!("Wait task panicked: {e}"),
+            })?;
+
+            subscription = returned_sub;
+
+            match wait_result {
+                WaitResult::EventsAvailable => {
+                    // Pull events via spawn_blocking (EvtNext/EvtRender are blocking APIs)
+                    let (returned_sub, events_result) = tokio::task::spawn_blocking({
+                        let mut sub = subscription;
+                        move || {
+                            let result = sub.pull_events(batch_size);
+                            (sub, result)
+                        }
+                    })
+                    .await
+                    .map_err(|e| WindowsEventLogError::ConfigError {
+                        message: format!("Pull task panicked: {e}"),
+                    })?;
+
+                    subscription = returned_sub;
+
+                    // Rate limiting between batches (async-compatible)
+                    if let Some(limiter) = subscription.rate_limiter() {
+                        limiter.until_ready().await;
+                    }
+
+                    match events_result {
+                        Ok(events) if events.is_empty() => {
+                            error_backoff = std::time::Duration::from_millis(100);
+                            continue;
+                        }
+                        Ok(events) => {
+                            error_backoff = std::time::Duration::from_millis(100);
+                            debug!(
+                                message = "Pulled Windows Event Log events.",
+                                event_count = events.len()
+                            );
+
+                            let (batch, receiver) =
+                                BatchNotifier::maybe_new_with_receiver(acknowledgements);
+
+                            let mut log_events = Vec::new();
+                            let mut total_byte_size = 0;
+                            let mut channels_in_batch = std::collections::HashSet::new();
+
+                            for event in events {
+                                let channel = event.channel.clone();
+                                channels_in_batch.insert(channel.clone());
+                                let event_id = event.event_id;
+                                match parser.parse_event(event) {
+                                    Ok(mut log_event) => {
+                                        let byte_size = log_event.estimated_json_encoded_size_of();
+                                        total_byte_size += byte_size.get();
+
+                                        if let Some(ref batch) = batch {
+                                            log_event = log_event.with_batch_notifier(batch);
+                                        }
+
+                                        log_events.push(log_event);
+                                    }
+                                    Err(e) => {
+                                        emit!(WindowsEventLogParseError {
+                                            error: e.to_string(),
+                                            channel,
+                                            event_id: Some(event_id),
+                                        });
+                                    }
+                                }
+                            }
+
+                            if !log_events.is_empty() {
+                                let count = log_events.len();
+                                events_received.emit(CountByteSize(count, total_byte_size.into()));
+                                bytes_received.emit(ByteSize(total_byte_size));
+
+                                // BACK PRESSURE: block here until the pipeline accepts
+                                // the batch. We don't call EvtNext again until this completes.
+                                if let Err(_error) = out.send_batch(log_events).await {
+                                    emit!(StreamClosedError { count });
+                                    break;
+                                }
+
+                                // Register checkpoint entry with finalizer
+                                let bookmarks: Vec<(String, String)> = channels_in_batch
+                                    .into_iter()
+                                    .filter_map(|channel| {
+                                        subscription
+                                            .get_bookmark_xml(&channel)
+                                            .map(|xml| (channel, xml))
+                                    })
+                                    .collect();
+
+                                if !bookmarks.is_empty() {
+                                    let entry = FinalizerEntry { bookmarks };
+                                    finalizer.finalize(entry, receiver).await;
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            emit!(WindowsEventLogQueryError {
+                                channel: "all".to_string(),
+                                query: None,
+                                error: e.to_string(),
+                            });
+                            if !e.is_recoverable() {
+                                error!(
+                                    message = "Non-recoverable pull error, shutting down.",
+                                    error = %e
+                                );
+                                break;
+                            }
+                            // Exponential backoff on consecutive recoverable errors
+                            warn!(
+                                message = "Recoverable pull error, backing off.",
+                                backoff_ms = error_backoff.as_millis() as u64,
+                                error = %e
+                            );
+                            tokio::time::sleep(error_backoff).await;
+                            error_backoff = (error_backoff * 2).min(MAX_ERROR_BACKOFF);
+                        }
+                    }
+                }
+
+                WaitResult::Timeout => {
+                    // A full wait cycle without errors means the system is healthy;
+                    // reset backoff so the next transient error starts fresh.
+                    error_backoff = std::time::Duration::from_millis(100);
+
+                    // Periodic checkpoint flush (sync mode only)
+                    if !acknowledgements && last_checkpoint.elapsed() >= checkpoint_interval {
+                        if let Err(e) = subscription.flush_bookmarks().await {
+                            warn!(
+                                message = "Failed to flush bookmarks during periodic checkpoint.",
+                                error = %e
+                            );
+                        }
+                        last_checkpoint = std::time::Instant::now();
+                    }
+
+                    // Health heartbeat on a separate ~30s cadence
+                    timeout_count += 1;
+                    if timeout_count >= health_interval_timeouts {
+                        timeout_count = 0;
+                        let (total, active) = subscription.channel_health_summary();
+                        if active < total {
+                            warn!(
+                                message = "Some channel subscriptions are inactive.",
+                                total_channels = total,
+                                active_channels = active,
+                            );
+                        } else {
+                            debug!(
+                                message = "All channel subscriptions healthy.",
+                                total_channels = total,
+                            );
+                        }
+                    }
+                }
+
+                WaitResult::Shutdown => {
+                    info!(message = "Windows Event Log wait received shutdown signal.");
+                    if !acknowledgements {
+                        info!(message = "Flushing bookmarks before shutdown.");
+                        if let Err(e) = subscription.flush_bookmarks().await {
+                            warn!(message = "Failed to flush bookmarks on shutdown.", error = %e);
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+} // if #[cfg(windows)]
+} // cfg_if!
+
+#[async_trait]
+#[typetag::serde(name = "windows_event_log")]
+impl SourceConfig for WindowsEventLogConfig {
+    async fn build(&self, _cx: SourceContext) -> crate::Result<super::Source> {
+        #[cfg(not(windows))]
+        {
+            Err("The windows_event_log source is only supported on Windows.".into())
+        }
+
+        #[cfg(windows)]
+        {
+            let data_dir = _cx
+                .globals
+                .resolve_and_make_data_subdir(self.data_dir.as_ref(), _cx.key.id())?;
+
+            let acknowledgements = _cx.do_acknowledgements(self.acknowledgements);
+
+            let log_namespace = _cx.log_namespace(self.log_namespace);
+            let source = WindowsEventLogSource::new(
+                self.clone(),
+                data_dir,
+                acknowledgements,
+                log_namespace,
+            )?;
+            Ok(Box::pin(async move {
+                let mut source = source;
+                if let Err(error) = source.run_internal(_cx.out, _cx.shutdown).await {
+                    error!(message = "Windows Event Log source failed.", %error);
+                }
+                Ok(())
+            }))
+        }
+    }
+
+    fn outputs(&self, global_log_namespace: LogNamespace) -> Vec<SourceOutput> {
+        let log_namespace = self
+            .log_namespace
+            .map(|b| {
+                if b {
+                    LogNamespace::Vector
+                } else {
+                    LogNamespace::Legacy
+                }
+            })
+            .unwrap_or(global_log_namespace);
+
+        let schema_definition = match log_namespace {
+            LogNamespace::Vector => vector_lib::schema::Definition::new_with_default_metadata(
+                Kind::object(std::collections::BTreeMap::from([
+                    ("timestamp".into(), Kind::timestamp().or_undefined()),
+                    ("message".into(), Kind::bytes().or_undefined()),
+                    ("level".into(), Kind::bytes().or_undefined()),
+                    ("source".into(), Kind::bytes().or_undefined()),
+                    ("event_id".into(), Kind::integer().or_undefined()),
+                    ("provider_name".into(), Kind::bytes().or_undefined()),
+                    ("computer".into(), Kind::bytes().or_undefined()),
+                    ("user_id".into(), Kind::bytes().or_undefined()),
+                    ("user_name".into(), Kind::bytes().or_undefined()),
+                    ("record_id".into(), Kind::integer().or_undefined()),
+                    ("activity_id".into(), Kind::bytes().or_undefined()),
+                    ("related_activity_id".into(), Kind::bytes().or_undefined()),
+                    ("process_id".into(), Kind::integer().or_undefined()),
+                    ("thread_id".into(), Kind::integer().or_undefined()),
+                    ("channel".into(), Kind::bytes().or_undefined()),
+                    ("opcode".into(), Kind::integer().or_undefined()),
+                    ("task".into(), Kind::integer().or_undefined()),
+                    ("keywords".into(), Kind::bytes().or_undefined()),
+                    ("level_value".into(), Kind::integer().or_undefined()),
+                    ("provider_guid".into(), Kind::bytes().or_undefined()),
+                    ("version".into(), Kind::integer().or_undefined()),
+                    ("qualifiers".into(), Kind::integer().or_undefined()),
+                    (
+                        "string_inserts".into(),
+                        Kind::array(Collection::empty().with_unknown(Kind::bytes())).or_undefined(),
+                    ),
+                    (
+                        "event_data".into(),
+                        Kind::object(std::collections::BTreeMap::new()).or_undefined(),
+                    ),
+                    (
+                        "user_data".into(),
+                        Kind::object(std::collections::BTreeMap::new()).or_undefined(),
+                    ),
+                    ("task_name".into(), Kind::bytes().or_undefined()),
+                    ("opcode_name".into(), Kind::bytes().or_undefined()),
+                    (
+                        "keyword_names".into(),
+                        Kind::array(Collection::empty().with_unknown(Kind::bytes())).or_undefined(),
+                    ),
+                ])),
+                [LogNamespace::Vector],
+            ),
+            LogNamespace::Legacy => vector_lib::schema::Definition::any(),
+        };
+
+        vec![SourceOutput::new_maybe_logs(
+            DataType::Log,
+            schema_definition,
+        )]
+    }
+
+    fn resources(&self) -> Vec<crate::config::Resource> {
+        self.channels
+            .iter()
+            .map(|channel| crate::config::Resource::DiskBuffer(channel.clone()))
+            .collect()
+    }
+
+    fn can_acknowledge(&self) -> bool {
+        true
+    }
+}
+
+inventory::submit! {
+    SourceDescription::new::<WindowsEventLogConfig>(
+        "windows_event_log",
+        "Collect logs from Windows Event Log channels",
+        "A Windows-specific source that subscribes to Windows Event Log channels and streams events in real-time using the Windows Event Log API.",
+        "https://vector.dev/docs/reference/configuration/sources/windows_event_log/"
+    )
+}

--- a/src/sources/windows_event_log/mod.rs
+++ b/src/sources/windows_event_log/mod.rs
@@ -25,6 +25,7 @@ cfg_if::cfg_if! {
         use std::path::PathBuf;
         use std::sync::Arc;
 
+        use chrono::Utc;
         use futures::StreamExt;
         use vector_lib::EstimatedJsonEncodedSizeOf;
         use vector_lib::finalizer::OrderedFinalizer;
@@ -166,6 +167,7 @@ impl Finalizer {
 async fn process_event_batch(
     events: Vec<WindowsEvent>,
     parser: &EventLogParser,
+    log_namespace: LogNamespace,
     acknowledgements: bool,
     subscription: &EventLogSubscription,
     out: &mut SourceSender,
@@ -189,6 +191,12 @@ async fn process_event_batch(
         let event_id = event.event_id;
         match parser.parse_event(event) {
             Ok(mut log_event) => {
+                log_namespace.insert_standard_vector_source_metadata(
+                    &mut log_event,
+                    WindowsEventLogConfig::NAME,
+                    Utc::now(),
+                );
+
                 let byte_size = log_event.estimated_json_encoded_size_of();
                 total_byte_size += byte_size.get();
                 if let Some(ref batch) = batch {
@@ -416,6 +424,7 @@ impl WindowsEventLogSource {
                             if process_event_batch(
                                 events,
                                 &parser,
+                                self.log_namespace,
                                 acknowledgements,
                                 &subscription,
                                 &mut out,
@@ -516,6 +525,7 @@ impl WindowsEventLogSource {
                             if process_event_batch(
                                 events,
                                 &parser,
+                                self.log_namespace,
                                 acknowledgements,
                                 &subscription,
                                 &mut out,
@@ -664,8 +674,11 @@ impl SourceConfig for WindowsEventLogConfig {
                     ),
                 ])),
                 [LogNamespace::Vector],
-            ),
-            LogNamespace::Legacy => vector_lib::schema::Definition::any(),
+            )
+            .with_standard_vector_source_metadata(),
+            LogNamespace::Legacy => {
+                vector_lib::schema::Definition::any().with_standard_vector_source_metadata()
+            }
         };
 
         vec![SourceOutput::new_maybe_logs(

--- a/src/sources/windows_event_log/mod.rs
+++ b/src/sources/windows_event_log/mod.rs
@@ -29,7 +29,7 @@ cfg_if::cfg_if! {
         use vector_lib::EstimatedJsonEncodedSizeOf;
         use vector_lib::finalizer::OrderedFinalizer;
         use vector_lib::internal_event::{
-            ByteSize, BytesReceived, CountByteSize, InternalEventHandle as _, Protocol,
+            ByteSize, BytesReceived, CountByteSize, InternalEventHandle, Protocol,
         };
         use windows::Win32::Foundation::{DUPLICATE_SAME_ACCESS, DuplicateHandle, HANDLE};
         use windows::Win32::System::Threading::GetCurrentProcess;
@@ -48,6 +48,7 @@ cfg_if::cfg_if! {
             error::WindowsEventLogError,
             parser::EventLogParser,
             subscription::{EventLogSubscription, WaitResult},
+            xml_parser::WindowsEvent,
         };
     }
 }
@@ -155,6 +156,107 @@ impl Finalizer {
             }
         }
     }
+}
+
+/// Parse, emit metrics for, send, and finalize a non-empty batch of pulled Windows events.
+///
+/// Both the `EventsAvailable` path and the speculative-timeout path share this
+/// logic. Returns `true` if the downstream pipeline closed and the caller
+/// should break out of the main event loop.
+async fn process_event_batch(
+    events: Vec<WindowsEvent>,
+    parser: &EventLogParser,
+    acknowledgements: bool,
+    subscription: &EventLogSubscription,
+    out: &mut SourceSender,
+    finalizer: &Finalizer,
+    events_received: &impl InternalEventHandle<Data = CountByteSize>,
+    bytes_received: &impl InternalEventHandle<Data = ByteSize>,
+) -> bool {
+    // Rate limiting between batches (async-compatible).
+    if let Some(limiter) = subscription.rate_limiter() {
+        limiter.until_ready().await;
+    }
+
+    let (batch, receiver) = BatchNotifier::maybe_new_with_receiver(acknowledgements);
+    let mut log_events = Vec::new();
+    let mut total_byte_size = 0usize;
+    let mut channels_in_batch = std::collections::HashSet::new();
+
+    for event in events {
+        let channel = event.channel.clone();
+        channels_in_batch.insert(channel.clone());
+        let event_id = event.event_id;
+        match parser.parse_event(event) {
+            Ok(mut log_event) => {
+                let byte_size = log_event.estimated_json_encoded_size_of();
+                total_byte_size += byte_size.get();
+                if let Some(ref batch) = batch {
+                    log_event = log_event.with_batch_notifier(batch);
+                }
+                log_events.push(log_event);
+            }
+            Err(e) => {
+                emit!(WindowsEventLogParseError {
+                    error: e.to_string(),
+                    channel,
+                    event_id: Some(event_id),
+                });
+            }
+        }
+    }
+
+    if !log_events.is_empty() {
+        let count = log_events.len();
+        events_received.emit(CountByteSize(count, total_byte_size.into()));
+        bytes_received.emit(ByteSize(total_byte_size));
+
+        // BACK PRESSURE: block until the pipeline accepts the batch.
+        // We don't call EvtNext again until this completes.
+        if let Err(_error) = out.send_batch(log_events).await {
+            emit!(StreamClosedError { count });
+            return true; // signal: break the main loop
+        }
+
+        // Register checkpoint entry with the finalizer.
+        let bookmarks: Vec<(String, String)> = channels_in_batch
+            .into_iter()
+            .filter_map(|channel| {
+                subscription
+                    .get_bookmark_xml(&channel)
+                    .map(|xml| (channel, xml))
+            })
+            .collect();
+
+        if !bookmarks.is_empty() {
+            let entry = FinalizerEntry { bookmarks };
+            finalizer.finalize(entry, receiver).await;
+        }
+    }
+
+    false // pipeline still open
+}
+
+/// Transfer ownership of `subscription` into a `spawn_blocking` task, run `f`
+/// on it, then return both the subscription and the result.
+///
+/// All blocking Windows APIs (`WaitForMultipleObjects`, `EvtNext`, `EvtRender`)
+/// must run in `spawn_blocking` to avoid stalling the async runtime. The
+/// ownership-transfer pattern ensures only one thread holds the subscription
+/// at a time, preventing data races without requiring locks.
+async fn with_subscription_blocking<F, R>(
+    subscription: EventLogSubscription,
+    f: F,
+) -> Result<(EventLogSubscription, R), WindowsEventLogError>
+where
+    F: FnOnce(EventLogSubscription) -> (EventLogSubscription, R) + Send + 'static,
+    R: Send + 'static,
+{
+    tokio::task::spawn_blocking(move || f(subscription))
+        .await
+        .map_err(|e| WindowsEventLogError::ConfigError {
+            message: format!("Blocking subscription task panicked: {e}"),
+        })
 }
 
 /// Windows Event Log source implementation
@@ -281,41 +383,24 @@ impl WindowsEventLogSource {
             // Ownership transfer ensures no data races between the blocking thread
             // and async code. The shutdown watcher uses a raw HANDLE value (just an
             // integer) to signal shutdown without needing access to the subscription.
-            let (returned_sub, wait_result) = tokio::task::spawn_blocking({
-                let sub = subscription;
-                move || {
+            let (returned_sub, wait_result) =
+                with_subscription_blocking(subscription, move |sub| {
                     let result = sub.wait_for_events_blocking(timeout_ms);
                     (sub, result)
-                }
-            })
-            .await
-            .map_err(|e| WindowsEventLogError::ConfigError {
-                message: format!("Wait task panicked: {e}"),
-            })?;
-
+                })
+                .await?;
             subscription = returned_sub;
 
             match wait_result {
                 WaitResult::EventsAvailable => {
                     // Pull events via spawn_blocking (EvtNext/EvtRender are blocking APIs)
-                    let (returned_sub, events_result) = tokio::task::spawn_blocking({
-                        let mut sub = subscription;
-                        move || {
+                    let (returned_sub, events_result) =
+                        with_subscription_blocking(subscription, move |mut sub| {
                             let result = sub.pull_events(batch_size);
                             (sub, result)
-                        }
-                    })
-                    .await
-                    .map_err(|e| WindowsEventLogError::ConfigError {
-                        message: format!("Pull task panicked: {e}"),
-                    })?;
-
+                        })
+                        .await?;
                     subscription = returned_sub;
-
-                    // Rate limiting between batches (async-compatible)
-                    if let Some(limiter) = subscription.rate_limiter() {
-                        limiter.until_ready().await;
-                    }
 
                     match events_result {
                         Ok(events) if events.is_empty() => {
@@ -328,65 +413,19 @@ impl WindowsEventLogSource {
                                 message = "Pulled Windows Event Log events.",
                                 event_count = events.len()
                             );
-
-                            let (batch, receiver) =
-                                BatchNotifier::maybe_new_with_receiver(acknowledgements);
-
-                            let mut log_events = Vec::new();
-                            let mut total_byte_size = 0;
-                            let mut channels_in_batch = std::collections::HashSet::new();
-
-                            for event in events {
-                                let channel = event.channel.clone();
-                                channels_in_batch.insert(channel.clone());
-                                let event_id = event.event_id;
-                                match parser.parse_event(event) {
-                                    Ok(mut log_event) => {
-                                        let byte_size = log_event.estimated_json_encoded_size_of();
-                                        total_byte_size += byte_size.get();
-
-                                        if let Some(ref batch) = batch {
-                                            log_event = log_event.with_batch_notifier(batch);
-                                        }
-
-                                        log_events.push(log_event);
-                                    }
-                                    Err(e) => {
-                                        emit!(WindowsEventLogParseError {
-                                            error: e.to_string(),
-                                            channel,
-                                            event_id: Some(event_id),
-                                        });
-                                    }
-                                }
-                            }
-
-                            if !log_events.is_empty() {
-                                let count = log_events.len();
-                                events_received.emit(CountByteSize(count, total_byte_size.into()));
-                                bytes_received.emit(ByteSize(total_byte_size));
-
-                                // BACK PRESSURE: block here until the pipeline accepts
-                                // the batch. We don't call EvtNext again until this completes.
-                                if let Err(_error) = out.send_batch(log_events).await {
-                                    emit!(StreamClosedError { count });
-                                    break;
-                                }
-
-                                // Register checkpoint entry with finalizer
-                                let bookmarks: Vec<(String, String)> = channels_in_batch
-                                    .into_iter()
-                                    .filter_map(|channel| {
-                                        subscription
-                                            .get_bookmark_xml(&channel)
-                                            .map(|xml| (channel, xml))
-                                    })
-                                    .collect();
-
-                                if !bookmarks.is_empty() {
-                                    let entry = FinalizerEntry { bookmarks };
-                                    finalizer.finalize(entry, receiver).await;
-                                }
+                            if process_event_batch(
+                                events,
+                                &parser,
+                                acknowledgements,
+                                &subscription,
+                                &mut out,
+                                &finalizer,
+                                &events_received,
+                                &bytes_received,
+                            )
+                            .await
+                            {
+                                break;
                             }
                         }
                         Err(e) => {
@@ -415,10 +454,6 @@ impl WindowsEventLogSource {
                 }
 
                 WaitResult::Timeout => {
-                    // A full wait cycle without errors means the system is healthy;
-                    // reset backoff so the next transient error starts fresh.
-                    error_backoff = std::time::Duration::from_millis(100);
-
                     // Periodic checkpoint flush (sync mode only)
                     if !acknowledgements && last_checkpoint.elapsed() >= checkpoint_interval {
                         if let Err(e) = subscription.flush_bookmarks().await {
@@ -446,6 +481,74 @@ impl WindowsEventLogSource {
                                 message = "All channel subscriptions healthy.",
                                 total_channels = total,
                             );
+                        }
+                    }
+
+                    // Speculative pull: self-heal against any lost-wakeup scenario,
+                    // regardless of root cause. If the OS signal was lost through any
+                    // mechanism (not just the pre-drain race fixed in #25194), this
+                    // ensures the source recovers within one timeout period.
+                    // Use the speculative pull variant so idle timeout cycles don't
+                    // refresh per-channel record-count gauges via EvtOpenLog /
+                    // EvtGetLogInfo on every configured channel.
+                    let (returned_sub, speculative_result) =
+                        with_subscription_blocking(subscription, move |mut sub| {
+                            let result = sub.pull_events_speculative(batch_size);
+                            (sub, result)
+                        })
+                        .await?;
+                    subscription = returned_sub;
+
+                    match speculative_result {
+                        Ok(events) if events.is_empty() => {
+                            // Healthy cycle: reset backoff so the next transient
+                            // error starts fresh.
+                            error_backoff = std::time::Duration::from_millis(100);
+                        }
+                        Ok(events) => {
+                            // Healthy cycle: reset backoff so the next transient
+                            // error starts fresh.
+                            error_backoff = std::time::Duration::from_millis(100);
+                            warn!(
+                                message = "Speculative timeout pull recovered events; possible lost wakeup detected.",
+                                event_count = events.len(),
+                            );
+                            if process_event_batch(
+                                events,
+                                &parser,
+                                acknowledgements,
+                                &subscription,
+                                &mut out,
+                                &finalizer,
+                                &events_received,
+                                &bytes_received,
+                            )
+                            .await
+                            {
+                                break;
+                            }
+                        }
+                        Err(e) => {
+                            emit!(WindowsEventLogQueryError {
+                                channel: "all".to_string(),
+                                query: None,
+                                error: e.to_string(),
+                            });
+                            if !e.is_recoverable() {
+                                error!(
+                                    message = "Non-recoverable speculative pull error, shutting down.",
+                                    error = %e
+                                );
+                                break;
+                            }
+                            // Exponential backoff mirrors the EventsAvailable error path.
+                            warn!(
+                                message = "Recoverable speculative pull error, backing off.",
+                                backoff_ms = error_backoff.as_millis() as u64,
+                                error = %e
+                            );
+                            tokio::time::sleep(error_backoff).await;
+                            error_backoff = (error_backoff * 2).min(MAX_ERROR_BACKOFF);
                         }
                     }
                 }

--- a/src/sources/windows_event_log/mod.rs
+++ b/src/sources/windows_event_log/mod.rs
@@ -27,6 +27,7 @@ cfg_if::cfg_if! {
 
         use chrono::Utc;
         use futures::StreamExt;
+        use tracing::Instrument;
         use vector_lib::EstimatedJsonEncodedSizeOf;
         use vector_lib::finalizer::OrderedFinalizer;
         use vector_lib::internal_event::{
@@ -101,7 +102,8 @@ impl Finalizer {
                 OrderedFinalizer::<FinalizerEntry>::new(Some(shutdown.clone()));
 
             // Spawn background task to process acknowledgments and update checkpoints
-            tokio::spawn(async move {
+            tokio::spawn(
+                async move {
                 while let Some((status, entry)) = ack_stream.next().await {
                     if status == BatchStatus::Delivered {
                         if let Err(e) = checkpointer.set_batch(entry.bookmarks.clone()).await {
@@ -123,7 +125,9 @@ impl Finalizer {
                     }
                 }
                 debug!(message = "Acknowledgement stream completed.");
-            });
+                }
+                .in_current_span(),
+            );
 
             Self::Async(finalizer)
         } else {
@@ -361,17 +365,21 @@ impl WindowsEventLogSource {
             }
         };
         let shutdown_watcher = shutdown.clone();
-        tokio::spawn(async move {
-            shutdown_watcher.await;
-            unsafe {
-                let handle =
-                    windows::Win32::Foundation::HANDLE(watcher_handle_raw as *mut std::ffi::c_void);
-                let _ = windows::Win32::System::Threading::SetEvent(handle);
-                if watcher_owns_handle {
-                    let _ = windows::Win32::Foundation::CloseHandle(handle);
+        tokio::spawn(
+            async move {
+                shutdown_watcher.await;
+                unsafe {
+                    let handle = windows::Win32::Foundation::HANDLE(
+                        watcher_handle_raw as *mut std::ffi::c_void,
+                    );
+                    let _ = windows::Win32::System::Threading::SetEvent(handle);
+                    if watcher_owns_handle {
+                        let _ = windows::Win32::Foundation::CloseHandle(handle);
+                    }
                 }
             }
-        });
+            .in_current_span(),
+        );
 
         // Track when we last flushed checkpoints
         let mut last_checkpoint = std::time::Instant::now();

--- a/src/sources/windows_event_log/parser.rs
+++ b/src/sources/windows_event_log/parser.rs
@@ -1,0 +1,804 @@
+use vector_lib::config::{LogNamespace, log_schema};
+use vrl::value::{ObjectMap, Value};
+
+use vector_lib::event::LogEvent;
+
+use super::{
+    config::{EventDataFormat, WindowsEventLogConfig},
+    error::*,
+    xml_parser::WindowsEvent,
+};
+
+/// Parser for converting Windows Event Log events to Vector LogEvents
+pub struct EventLogParser {
+    config: WindowsEventLogConfig,
+    log_namespace: LogNamespace,
+}
+
+impl EventLogParser {
+    /// Create a new parser with the given configuration and resolved namespace
+    pub fn new(config: &WindowsEventLogConfig, log_namespace: LogNamespace) -> Self {
+        Self {
+            config: config.clone(),
+            log_namespace,
+        }
+    }
+
+    /// Parse a Windows event into a Vector LogEvent
+    pub fn parse_event(&self, event: WindowsEvent) -> Result<LogEvent, WindowsEventLogError> {
+        let mut log_event = LogEvent::default();
+
+        // Set core fields based on log namespace
+        match self.log_namespace {
+            LogNamespace::Vector => {
+                self.set_vector_namespace_fields(&mut log_event, &event)?;
+            }
+            LogNamespace::Legacy => {
+                self.set_legacy_namespace_fields(&mut log_event, &event)?;
+            }
+        }
+
+        // Apply field filtering
+        self.apply_field_filtering(&mut log_event)?;
+
+        // Apply custom formatting
+        self.apply_custom_formatting(&mut log_event)?;
+
+        Ok(log_event)
+    }
+
+    fn set_vector_namespace_fields(
+        &self,
+        log_event: &mut LogEvent,
+        event: &WindowsEvent,
+    ) -> Result<(), WindowsEventLogError> {
+        let log_schema = log_schema();
+
+        // Set timestamp
+        if let Some(timestamp_key) = log_schema.timestamp_key() {
+            log_event.try_insert(
+                timestamp_key.to_string().as_str(),
+                Value::Timestamp(event.time_created),
+            );
+        }
+
+        // Set message (rendered message or event data)
+        if let Some(message_key) = log_schema.message_key() {
+            let message = event
+                .rendered_message
+                .as_ref()
+                .cloned()
+                .unwrap_or_else(|| self.extract_message_from_event_data(event));
+
+            log_event.try_insert(
+                message_key.to_string().as_str(),
+                Value::Bytes(message.into()),
+            );
+        }
+
+        // Set source/host
+        if let Some(host_key) = log_schema.host_key() {
+            log_event.try_insert(
+                host_key.to_string().as_str(),
+                Value::Bytes(event.computer.clone().into()),
+            );
+        }
+
+        // Set Windows-specific fields
+        self.set_windows_fields(log_event, event)?;
+
+        Ok(())
+    }
+
+    fn set_legacy_namespace_fields(
+        &self,
+        log_event: &mut LogEvent,
+        event: &WindowsEvent,
+    ) -> Result<(), WindowsEventLogError> {
+        // Legacy namespace puts everything in the root
+        let log_schema = log_schema();
+
+        // Set standard fields
+        if let Some(timestamp_key) = log_schema.timestamp_key() {
+            log_event.try_insert(
+                timestamp_key.to_string().as_str(),
+                Value::Timestamp(event.time_created),
+            );
+        }
+
+        if let Some(message_key) = log_schema.message_key() {
+            let message = event
+                .rendered_message
+                .as_ref()
+                .cloned()
+                .unwrap_or_else(|| self.extract_message_from_event_data(event));
+
+            log_event.try_insert(
+                message_key.to_string().as_str(),
+                Value::Bytes(message.into()),
+            );
+        }
+
+        if let Some(host_key) = log_schema.host_key() {
+            log_event.try_insert(
+                host_key.to_string().as_str(),
+                Value::Bytes(event.computer.clone().into()),
+            );
+        }
+
+        // Set Windows-specific fields at root level
+        self.set_windows_fields(log_event, event)?;
+
+        Ok(())
+    }
+
+    fn set_windows_fields(
+        &self,
+        log_event: &mut LogEvent,
+        event: &WindowsEvent,
+    ) -> Result<(), WindowsEventLogError> {
+        // Core Windows Event Log fields
+        log_event.insert("event_id", Value::Integer(event.event_id as i64));
+
+        log_event.insert("record_id", Value::Integer(event.record_id as i64));
+
+        log_event.insert("level", Value::Bytes(event.level_name().into()));
+
+        log_event.insert("level_value", Value::Integer(event.level as i64));
+
+        log_event.insert("channel", Value::Bytes(event.channel.clone().into()));
+
+        log_event.insert(
+            "provider_name",
+            Value::Bytes(event.provider_name.clone().into()),
+        );
+
+        if let Some(ref provider_guid) = event.provider_guid {
+            log_event.insert("provider_guid", Value::Bytes(provider_guid.clone().into()));
+        }
+
+        log_event.insert("computer", Value::Bytes(event.computer.clone().into()));
+
+        if let Some(ref user_id) = event.user_id {
+            log_event.insert("user_id", Value::Bytes(user_id.clone().into()));
+        }
+
+        if let Some(ref user_name) = event.user_name {
+            log_event.insert("user_name", Value::Bytes(user_name.clone().into()));
+        }
+
+        log_event.insert("process_id", Value::Integer(event.process_id as i64));
+
+        log_event.insert("thread_id", Value::Integer(event.thread_id as i64));
+
+        if event.task != 0 {
+            log_event.insert("task", Value::Integer(event.task as i64));
+
+            if let Some(ref task_name) = event.task_name {
+                log_event.insert("task_name", Value::Bytes(task_name.clone().into()));
+            }
+        }
+
+        if event.opcode != 0 {
+            log_event.insert("opcode", Value::Integer(event.opcode as i64));
+
+            if let Some(ref opcode_name) = event.opcode_name {
+                log_event.insert("opcode_name", Value::Bytes(opcode_name.clone().into()));
+            }
+        }
+
+        if event.keywords != 0 {
+            log_event.insert(
+                "keywords",
+                Value::Bytes(format!("0x{:016X}", event.keywords).into()),
+            );
+
+            if !event.keyword_names.is_empty() {
+                let kw_values: Vec<Value> = event
+                    .keyword_names
+                    .iter()
+                    .map(|s| Value::Bytes(s.clone().into()))
+                    .collect();
+                log_event.insert("keyword_names", Value::Array(kw_values));
+            }
+        }
+
+        if let Some(ref activity_id) = event.activity_id {
+            log_event.insert("activity_id", Value::Bytes(activity_id.clone().into()));
+        }
+
+        if let Some(ref related_activity_id) = event.related_activity_id {
+            log_event.insert(
+                "related_activity_id",
+                Value::Bytes(related_activity_id.clone().into()),
+            );
+        }
+
+        // New FluentBit-compatible fields
+        if let Some(version) = event.version {
+            log_event.insert("version", Value::Integer(version as i64));
+        }
+
+        if let Some(qualifiers) = event.qualifiers {
+            log_event.insert("qualifiers", Value::Integer(qualifiers as i64));
+        }
+
+        // StringInserts field for FluentBit compatibility
+        if !event.string_inserts.is_empty() {
+            let string_inserts: Vec<Value> = event
+                .string_inserts
+                .iter()
+                .map(|s| Value::Bytes(s.clone().into()))
+                .collect();
+            log_event.insert("string_inserts", Value::Array(string_inserts));
+        }
+
+        // Include raw XML if requested
+        if self.config.include_xml && !event.raw_xml.is_empty() {
+            log_event.insert("xml", Value::Bytes(event.raw_xml.clone().into()));
+        }
+
+        // Include event data if configured
+        if self.config.field_filter.include_event_data && !event.event_data.is_empty() {
+            let mut event_data_map = ObjectMap::new();
+            for (key, value) in &event.event_data {
+                let typed_value = self.coerce_field_value(key, value);
+                event_data_map.insert(key.clone().into(), typed_value);
+            }
+            log_event.insert("event_data", Value::Object(event_data_map));
+        }
+
+        // Include user data if configured
+        if self.config.field_filter.include_user_data && !event.user_data.is_empty() {
+            let mut user_data_map = ObjectMap::new();
+            for (key, value) in &event.user_data {
+                let typed_value = self.coerce_field_value(key, value);
+                user_data_map.insert(key.clone().into(), typed_value);
+            }
+            log_event.insert("user_data", Value::Object(user_data_map));
+        }
+
+        Ok(())
+    }
+
+    /// Convert a string value to a typed Value using explicit format config.
+    ///
+    /// Values are kept as strings by default. This prevents silent breakage
+    /// of downstream SIEM correlation rules that
+    /// compare event data fields as strings (e.g. `LogonType == "2"`).
+    ///
+    /// Use `event_data_format` config entries to opt in to typed coercion
+    /// for specific fields.
+    fn coerce_field_value(&self, key: &str, value: &str) -> Value {
+        let as_bytes = || Value::Bytes(value.to_string().into());
+
+        if let Some(fmt) = self.config.event_data_format.get(key) {
+            return match fmt {
+                EventDataFormat::Integer => value
+                    .parse::<i64>()
+                    .map(Value::Integer)
+                    .unwrap_or_else(|_| as_bytes()),
+                EventDataFormat::Float => value
+                    .parse::<f64>()
+                    .ok()
+                    .and_then(|f| ordered_float::NotNan::new(f).ok())
+                    .map(Value::Float)
+                    .unwrap_or_else(as_bytes),
+                EventDataFormat::Boolean => {
+                    let lower = value.to_lowercase();
+                    Value::Boolean(matches!(lower.as_str(), "true" | "1" | "yes" | "on"))
+                }
+                EventDataFormat::String | EventDataFormat::Auto => as_bytes(),
+            };
+        }
+
+        as_bytes()
+    }
+
+    fn extract_message_from_event_data(&self, event: &WindowsEvent) -> String {
+        // Try to find a message in named event data fields
+        for (key, value) in &event.event_data {
+            if key.to_lowercase().contains("message") {
+                return value.clone();
+            }
+        }
+
+        // Try string inserts (unnamed <Data> elements, e.g. from eventcreate)
+        if let Some(first) = event.string_inserts.first() {
+            if !first.is_empty() {
+                return first.clone();
+            }
+        }
+
+        // Fall back to generic message
+        format!(
+            "Event ID {} from {} on {}",
+            event.event_id, event.provider_name, event.computer
+        )
+    }
+
+    fn apply_field_filtering(&self, log_event: &mut LogEvent) -> Result<(), WindowsEventLogError> {
+        let filter = &self.config.field_filter;
+
+        // If include_fields is specified, remove fields not in the list
+        if let Some(ref include_fields) = filter.include_fields {
+            // Pre-allocate HashSet with known capacity for better performance
+            let mut include_set = std::collections::HashSet::with_capacity(include_fields.len());
+            for field in include_fields {
+                include_set.insert(field.as_str());
+            }
+
+            // Remove fields not in include set
+            let keys_to_remove: Vec<String> = log_event
+                .all_event_fields()
+                .map(|iter| iter.collect::<Vec<_>>())
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(|(key, _)| {
+                    if !include_set.contains(key.as_str()) {
+                        Some(key.to_string())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            for key in keys_to_remove {
+                log_event.remove(key.as_str());
+            }
+        }
+
+        // Remove fields in exclude_fields list - single pass removal
+        if let Some(ref exclude_fields) = filter.exclude_fields {
+            for field in exclude_fields {
+                log_event.remove(field.as_str());
+            }
+        }
+
+        Ok(())
+    }
+
+    fn apply_custom_formatting(
+        &self,
+        log_event: &mut LogEvent,
+    ) -> Result<(), WindowsEventLogError> {
+        for (field_name, format) in &self.config.event_data_format {
+            if let Some(current_value) = log_event.get(field_name.as_str()) {
+                let formatted_value = self.format_value(current_value, format)?;
+                log_event.insert(field_name.as_str(), formatted_value);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn format_value(
+        &self,
+        value: &Value,
+        format: &EventDataFormat,
+    ) -> Result<Value, WindowsEventLogError> {
+        match format {
+            EventDataFormat::String => Ok(Value::Bytes(value.to_string().into())),
+            EventDataFormat::Integer => {
+                let int_value = match value {
+                    Value::Integer(i) => *i,
+                    Value::Float(f) => f.into_inner() as i64,
+                    Value::Bytes(b) => String::from_utf8_lossy(b).parse::<i64>().map_err(|_| {
+                        WindowsEventLogError::FilterError {
+                            message: format!(
+                                "Cannot convert '{}' to integer",
+                                String::from_utf8_lossy(b)
+                            ),
+                        }
+                    })?,
+                    _ => {
+                        return Err(WindowsEventLogError::FilterError {
+                            message: format!("Cannot convert {:?} to integer", value),
+                        });
+                    }
+                };
+                Ok(Value::Integer(int_value))
+            }
+            EventDataFormat::Float => {
+                let float_value = match value {
+                    Value::Float(f) => f.into_inner(),
+                    Value::Integer(i) => *i as f64,
+                    Value::Bytes(b) => String::from_utf8_lossy(b).parse::<f64>().map_err(|_| {
+                        WindowsEventLogError::FilterError {
+                            message: format!(
+                                "Cannot convert '{}' to float",
+                                String::from_utf8_lossy(b)
+                            ),
+                        }
+                    })?,
+                    _ => {
+                        return Err(WindowsEventLogError::FilterError {
+                            message: format!("Cannot convert {:?} to float", value),
+                        });
+                    }
+                };
+                Ok(Value::Float(
+                    ordered_float::NotNan::new(float_value)
+                        .unwrap_or_else(|_| ordered_float::NotNan::new(0.0).unwrap()),
+                ))
+            }
+            EventDataFormat::Boolean => {
+                let bool_value = match value {
+                    Value::Boolean(b) => *b,
+                    Value::Integer(i) => *i != 0,
+                    Value::Bytes(b) => {
+                        let s = String::from_utf8_lossy(b).to_lowercase();
+                        matches!(s.as_str(), "true" | "1" | "yes" | "on")
+                    }
+                    _ => {
+                        return Err(WindowsEventLogError::FilterError {
+                            message: format!("Cannot convert {:?} to boolean", value),
+                        });
+                    }
+                };
+                Ok(Value::Boolean(bool_value))
+            }
+            EventDataFormat::Auto => {
+                // Keep the original format
+                Ok(value.clone())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::collections::HashMap;
+
+    /// Creates a generic test event for parser unit tests.
+    /// Note: tests.rs has a separate create_test_event() with realistic Security audit data.
+    /// This version uses simple generic values to isolate parser logic testing.
+    fn create_test_event() -> WindowsEvent {
+        WindowsEvent {
+            record_id: 12345,
+            event_id: 1000,
+            level: 4,
+            task: 1,
+            opcode: 2,
+            keywords: 0x8000000000000000,
+            time_created: Utc::now(),
+            provider_name: "TestProvider".to_string(),
+            provider_guid: Some("{12345678-1234-1234-1234-123456789012}".to_string()),
+            channel: "TestChannel".to_string(),
+            computer: "TEST-PC".to_string(),
+            user_id: Some("S-1-5-21-1234567890-1234567890-1234567890-1000".to_string()),
+            process_id: 1234,
+            thread_id: 5678,
+            activity_id: Some("{ABCDEFGH-1234-1234-1234-123456789012}".to_string()),
+            related_activity_id: None,
+            raw_xml: "<Event><System><EventID>1000</EventID></System></Event>".to_string(),
+            rendered_message: Some("Test message".to_string()),
+            event_data: {
+                let mut map = HashMap::new();
+                map.insert("key1".to_string(), "value1".to_string());
+                map.insert("key2".to_string(), "value2".to_string());
+                map
+            },
+            user_data: HashMap::new(),
+            task_name: None,
+            opcode_name: Some("Stop".to_string()),
+            keyword_names: vec!["Classic".to_string()],
+            user_name: None,
+            version: Some(1),
+            qualifiers: Some(0),
+            string_inserts: vec!["value1".to_string(), "value2".to_string()],
+        }
+    }
+
+    #[test]
+    fn test_parser_uses_provided_namespace() {
+        let config = WindowsEventLogConfig::default();
+        let parser = EventLogParser::new(&config, LogNamespace::Vector);
+
+        assert!(matches!(parser.log_namespace, LogNamespace::Vector));
+    }
+
+    #[test]
+    fn test_parse_event_basic() {
+        let config = WindowsEventLogConfig::default();
+        let parser = EventLogParser::new(&config, LogNamespace::Legacy);
+        let event = create_test_event();
+
+        let log_event = parser.parse_event(event.clone()).unwrap();
+
+        // Check core fields
+        assert_eq!(log_event.get("event_id").unwrap(), &Value::Integer(1000));
+        assert_eq!(log_event.get("record_id").unwrap(), &Value::Integer(12345));
+        assert_eq!(
+            log_event.get("level").unwrap(),
+            &Value::Bytes("Information".into())
+        );
+        assert_eq!(
+            log_event.get("channel").unwrap(),
+            &Value::Bytes("TestChannel".into())
+        );
+        assert_eq!(
+            log_event.get("provider_name").unwrap(),
+            &Value::Bytes("TestProvider".into())
+        );
+        assert_eq!(
+            log_event.get("computer").unwrap(),
+            &Value::Bytes("TEST-PC".into())
+        );
+
+        // Enriched fields from the new resolution methods
+        // opcode=2 -> "Stop"
+        assert_eq!(
+            log_event.get("opcode_name").unwrap(),
+            &Value::Bytes("Stop".into())
+        );
+        // keywords=0x8000000000000000 -> ["Classic"]
+        assert_eq!(
+            log_event.get("keyword_names").unwrap(),
+            &Value::Array(vec![Value::Bytes("Classic".into())])
+        );
+        // task=1 with provider "TestProvider" has no known mapping
+        assert!(log_event.get("task_name").is_none());
+    }
+
+    #[test]
+    fn test_parse_security_audit_event() {
+        let config = WindowsEventLogConfig::default();
+        let parser = EventLogParser::new(&config, LogNamespace::Legacy);
+
+        let event = WindowsEvent {
+            record_id: 99999,
+            event_id: 4624,
+            level: 0, // Security audit events use level 0
+            task: 12544,
+            opcode: 0,
+            keywords: 0x0020000000000000, // Audit Success
+            time_created: Utc::now(),
+            provider_name: "Microsoft-Windows-Security-Auditing".to_string(),
+            provider_guid: Some("{54849625-5478-4994-A5BA-3E3B0328C30D}".to_string()),
+            channel: "Security".to_string(),
+            computer: "DC01.corp.local".to_string(),
+            user_id: Some("S-1-5-18".to_string()),
+            process_id: 636,
+            thread_id: 1234,
+            activity_id: None,
+            related_activity_id: None,
+            raw_xml: String::new(),
+            rendered_message: Some("An account was successfully logged on.".to_string()),
+            event_data: HashMap::new(),
+            user_data: HashMap::new(),
+            task_name: Some("Logon".to_string()),
+            opcode_name: None,
+            keyword_names: vec!["Audit Success".to_string()],
+            user_name: None,
+            version: Some(2),
+            qualifiers: None,
+            string_inserts: vec![],
+        };
+
+        let log_event = parser.parse_event(event).unwrap();
+
+        // Level 0 should map to "Information" (not "Unknown")
+        assert_eq!(
+            log_event.get("level").unwrap(),
+            &Value::Bytes("Information".into())
+        );
+        assert_eq!(log_event.get("level_value").unwrap(), &Value::Integer(0));
+
+        // Task 12544 -> "Logon"
+        assert_eq!(
+            log_event.get("task_name").unwrap(),
+            &Value::Bytes("Logon".into())
+        );
+
+        // keywords=Audit Success
+        assert_eq!(
+            log_event.get("keyword_names").unwrap(),
+            &Value::Array(vec![Value::Bytes("Audit Success".into())])
+        );
+
+        // opcode=0 is not emitted since the condition is `if event.opcode != 0`
+        assert!(log_event.get("opcode").is_none());
+        assert!(log_event.get("opcode_name").is_none());
+    }
+
+    #[test]
+    fn test_parse_event_with_xml() {
+        let mut config = WindowsEventLogConfig::default();
+        config.include_xml = true;
+
+        let parser = EventLogParser::new(&config, LogNamespace::Legacy);
+        let event = create_test_event();
+
+        let log_event = parser.parse_event(event.clone()).unwrap();
+
+        assert!(log_event.get("xml").is_some());
+        assert_eq!(
+            log_event.get("xml").unwrap(),
+            &Value::Bytes(event.raw_xml.into())
+        );
+    }
+
+    #[test]
+    fn test_parse_event_data_filtering() {
+        let mut config = WindowsEventLogConfig::default();
+        config.field_filter.include_event_data = true;
+
+        let parser = EventLogParser::new(&config, LogNamespace::Legacy);
+        let event = create_test_event();
+
+        let log_event = parser.parse_event(event.clone()).unwrap();
+
+        if let Some(Value::Object(event_data)) = log_event.get("event_data") {
+            assert_eq!(event_data.get("key1"), Some(&Value::Bytes("value1".into())));
+            assert_eq!(event_data.get("key2"), Some(&Value::Bytes("value2".into())));
+        } else {
+            panic!("event_data should be present");
+        }
+    }
+
+    #[test]
+    fn test_custom_formatting() {
+        let mut config = WindowsEventLogConfig::default();
+        config
+            .event_data_format
+            .insert("event_id".to_string(), EventDataFormat::String);
+
+        let parser = EventLogParser::new(&config, LogNamespace::Legacy);
+        let event = create_test_event();
+
+        let log_event = parser.parse_event(event).unwrap();
+
+        // event_id should be converted to string
+        assert_eq!(
+            log_event.get("event_id").unwrap(),
+            &Value::Bytes("1000".into())
+        );
+    }
+
+    #[test]
+    fn test_field_include_filtering() {
+        let mut config = WindowsEventLogConfig::default();
+        config.field_filter.include_fields =
+            Some(vec!["event_id".to_string(), "level".to_string()]);
+
+        let parser = EventLogParser::new(&config, LogNamespace::Legacy);
+        let event = create_test_event();
+
+        let log_event = parser.parse_event(event).unwrap();
+
+        // Only included fields should be present
+        assert!(log_event.get("event_id").is_some());
+        assert!(log_event.get("level").is_some());
+        // Other fields should be filtered out
+        // Note: This test might need adjustment based on actual field filtering implementation
+    }
+
+    #[test]
+    fn test_field_exclude_filtering() {
+        let mut config = WindowsEventLogConfig::default();
+        config.field_filter.exclude_fields =
+            Some(vec!["raw_xml".to_string(), "provider_guid".to_string()]);
+
+        let parser = EventLogParser::new(&config, LogNamespace::Legacy);
+        let event = create_test_event();
+
+        let log_event = parser.parse_event(event).unwrap();
+
+        // Excluded fields should not be present
+        assert!(log_event.get("raw_xml").is_none());
+        assert!(log_event.get("provider_guid").is_none());
+        // Other fields should still be there
+        assert!(log_event.get("event_id").is_some());
+    }
+
+    #[test]
+    fn test_extract_message_from_event_data() {
+        let config = WindowsEventLogConfig::default();
+        let parser = EventLogParser::new(&config, LogNamespace::Legacy);
+
+        let mut event = create_test_event();
+        event.rendered_message = None;
+        event
+            .event_data
+            .insert("message".to_string(), "Custom message".to_string());
+
+        let message = parser.extract_message_from_event_data(&event);
+        assert_eq!(message, "Custom message");
+    }
+
+    #[test]
+    fn test_format_value_conversions() {
+        let config = WindowsEventLogConfig::default();
+        let parser = EventLogParser::new(&config, LogNamespace::Legacy);
+
+        // Test string conversion
+        let value = Value::Integer(123);
+        let result = parser
+            .format_value(&value, &EventDataFormat::String)
+            .unwrap();
+        assert_eq!(result, Value::Bytes("123".into()));
+
+        // Test integer conversion
+        let value = Value::Bytes("456".into());
+        let result = parser
+            .format_value(&value, &EventDataFormat::Integer)
+            .unwrap();
+        assert_eq!(result, Value::Integer(456));
+
+        // Test float conversion
+        let value = Value::Bytes("123.45".into());
+        let result = parser
+            .format_value(&value, &EventDataFormat::Float)
+            .unwrap();
+        if let Value::Float(f) = result {
+            assert!((f.into_inner() - 123.45).abs() < f64::EPSILON);
+        } else {
+            panic!("Expected float value");
+        }
+
+        // Test boolean conversion
+        let value = Value::Bytes("true".into());
+        let result = parser
+            .format_value(&value, &EventDataFormat::Boolean)
+            .unwrap();
+        assert_eq!(result, Value::Boolean(true));
+
+        // Test auto format (no change)
+        let value = Value::Integer(789);
+        let result = parser.format_value(&value, &EventDataFormat::Auto).unwrap();
+        assert_eq!(result, Value::Integer(789));
+    }
+
+    #[test]
+    fn test_include_and_exclude_fields_interaction() {
+        let mut config = WindowsEventLogConfig::default();
+        // Include a set of fields, then exclude one from that set
+        config.field_filter.include_fields = Some(vec![
+            "event_id".to_string(),
+            "level".to_string(),
+            "channel".to_string(),
+        ]);
+        config.field_filter.exclude_fields = Some(vec!["channel".to_string()]);
+
+        let parser = EventLogParser::new(&config, LogNamespace::Legacy);
+        let event = create_test_event();
+        let log_event = parser.parse_event(event).unwrap();
+
+        // event_id and level should be present (in include list, not in exclude list)
+        assert!(log_event.get("event_id").is_some());
+        assert!(log_event.get("level").is_some());
+        // channel should be excluded (in both include and exclude, exclude wins)
+        assert!(log_event.get("channel").is_none());
+        // Fields not in include list should be absent
+        assert!(log_event.get("computer").is_none());
+        assert!(log_event.get("record_id").is_none());
+    }
+
+    #[test]
+    fn test_apply_custom_formatting_error_on_invalid_conversion() {
+        let mut config = WindowsEventLogConfig::default();
+        // Configure event_id to be formatted as integer — it already is an integer,
+        // so this succeeds. Instead, configure a string field to be converted to integer.
+        config
+            .event_data_format
+            .insert("level".to_string(), EventDataFormat::Integer);
+
+        let parser = EventLogParser::new(&config, LogNamespace::Legacy);
+        let event = create_test_event();
+
+        // level is stored as a string like "Information" — converting to integer should fail
+        let result = parser.parse_event(event);
+        assert!(
+            result.is_err(),
+            "Should fail when converting non-numeric string to integer"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("Cannot convert"),
+            "Error should describe the conversion failure, got: {err}"
+        );
+    }
+}

--- a/src/sources/windows_event_log/render.rs
+++ b/src/sources/windows_event_log/render.rs
@@ -1,0 +1,166 @@
+//! Event rendering and channel statistics helpers for Windows Event Log.
+//!
+//! Extracted from `subscription.rs` to keep that module focused on
+//! subscription lifecycle and event pulling.
+
+use metrics::Gauge;
+use windows::Win32::Foundation::ERROR_INSUFFICIENT_BUFFER;
+use windows::Win32::System::EventLog::{
+    EVT_HANDLE, EVT_LOG_PROPERTY_ID, EvtClose, EvtGetLogInfo, EvtLogNumberOfLogRecords, EvtOpenLog,
+    EvtRender, EvtRenderEventXml,
+};
+use windows::core::HSTRING;
+
+use super::error::WindowsEventLogError;
+
+/// Render an event handle to XML using reusable buffers.
+pub(super) fn render_event_xml(
+    render_buffer: &mut Vec<u8>,
+    decode_buffer: &mut Vec<u16>,
+    event_handle: EVT_HANDLE,
+) -> Result<String, WindowsEventLogError> {
+    const MAX_BUFFER_SIZE: u32 = 10 * 1024 * 1024; // 10MB limit
+
+    let buffer_size = render_buffer.len() as u32;
+    let mut buffer_used = 0u32;
+    let mut property_count = 0u32;
+
+    let result = unsafe {
+        EvtRender(
+            None,
+            event_handle,
+            EvtRenderEventXml.0,
+            buffer_size,
+            Some(render_buffer.as_mut_ptr() as *mut std::ffi::c_void),
+            &mut buffer_used,
+            &mut property_count,
+        )
+    };
+
+    if let Err(e) = result {
+        if e.code() == ERROR_INSUFFICIENT_BUFFER.into() {
+            if buffer_used == 0 {
+                return Ok(String::new());
+            }
+            if buffer_used > MAX_BUFFER_SIZE {
+                return Err(WindowsEventLogError::ReadEventError { source: e });
+            }
+
+            // Grow the reusable buffer
+            render_buffer.resize(buffer_used as usize, 0);
+            let mut second_buffer_used = 0u32;
+            let mut second_property_count = 0u32;
+
+            unsafe {
+                EvtRender(
+                    None,
+                    event_handle,
+                    EvtRenderEventXml.0,
+                    buffer_used,
+                    Some(render_buffer.as_mut_ptr() as *mut std::ffi::c_void),
+                    &mut second_buffer_used,
+                    &mut second_property_count,
+                )
+            }
+            .map_err(|e2| WindowsEventLogError::ReadEventError { source: e2 })?;
+
+            let result = decode_utf16_buffer(render_buffer, second_buffer_used, decode_buffer);
+
+            // Shrink if buffer grew very large (match normal-path threshold)
+            const SHRINK_THRESHOLD: usize = 64 * 1024;
+            if render_buffer.len() > SHRINK_THRESHOLD {
+                render_buffer.resize(SHRINK_THRESHOLD, 0);
+                render_buffer.shrink_to_fit();
+            }
+
+            return Ok(result);
+        }
+        return Err(WindowsEventLogError::ReadEventError { source: e });
+    }
+
+    let result = decode_utf16_buffer(render_buffer, buffer_used, decode_buffer);
+
+    // Shrink the buffer back down if a large event caused it to grow.
+    // 64 KB covers the vast majority of events without repeated reallocation.
+    const SHRINK_THRESHOLD: usize = 64 * 1024;
+    if render_buffer.len() > SHRINK_THRESHOLD {
+        render_buffer.resize(SHRINK_THRESHOLD, 0);
+        render_buffer.shrink_to_fit();
+    }
+
+    Ok(result)
+}
+
+/// Update the channel record count gauge using EvtGetLogInfo.
+///
+/// Reports total records in the channel. SOC teams compare this against
+/// `rate(events_read_total)` to detect ingestion lag.
+/// Best-effort: if any API call fails, the gauge is left unchanged.
+pub(super) fn update_channel_records(channel: &str, gauge: &Gauge) {
+    let channel_hstring = HSTRING::from(channel);
+    let log_handle = unsafe {
+        // EvtOpenChannelPath = 1
+        match EvtOpenLog(None, &channel_hstring, 1) {
+            Ok(h) => h,
+            Err(_) => return,
+        }
+    };
+
+    // EVT_VARIANT is 16 bytes: 8 bytes value + 4 bytes count + 4 bytes type
+    let mut buffer = [0u8; 16];
+    let mut buffer_used = 0u32;
+
+    let result = unsafe {
+        EvtGetLogInfo(
+            log_handle,
+            EVT_LOG_PROPERTY_ID(EvtLogNumberOfLogRecords.0),
+            buffer.len() as u32,
+            Some(buffer.as_mut_ptr() as *mut _),
+            &mut buffer_used,
+        )
+    };
+
+    unsafe {
+        let _ = EvtClose(log_handle);
+    }
+
+    if result.is_ok() {
+        // EVT_VARIANT for UInt64: first 8 bytes are the value (little-endian)
+        let record_count = u64::from_le_bytes(buffer[..8].try_into().unwrap_or([0; 8]));
+        gauge.set(record_count as f64);
+    }
+}
+
+/// Decode a UTF-16LE buffer (as returned by Windows EvtRender) into a String.
+///
+/// Uses a reusable `Vec<u16>` decode buffer to avoid per-event heap allocations.
+/// Copies byte pairs into the properly-aligned buffer instead of casting the
+/// pointer, which would be undefined behavior when the source buffer is not
+/// 2-byte aligned.
+fn decode_utf16_buffer(buffer: &[u8], bytes_used: u32, decode_buf: &mut Vec<u16>) -> String {
+    if bytes_used == 0 || bytes_used as usize > buffer.len() {
+        return String::new();
+    }
+    if bytes_used < 2 || bytes_used % 2 != 0 {
+        return String::new();
+    }
+
+    let u16_len = bytes_used as usize / 2;
+    decode_buf.resize(u16_len, 0);
+    for i in 0..u16_len {
+        decode_buf[i] = u16::from_le_bytes([buffer[i * 2], buffer[i * 2 + 1]]);
+    }
+
+    // Strip trailing null terminator
+    let xml_len = if !decode_buf.is_empty() && decode_buf[u16_len - 1] == 0 {
+        u16_len - 1
+    } else {
+        u16_len
+    };
+
+    if xml_len == 0 {
+        return String::new();
+    }
+
+    String::from_utf16_lossy(&decode_buf[..xml_len])
+}

--- a/src/sources/windows_event_log/sid_resolver.rs
+++ b/src/sources/windows_event_log/sid_resolver.rs
@@ -1,0 +1,160 @@
+use std::num::NonZeroUsize;
+
+use lru::LruCache;
+use windows::Win32::Foundation::{HLOCAL, LocalFree};
+use windows::Win32::Security::Authorization::ConvertStringSidToSidW;
+use windows::Win32::Security::{LookupAccountSidW, PSID, SID_NAME_USE};
+use windows::core::{HSTRING, PWSTR};
+
+/// Maximum number of SID-to-account name mappings to cache.
+const SID_CACHE_CAPACITY: usize = 4096;
+
+/// Resolves Windows SID strings (e.g. "S-1-5-18") to human-readable account
+/// names (e.g. "NT AUTHORITY\SYSTEM") using the Windows `LookupAccountSidW` API.
+///
+/// Results are cached in an LRU cache to avoid repeated lookups for the same SID.
+pub struct SidResolver {
+    cache: LruCache<String, Option<String>>,
+}
+
+impl SidResolver {
+    pub fn new() -> Self {
+        Self {
+            cache: LruCache::new(NonZeroUsize::new(SID_CACHE_CAPACITY).unwrap()),
+        }
+    }
+
+    /// Resolve a SID string to "DOMAIN\Username" format.
+    /// Returns `None` if the SID cannot be resolved (unknown account, invalid SID, etc.).
+    /// Caches both successful and failed lookups.
+    pub fn resolve(&mut self, sid_string: &str) -> Option<String> {
+        if let Some(cached) = self.cache.get(sid_string) {
+            return cached.clone();
+        }
+
+        let result = lookup_sid(sid_string);
+        self.cache.put(sid_string.to_string(), result.clone());
+        result
+    }
+}
+
+/// Convert a SID string to a PSID via ConvertStringSidToSidW, then call
+/// LookupAccountSidW to get the account name.
+fn lookup_sid(sid_string: &str) -> Option<String> {
+    let sid_hstring = HSTRING::from(sid_string);
+
+    // Convert string SID to binary PSID
+    let mut psid = PSID::default();
+    let convert_result = unsafe { ConvertStringSidToSidW(&sid_hstring, &mut psid) };
+    if convert_result.is_err() {
+        return None;
+    }
+
+    // LookupAccountSidW: first call to get buffer sizes
+    let mut name_len: u32 = 0;
+    let mut domain_len: u32 = 0;
+    let mut sid_type = SID_NAME_USE::default();
+
+    let _ = unsafe {
+        LookupAccountSidW(
+            None,
+            psid,
+            PWSTR::null(),
+            &mut name_len,
+            PWSTR::null(),
+            &mut domain_len,
+            &mut sid_type,
+        )
+    };
+
+    if name_len == 0 {
+        unsafe {
+            let _ = LocalFree(HLOCAL(psid.0));
+        }
+        return None;
+    }
+
+    // Second call with properly sized buffers
+    let mut name_buf = vec![0u16; name_len as usize];
+    let mut domain_buf = vec![0u16; domain_len as usize];
+
+    let result = unsafe {
+        LookupAccountSidW(
+            None,
+            psid,
+            PWSTR(name_buf.as_mut_ptr()),
+            &mut name_len,
+            PWSTR(domain_buf.as_mut_ptr()),
+            &mut domain_len,
+            &mut sid_type,
+        )
+    };
+
+    // Free the PSID allocated by ConvertStringSidToSidW
+    unsafe {
+        let _ = LocalFree(HLOCAL(psid.0));
+    }
+
+    if result.is_err() {
+        return None;
+    }
+
+    let name = String::from_utf16_lossy(&name_buf[..name_len as usize]);
+    let domain = String::from_utf16_lossy(&domain_buf[..domain_len as usize]);
+
+    if domain.is_empty() {
+        Some(name)
+    } else {
+        Some(format!("{domain}\\{name}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sid_resolver_caches_results() {
+        let mut resolver = SidResolver::new();
+        // Well-known SID: S-1-5-18 = NT AUTHORITY\SYSTEM
+        let first = resolver.resolve("S-1-5-18");
+        let second = resolver.resolve("S-1-5-18");
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_invalid_sid_returns_none() {
+        let mut resolver = SidResolver::new();
+        assert!(resolver.resolve("not-a-sid").is_none());
+        assert!(resolver.resolve("").is_none());
+    }
+
+    #[test]
+    fn test_well_known_sids() {
+        let mut resolver = SidResolver::new();
+
+        // S-1-5-18 = SYSTEM
+        if let Some(name) = resolver.resolve("S-1-5-18") {
+            assert!(
+                name.contains("SYSTEM"),
+                "S-1-5-18 should resolve to SYSTEM, got: {name}"
+            );
+        }
+
+        // S-1-5-19 = LOCAL SERVICE
+        if let Some(name) = resolver.resolve("S-1-5-19") {
+            assert!(
+                name.contains("LOCAL SERVICE"),
+                "S-1-5-19 should resolve to LOCAL SERVICE, got: {name}"
+            );
+        }
+
+        // S-1-5-20 = NETWORK SERVICE
+        if let Some(name) = resolver.resolve("S-1-5-20") {
+            assert!(
+                name.contains("NETWORK SERVICE"),
+                "S-1-5-20 should resolve to NETWORK SERVICE, got: {name}"
+            );
+        }
+    }
+}

--- a/src/sources/windows_event_log/subscription.rs
+++ b/src/sources/windows_event_log/subscription.rs
@@ -1,0 +1,1275 @@
+use std::{
+    collections::HashMap,
+    num::{NonZeroU32, NonZeroUsize},
+    sync::Arc,
+};
+
+use lru::LruCache;
+
+use governor::{
+    Quota, RateLimiter,
+    clock::DefaultClock,
+    state::{InMemoryState, NotKeyed},
+};
+use metrics::{Counter, Gauge, counter, gauge};
+use windows::Win32::Foundation::{CloseHandle, HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT};
+use windows::Win32::System::EventLog::{
+    EVT_HANDLE, EvtClose, EvtNext, EvtOpenChannelConfig, EvtSubscribe,
+    EvtSubscribeStartAfterBookmark, EvtSubscribeStartAtOldestRecord, EvtSubscribeStrict,
+    EvtSubscribeToFutureEvents,
+};
+#[cfg(test)]
+use windows::Win32::System::Threading::SetEvent;
+use windows::Win32::System::Threading::{CreateEventW, ResetEvent, WaitForMultipleObjects};
+use windows::core::HSTRING;
+
+use super::{
+    bookmark::BookmarkManager, checkpoint::Checkpointer, config::WindowsEventLogConfig, error::*,
+    metadata, sid_resolver::SidResolver, xml_parser,
+};
+
+use crate::internal_events::WindowsEventLogBookmarkError;
+
+/// Maximum number of entries in the EvtFormatMessage result cache.
+pub const FORMAT_CACHE_CAPACITY: usize = 10_000;
+/// Maximum number of cached publisher metadata handles.
+const PUBLISHER_CACHE_CAPACITY: usize = 256;
+
+/// RAII wrapper for EvtOpenPublisherMetadata handles.
+/// Calls EvtClose on drop to prevent handle leaks when evicted from LRU cache.
+pub struct PublisherHandle(pub isize);
+
+impl Drop for PublisherHandle {
+    fn drop(&mut self) {
+        if self.0 != 0 {
+            unsafe {
+                let _ = EvtClose(EVT_HANDLE(self.0));
+            }
+        }
+    }
+}
+
+// Win32 error codes extracted from the lower 16 bits of HRESULT.
+// Using named constants instead of magic numbers for maintainability.
+const ERROR_FILE_NOT_FOUND: u32 = 2;
+const ERROR_ACCESS_DENIED: u32 = 5;
+const ERROR_NO_MORE_ITEMS: u32 = 259;
+const ERROR_EVT_QUERY_RESULT_STALE: u32 = 4317;
+const ERROR_EVT_CHANNEL_NOT_FOUND: u32 = 0x3AA1; // 15009
+const ERROR_EVT_INVALID_QUERY: u32 = 15007;
+const ERROR_EVT_QUERY_RESULT_INVALID_POSITION: u32 = 0x4239; // 16953
+
+/// Per-channel subscription state for pull model.
+struct ChannelSubscription {
+    channel: String,
+    subscription_handle: EVT_HANDLE,
+    signal_event: HANDLE,
+    bookmark: BookmarkManager,
+    /// Pre-registered counter for events read on this channel.
+    events_read_counter: Counter,
+    /// Pre-registered counter for render errors on this channel.
+    render_errors_counter: Counter,
+    /// Gauge indicating whether this channel subscription is active (1.0) or failed (0.0).
+    subscription_active_gauge: Gauge,
+    /// Gauge tracking the timestamp (unix seconds) of the last event received on this channel.
+    last_event_timestamp_gauge: Gauge,
+    /// Gauge tracking total record count in the channel log.
+    /// SOC teams use `rate(events_read_total)` vs this gauge to detect ingestion lag.
+    channel_records_gauge: Gauge,
+}
+
+// SAFETY: Same rationale as EventLogSubscription - Windows kernel handles are thread-safe.
+unsafe impl Send for ChannelSubscription {}
+
+/// Result of waiting for events across all channels.
+pub enum WaitResult {
+    /// At least one channel has events available.
+    EventsAvailable,
+    /// Timeout expired without any events.
+    Timeout,
+    /// Shutdown was signaled.
+    Shutdown,
+}
+
+/// Pull-model Windows Event Log subscription using EvtSubscribe + signal event + EvtNext.
+///
+/// Instead of a callback (push model), we use:
+/// 1. `CreateEventW` to create a manual-reset signal per channel
+/// 2. `EvtSubscribe` with NULL callback (pull mode) and signal event
+/// 3. `WaitForMultipleObjects` to wait for any channel signal or shutdown
+/// 4. `EvtNext` to pull events in batches when signaled
+///
+/// This eliminates event drops under back pressure because we don't call
+/// `EvtNext` again until the pipeline has consumed the current batch.
+pub struct EventLogSubscription {
+    config: Arc<WindowsEventLogConfig>,
+    channels: Vec<ChannelSubscription>,
+    checkpointer: Arc<Checkpointer>,
+    rate_limiter: Option<RateLimiter<NotKeyed, InMemoryState, DefaultClock>>,
+    shutdown_event: HANDLE,
+    render_buffer: Vec<u8>,
+    /// Cached EvtOpenPublisherMetadata handles keyed by provider name.
+    /// Bounded LRU; evicted handles are closed via `PublisherHandle::drop`.
+    publisher_cache: LruCache<String, PublisherHandle>,
+    /// Cached EvtFormatMessage results. Outer key is provider name (looked up
+    /// via `&str` — zero allocation on the hot path), inner LRU is bounded per provider.
+    format_cache: HashMap<String, LruCache<(u32, u64), Option<String>>>,
+    /// Pre-registered counter for metadata cache hits.
+    cache_hits_counter: Counter,
+    /// Pre-registered counter for metadata cache misses.
+    cache_misses_counter: Counter,
+    /// SID-to-username resolver with LRU cache.
+    sid_resolver: SidResolver,
+    /// Reusable UTF-16 decode buffer to avoid per-event allocations.
+    decode_buffer: Vec<u16>,
+    /// Round-robin index for fair channel scheduling. Rotates the starting
+    /// channel each pull_events call to prevent a single busy channel
+    /// (e.g., Security on a domain controller) from starving others.
+    round_robin_index: usize,
+}
+
+// SAFETY: Windows HANDLE and EVT_HANDLE are kernel objects safe to use across
+// threads. In windows 0.58, HANDLE wraps *mut c_void which is !Send/!Sync,
+// but the underlying kernel handles are thread-safe.
+unsafe impl Send for EventLogSubscription {}
+
+impl EventLogSubscription {
+    /// Create a new pull-model subscription for all configured channels.
+    ///
+    /// Each channel gets its own signal event and EvtSubscribe handle.
+    /// A shutdown event is created for clean termination of blocking waits.
+    pub async fn new(
+        config: &WindowsEventLogConfig,
+        checkpointer: Arc<Checkpointer>,
+        _acknowledgements: bool,
+    ) -> Result<Self, WindowsEventLogError> {
+        // Create rate limiter if configured
+        let rate_limiter = if config.events_per_second > 0 {
+            NonZeroU32::new(config.events_per_second).map(|rate| {
+                info!(
+                    message = "Enabling rate limiting for Windows Event Log source.",
+                    events_per_second = config.events_per_second
+                );
+                RateLimiter::direct(Quota::per_second(rate))
+            })
+        } else {
+            None
+        };
+
+        let config = Arc::new(config.clone());
+
+        // Validate channels exist and are accessible
+        Self::validate_channels(&config)?;
+
+        // Store as isize while held across await points (HANDLE wraps *mut c_void which is !Send)
+        let shutdown_event_raw: isize = unsafe {
+            let h = CreateEventW(None, true, false, None).map_err(|e| {
+                WindowsEventLogError::ConfigError {
+                    message: format!("Failed to create shutdown event: {e}"),
+                }
+            })?;
+            h.0 as isize
+        };
+
+        let mut channel_subscriptions = Vec::with_capacity(config.channels.len());
+
+        for channel in &config.channels {
+            // Initialize bookmark from checkpoint or create fresh
+            let (bookmark, has_valid_checkpoint) = if let Some(checkpoint) =
+                checkpointer.get(channel).await
+            {
+                match BookmarkManager::from_xml(&checkpoint.bookmark_xml) {
+                    Ok(bm) => {
+                        info!(
+                            message = "Resuming from checkpoint bookmark.",
+                            channel = %channel
+                        );
+                        (bm, true)
+                    }
+                    Err(e) => {
+                        warn!(
+                            message = "Corrupted bookmark XML in checkpoint, creating fresh bookmark. Potential re-delivery of events.",
+                            channel = %channel,
+                            error = %e
+                        );
+                        (BookmarkManager::new()?, false)
+                    }
+                }
+            } else {
+                info!(
+                    message = "No checkpoint found, creating fresh bookmark.",
+                    channel = %channel
+                );
+                (BookmarkManager::new()?, false)
+            };
+
+            // Create manual-reset signal event, initially signaled.
+            // Initially signaled ensures the first iteration drains any buffered events.
+            // Manual reset prevents missing signals between WaitForMultipleObjects return
+            // and EvtNext draining.
+            let signal_event = unsafe {
+                CreateEventW(None, true, true, None).map_err(|e| {
+                    WindowsEventLogError::ConfigError {
+                        message: format!(
+                            "Failed to create signal event for channel '{channel}': {e}"
+                        ),
+                    }
+                })?
+            };
+
+            let channel_hstring = HSTRING::from(channel.as_str());
+            let query = Self::build_xpath_query(&config)?;
+            let query_hstring = HSTRING::from(query.clone());
+
+            // Determine subscription flags.
+            // When resuming from a bookmark, OR in EvtSubscribeStrict (0x10000) so that
+            // Windows fails explicitly if the bookmark position is stale/invalid,
+            // rather than silently falling back to oldest-record.
+            let subscription_flags = if has_valid_checkpoint {
+                EvtSubscribeStartAfterBookmark.0 | EvtSubscribeStrict.0
+            } else if config.read_existing_events {
+                EvtSubscribeStartAtOldestRecord.0
+            } else {
+                EvtSubscribeToFutureEvents.0
+            };
+
+            let fallback_flags = if config.read_existing_events {
+                EvtSubscribeStartAtOldestRecord.0
+            } else {
+                EvtSubscribeToFutureEvents.0
+            };
+
+            debug!(
+                message = "Creating pull-mode subscription.",
+                channel = %channel,
+                query = %query,
+                has_valid_checkpoint = has_valid_checkpoint,
+                read_existing = config.read_existing_events,
+                flags = format!("{:#x}", subscription_flags)
+            );
+
+            // EvtSubscribe with signal event and NULL callback = pull mode
+            let bookmark_handle = bookmark.as_handle();
+            let subscription_result = unsafe {
+                if has_valid_checkpoint {
+                    let strict_result = EvtSubscribe(
+                        None,
+                        signal_event,
+                        &channel_hstring,
+                        &query_hstring,
+                        bookmark_handle,
+                        None, // NULL context = pull mode
+                        None, // NULL callback = pull mode
+                        subscription_flags,
+                    );
+                    match strict_result {
+                        Ok(handle) => Ok(handle),
+                        Err(e) => {
+                            warn!(
+                                message = "Strict bookmark subscribe failed, retrying without bookmark. Potential re-delivery of events.",
+                                channel = %channel,
+                                error = %e,
+                                fallback_flags = format!("{:#x}", fallback_flags)
+                            );
+                            EvtSubscribe(
+                                None,
+                                signal_event,
+                                &channel_hstring,
+                                &query_hstring,
+                                None, // No bookmark for fallback
+                                None,
+                                None,
+                                fallback_flags,
+                            )
+                        }
+                    }
+                } else {
+                    EvtSubscribe(
+                        None,
+                        signal_event,
+                        &channel_hstring,
+                        &query_hstring,
+                        None, // No bookmark for fresh start
+                        None, // NULL context
+                        None, // NULL callback
+                        subscription_flags,
+                    )
+                }
+            };
+
+            match subscription_result {
+                Ok(subscription_handle) => {
+                    info!(
+                        message = "Pull-mode subscription created successfully.",
+                        channel = %channel
+                    );
+                    counter!(
+                        "windows_event_log_subscriptions_total",
+                        "channel" => channel.clone()
+                    )
+                    .increment(1);
+                    let subscription_active_gauge = gauge!(
+                        "windows_event_log_subscription_active",
+                        "channel" => channel.clone()
+                    );
+                    subscription_active_gauge.set(1.0);
+
+                    channel_subscriptions.push(ChannelSubscription {
+                        channel: channel.clone(),
+                        events_read_counter: counter!(
+                            "windows_event_log_events_read_total",
+                            "channel" => channel.clone()
+                        ),
+                        render_errors_counter: counter!(
+                            "windows_event_log_render_errors_total",
+                            "channel" => channel.clone()
+                        ),
+                        subscription_active_gauge,
+                        last_event_timestamp_gauge: gauge!(
+                            "windows_event_log_last_event_timestamp_seconds",
+                            "channel" => channel.clone()
+                        ),
+                        channel_records_gauge: gauge!(
+                            "windows_event_log_channel_records_total",
+                            "channel" => channel.clone()
+                        ),
+                        subscription_handle,
+                        signal_event,
+                        bookmark,
+                    });
+                }
+                Err(e) => {
+                    let error_code = (e.code().0 as u32) & 0xFFFF;
+                    if error_code == ERROR_EVT_CHANNEL_NOT_FOUND
+                        || error_code == ERROR_EVT_INVALID_QUERY
+                    {
+                        warn!(
+                            message = "Skipping channel (not found or invalid query).",
+                            channel = %channel,
+                            error_code = error_code
+                        );
+                        unsafe {
+                            let _ = CloseHandle(signal_event);
+                        }
+                        continue;
+                    } else if error_code == ERROR_ACCESS_DENIED {
+                        warn!(
+                            message = "Skipping channel due to access denied.",
+                            channel = %channel
+                        );
+                        unsafe {
+                            let _ = CloseHandle(signal_event);
+                        }
+                        continue;
+                    } else {
+                        // Clean up already-created subscriptions on failure
+                        for sub in channel_subscriptions {
+                            unsafe {
+                                let _ = EvtClose(sub.subscription_handle);
+                                let _ = CloseHandle(sub.signal_event);
+                            }
+                        }
+                        unsafe {
+                            let _ =
+                                CloseHandle(HANDLE(shutdown_event_raw as *mut std::ffi::c_void));
+                        }
+                        return Err(WindowsEventLogError::CreateSubscriptionError { source: e });
+                    }
+                }
+            }
+        }
+
+        // Verify we subscribed to at least one channel
+        if channel_subscriptions.is_empty() {
+            unsafe {
+                let _ = CloseHandle(HANDLE(shutdown_event_raw as *mut std::ffi::c_void));
+            }
+            return Err(WindowsEventLogError::ConfigError {
+                message: "No channels could be subscribed to. All channels may be inaccessible or direct/analytic channels.".into(),
+            });
+        }
+
+        info!(
+            message = "Successfully subscribed to channels (pull mode).",
+            channel_count = channel_subscriptions.len()
+        );
+
+        let shutdown_event = HANDLE(shutdown_event_raw as *mut std::ffi::c_void);
+        Ok(Self {
+            config,
+            channels: channel_subscriptions,
+            checkpointer,
+            rate_limiter,
+            shutdown_event,
+            render_buffer: vec![0u8; 16384],
+            publisher_cache: LruCache::new(NonZeroUsize::new(PUBLISHER_CACHE_CAPACITY).unwrap()),
+            format_cache: HashMap::new(),
+            cache_hits_counter: counter!("windows_event_log_cache_hits_total"),
+            cache_misses_counter: counter!("windows_event_log_cache_misses_total"),
+            sid_resolver: SidResolver::new(),
+            decode_buffer: vec![0u16; 8192],
+            round_robin_index: 0,
+        })
+    }
+
+    /// Wait for events to become available on any channel, or for shutdown.
+    ///
+    /// Uses `WaitForMultipleObjects` via `spawn_blocking` to avoid blocking the
+    /// Tokio runtime. The wait array includes all channel signal events plus the
+    /// shutdown event.
+    pub fn wait_for_events_blocking(&self, timeout_ms: u32) -> WaitResult {
+        // Build wait handle array: [channel0_signal, channel1_signal, ..., shutdown_event]
+        let mut handles: Vec<HANDLE> = self.channels.iter().map(|c| c.signal_event).collect();
+        handles.push(self.shutdown_event);
+
+        let result = unsafe { WaitForMultipleObjects(&handles, false, timeout_ms) };
+
+        let shutdown_index = (self.channels.len()) as u32;
+
+        match result {
+            r if r == WAIT_TIMEOUT => WaitResult::Timeout,
+            r if r.0 < WAIT_OBJECT_0.0 + shutdown_index => WaitResult::EventsAvailable,
+            r if r.0 == WAIT_OBJECT_0.0 + shutdown_index => WaitResult::Shutdown,
+            _ => {
+                // WAIT_FAILED or unexpected - treat as timeout to avoid tight loop
+                warn!(
+                    message = "WaitForMultipleObjects returned unexpected result.",
+                    result = result.0
+                );
+                WaitResult::Timeout
+            }
+        }
+    }
+
+    /// Pull events from all signaled channels with fair scheduling.
+    ///
+    /// Each channel gets a per-channel budget of `max_events / num_channels`
+    /// to prevent a single busy channel (e.g., Security) from starving others.
+    /// The starting channel rotates each call via round-robin. Channels that
+    /// don't use their budget simply leave slots unused — the next pull_events
+    /// call reclaims them naturally since the signal stays set.
+    ///
+    /// # At-least-once delivery semantics
+    ///
+    /// If a bookmark update fails mid-batch, events processed *before* the
+    /// failure are still returned and sent downstream, but the bookmark position
+    /// does not advance. On restart, those events will be re-read from the
+    /// channel, resulting in duplicates. This is an intentional trade-off:
+    /// at-least-once delivery is preferable to data loss.
+    pub fn pull_events(
+        &mut self,
+        max_events: usize,
+    ) -> Result<Vec<xml_parser::WindowsEvent>, WindowsEventLogError> {
+        let mut all_events = Vec::with_capacity(max_events.min(1000));
+        let num_channels = self.channels.len().max(1);
+        let per_channel_budget = (max_events / num_channels).max(1);
+        let start = self.round_robin_index % num_channels;
+        self.round_robin_index = self.round_robin_index.wrapping_add(1);
+
+        for i in 0..num_channels {
+            let channel_idx = (start + i) % num_channels;
+            let channel_sub = &mut self.channels[channel_idx];
+            let channel_limit = per_channel_budget.min(max_events.saturating_sub(all_events.len()));
+
+            if channel_limit == 0 {
+                break;
+            }
+
+            let mut channel_drained = false;
+            let mut bookmark_failed = false;
+            let mut channel_count = 0usize;
+
+            // Drain loop: keep calling EvtNext until ERROR_NO_MORE_ITEMS or channel budget.
+            // Only reset the signal once the channel is fully drained; if we hit the
+            // budget limit the signal stays set so WaitForMultipleObjects returns immediately.
+            'drain: loop {
+                if channel_count >= channel_limit {
+                    break;
+                }
+
+                let batch_size = (channel_limit - channel_count).min(100);
+                let mut event_handles: Vec<isize> = vec![0isize; batch_size];
+                let mut returned: u32 = 0;
+
+                let result = unsafe {
+                    EvtNext(
+                        channel_sub.subscription_handle,
+                        &mut event_handles,
+                        0,
+                        0,
+                        &mut returned,
+                    )
+                };
+
+                if let Err(err) = result {
+                    let code = (err.code().0 as u32) & 0xFFFF;
+                    if code == ERROR_NO_MORE_ITEMS {
+                        channel_drained = true;
+                        break;
+                    }
+                    if code == ERROR_EVT_QUERY_RESULT_STALE {
+                        debug!(
+                            message = "Channel subscription ended.",
+                            channel = %channel_sub.channel
+                        );
+                        channel_drained = true;
+                        break;
+                    }
+                    if code == ERROR_EVT_QUERY_RESULT_INVALID_POSITION {
+                        warn!(
+                            message = "Event log channel was cleared or query position invalidated, attempting re-subscription.",
+                            channel = %channel_sub.channel
+                        );
+                        match Self::resubscribe_channel(channel_sub, &self.config) {
+                            Ok(()) => {
+                                info!(
+                                    message = "Re-subscription succeeded after stale query.",
+                                    channel = %channel_sub.channel
+                                );
+                                // Retry from fresh subscription — the signal will fire again
+                                channel_drained = true;
+                                break;
+                            }
+                            Err(e) => {
+                                warn!(
+                                    message = "Re-subscription failed, will retry next cycle.",
+                                    channel = %channel_sub.channel,
+                                    error = %e
+                                );
+                                channel_sub.subscription_active_gauge.set(0.0);
+                                channel_drained = true;
+                                break;
+                            }
+                        }
+                    }
+                    return Err(WindowsEventLogError::PullEventsError {
+                        channel: channel_sub.channel.clone(),
+                        source: err,
+                    });
+                }
+
+                if returned == 0 {
+                    channel_drained = true;
+                    break;
+                }
+
+                channel_sub.events_read_counter.increment(returned as u64);
+                channel_sub
+                    .last_event_timestamp_gauge
+                    .set(chrono::Utc::now().timestamp() as f64);
+
+                let batch_handles = &event_handles[..returned as usize];
+                for (idx, &raw_handle) in batch_handles.iter().enumerate() {
+                    let event_handle = EVT_HANDLE(raw_handle);
+
+                    match super::render::render_event_xml(
+                        &mut self.render_buffer,
+                        &mut self.decode_buffer,
+                        event_handle,
+                    ) {
+                        Ok(xml) => {
+                            // Single-pass: parse all System fields in one traversal
+                            let system_fields = xml_parser::parse_system_section(&xml);
+
+                            // Early pre-filter: discard non-matching event IDs before
+                            // the expensive resolve_event_metadata / format_event_message
+                            // calls. This guarantees improved performance even when
+                            // XPath-level filtering is not applied (e.g. large ID lists).
+                            if let Some(ref only_ids) = self.config.only_event_ids
+                                && !only_ids.contains(&system_fields.event_id)
+                            {
+                                counter!("windows_event_log_events_filtered_total", "reason" => "event_id_prefilter")
+                                    .increment(1);
+                                unsafe {
+                                    let _ = EvtClose(event_handle);
+                                }
+                                continue;
+                            }
+                            if self
+                                .config
+                                .ignore_event_ids
+                                .contains(&system_fields.event_id)
+                            {
+                                counter!("windows_event_log_events_filtered_total", "reason" => "event_id_prefilter")
+                                    .increment(1);
+                                unsafe {
+                                    let _ = EvtClose(event_handle);
+                                }
+                                continue;
+                            }
+
+                            let channel_name = if system_fields.channel.is_empty() {
+                                channel_sub.channel.clone()
+                            } else {
+                                system_fields.channel.clone()
+                            };
+                            let provider_name = system_fields.provider_name.clone();
+                            let task_val = system_fields.task as u64;
+                            let opcode_val = system_fields.opcode as u64;
+                            let keywords_val = system_fields.keywords;
+
+                            let (task_name, opcode_name, keyword_names) =
+                                if !provider_name.is_empty() {
+                                    metadata::resolve_event_metadata(
+                                        &mut self.publisher_cache,
+                                        &mut self.format_cache,
+                                        &self.cache_hits_counter,
+                                        &self.cache_misses_counter,
+                                        event_handle,
+                                        &provider_name,
+                                        task_val,
+                                        opcode_val,
+                                        keywords_val,
+                                    )
+                                } else {
+                                    (None, None, Vec::new())
+                                };
+
+                            let rendered_message =
+                                if self.config.render_message && !provider_name.is_empty() {
+                                    metadata::format_event_message(
+                                        &mut self.publisher_cache,
+                                        event_handle,
+                                        &provider_name,
+                                    )
+                                } else {
+                                    None
+                                };
+
+                            if let Ok(Some(mut event)) = xml_parser::build_event(
+                                xml,
+                                &channel_name,
+                                &self.config,
+                                rendered_message,
+                                system_fields,
+                            ) {
+                                event.task_name = task_name;
+                                event.opcode_name = opcode_name;
+                                event.keyword_names = keyword_names;
+
+                                // Resolve SID to human-readable account name
+                                if let Some(ref sid) = event.user_id {
+                                    if let Some(account_name) = self.sid_resolver.resolve(sid) {
+                                        event.user_name = Some(account_name);
+                                    }
+                                }
+
+                                if let Err(e) = channel_sub.bookmark.update(event_handle) {
+                                    emit!(WindowsEventLogBookmarkError {
+                                        channel: channel_sub.channel.clone(),
+                                        error: e.to_string(),
+                                    });
+                                    bookmark_failed = true;
+                                    // Events already in all_events will still be delivered
+                                    // (at-least-once semantics — see doc comment on pull_events).
+                                    // Close current handle normally
+                                    unsafe {
+                                        let _ = EvtClose(event_handle);
+                                    }
+                                    // Close remaining unprocessed handles to prevent leak
+                                    for &h in &batch_handles[idx + 1..] {
+                                        unsafe {
+                                            let _ = EvtClose(EVT_HANDLE(h));
+                                        }
+                                    }
+                                    break 'drain;
+                                }
+                                all_events.push(event);
+                                channel_count += 1;
+                            }
+                        }
+                        Err(e) => {
+                            channel_sub.render_errors_counter.increment(1);
+                            warn!(
+                                message = "Failed to render event XML.",
+                                channel = %channel_sub.channel,
+                                batch_index = idx,
+                                event_handle = raw_handle,
+                                error = %e
+                            );
+                        }
+                    }
+
+                    unsafe {
+                        let _ = EvtClose(event_handle);
+                    }
+                }
+            }
+
+            if channel_drained && !bookmark_failed {
+                unsafe {
+                    let _ = ResetEvent(channel_sub.signal_event);
+                }
+
+                // Update channel record count gauge for lag detection.
+                super::render::update_channel_records(
+                    &channel_sub.channel,
+                    &channel_sub.channel_records_gauge,
+                );
+            }
+        }
+
+        Ok(all_events)
+    }
+
+    /// Re-subscribe a channel after its query position becomes invalid
+    /// (e.g., an admin cleared the event log). Closes the old subscription
+    /// handle and creates a new one using the current bookmark.
+    fn resubscribe_channel(
+        channel_sub: &mut ChannelSubscription,
+        config: &WindowsEventLogConfig,
+    ) -> Result<(), WindowsEventLogError> {
+        // Close the stale subscription handle
+        unsafe {
+            let _ = EvtClose(channel_sub.subscription_handle);
+        }
+
+        let channel_hstring = HSTRING::from(channel_sub.channel.as_str());
+        let query = Self::build_xpath_query(config)?;
+        let query_hstring = HSTRING::from(query);
+
+        let bookmark_handle = channel_sub.bookmark.as_handle();
+        let has_bookmark = bookmark_handle.0 != 0;
+
+        // Use EvtSubscribeStrict when resuming from bookmark so Windows fails
+        // explicitly if the bookmark position is stale, rather than silently
+        // falling back to oldest-record.
+        let subscription_flags = if has_bookmark {
+            EvtSubscribeStartAfterBookmark.0 | EvtSubscribeStrict.0
+        } else {
+            EvtSubscribeStartAtOldestRecord.0
+        };
+
+        let fallback_flags = if config.read_existing_events {
+            EvtSubscribeStartAtOldestRecord.0
+        } else {
+            EvtSubscribeToFutureEvents.0
+        };
+
+        let new_handle = unsafe {
+            if has_bookmark {
+                let strict_result = EvtSubscribe(
+                    None,
+                    channel_sub.signal_event,
+                    &channel_hstring,
+                    &query_hstring,
+                    bookmark_handle,
+                    None,
+                    None,
+                    subscription_flags,
+                );
+                match strict_result {
+                    Ok(handle) => Ok(handle),
+                    Err(e) => {
+                        warn!(
+                            message = "Strict bookmark resubscribe failed, retrying without bookmark. Potential re-delivery of events.",
+                            channel = %channel_sub.channel,
+                            error = %e,
+                            fallback_flags = format!("{:#x}", fallback_flags)
+                        );
+                        EvtSubscribe(
+                            None,
+                            channel_sub.signal_event,
+                            &channel_hstring,
+                            &query_hstring,
+                            None,
+                            None,
+                            None,
+                            fallback_flags,
+                        )
+                    }
+                }
+            } else {
+                EvtSubscribe(
+                    None,
+                    channel_sub.signal_event,
+                    &channel_hstring,
+                    &query_hstring,
+                    None,
+                    None,
+                    None,
+                    subscription_flags,
+                )
+            }
+        }
+        .map_err(|e| WindowsEventLogError::CreateSubscriptionError { source: e })?;
+
+        channel_sub.subscription_handle = new_handle;
+        channel_sub.subscription_active_gauge.set(1.0);
+
+        counter!(
+            "windows_event_log_resubscriptions_total",
+            "channel" => channel_sub.channel.clone()
+        )
+        .increment(1);
+
+        Ok(())
+    }
+
+    /// Returns the raw shutdown event handle value for use in the async shutdown watcher.
+    ///
+    /// The returned pointer is the underlying value of the Windows HANDLE. It can be
+    /// safely copied and used from another thread to call `SetEvent` because Windows
+    /// kernel objects are reference-counted and remain valid as long as at least one
+    /// handle is open (which this subscription maintains until Drop).
+    pub const fn shutdown_event_raw(&self) -> *mut std::ffi::c_void {
+        self.shutdown_event.0
+    }
+
+    /// Returns a reference to the rate limiter, if configured.
+    pub const fn rate_limiter(
+        &self,
+    ) -> Option<&RateLimiter<NotKeyed, InMemoryState, DefaultClock>> {
+        self.rate_limiter.as_ref()
+    }
+
+    /// Returns (total_channels, active_channels) for health reporting.
+    pub fn channel_health_summary(&self) -> (usize, usize) {
+        let total = self.channels.len();
+        // A channel is considered active if its subscription handle is non-null
+        let active = self
+            .channels
+            .iter()
+            .filter(|c| c.subscription_handle.0 != 0)
+            .count();
+        (total, active)
+    }
+
+    /// Flush all bookmarks to checkpoint storage.
+    ///
+    /// Call this before shutdown to ensure no events are lost.
+    pub async fn flush_bookmarks(&mut self) -> Result<(), WindowsEventLogError> {
+        debug!(message = "Flushing bookmarks to checkpoint storage.");
+
+        let bookmark_xmls: Vec<(String, String)> = self
+            .channels
+            .iter()
+            .filter_map(
+                |sub| match BookmarkManager::serialize_handle(sub.bookmark.as_handle()) {
+                    Ok(xml) if xml_parser::is_valid_bookmark_xml(&xml) => {
+                        Some((sub.channel.clone(), xml))
+                    }
+                    Ok(_) => None,
+                    Err(e) => {
+                        emit!(WindowsEventLogBookmarkError {
+                            channel: sub.channel.clone(),
+                            error: e.to_string(),
+                        });
+                        None
+                    }
+                },
+            )
+            .collect();
+
+        if !bookmark_xmls.is_empty() {
+            self.checkpointer.set_batch(bookmark_xmls).await?;
+            counter!("windows_event_log_checkpoint_writes_total").increment(1);
+        }
+
+        debug!(message = "Bookmark flush complete.");
+        Ok(())
+    }
+
+    /// Get the current bookmark XML for a specific channel.
+    ///
+    /// Used for acknowledgment-based checkpointing where the bookmark
+    /// state needs to be captured when events are read (not when they're acknowledged).
+    pub fn get_bookmark_xml(&self, channel: &str) -> Option<String> {
+        self.channels
+            .iter()
+            .find(|sub| sub.channel == channel)
+            .and_then(
+                |sub| match BookmarkManager::serialize_handle(sub.bookmark.as_handle()) {
+                    Ok(xml) if xml_parser::is_valid_bookmark_xml(&xml) => Some(xml),
+                    _ => None,
+                },
+            )
+    }
+
+    fn build_xpath_query(config: &WindowsEventLogConfig) -> Result<String, WindowsEventLogError> {
+        build_xpath_query(config)
+    }
+
+    fn validate_channels(config: &WindowsEventLogConfig) -> Result<(), WindowsEventLogError> {
+        for channel in &config.channels {
+            let channel_hstring = HSTRING::from(channel.as_str());
+            let channel_handle = unsafe { EvtOpenChannelConfig(None, &channel_hstring, 0) };
+
+            match channel_handle {
+                Ok(handle) => {
+                    if let Err(e) = unsafe { EvtClose(handle) } {
+                        warn!(message = "Failed to close channel config handle.", error = %e);
+                    }
+                }
+                Err(e) => {
+                    let error_code = (e.code().0 as u32) & 0xFFFF;
+                    if error_code == ERROR_FILE_NOT_FOUND
+                        || error_code == ERROR_EVT_CHANNEL_NOT_FOUND
+                        || error_code == ERROR_EVT_INVALID_QUERY
+                    {
+                        // Non-existent channels are skipped during EvtSubscribe below,
+                        // so warn here rather than failing the entire source.
+                        warn!(
+                            message = "Channel not found, will be skipped.",
+                            channel = %channel
+                        );
+                        continue;
+                    } else if error_code == ERROR_ACCESS_DENIED {
+                        warn!(
+                            message = "Channel access denied, will be skipped.",
+                            channel = %channel
+                        );
+                        continue;
+                    } else {
+                        return Err(WindowsEventLogError::OpenChannelError {
+                            channel: channel.clone(),
+                            source: e,
+                        });
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Maximum XPath query length supported by Windows Event Log API.
+/// Queries exceeding this limit fall back to `"*"` (all events).
+const XPATH_MAX_LENGTH: usize = 4096;
+
+/// Build an XPath query from config, incorporating `only_event_ids` when no
+/// explicit `event_query` is set.
+///
+/// When `only_event_ids` is configured and no custom `event_query` is provided,
+/// generates a query like `*[System[EventID=4624 or EventID=4625]]` so that
+/// the Windows API filters events at the source, avoiding the cost of pulling,
+/// rendering, and discarding non-matching events.
+///
+/// If the generated query exceeds [`XPATH_MAX_LENGTH`] (4096 chars), falls back
+/// to `"*"` and lets the downstream filter in `build_event()` handle it.
+pub(super) fn build_xpath_query(
+    config: &WindowsEventLogConfig,
+) -> Result<String, WindowsEventLogError> {
+    // Explicit event_query always takes precedence.
+    if let Some(ref custom_query) = config.event_query {
+        return Ok(custom_query.clone());
+    }
+
+    // Generate XPath from only_event_ids if present and non-empty.
+    if let Some(ref ids) = config.only_event_ids
+        && !ids.is_empty()
+    {
+        let query = if ids.len() == 1 {
+            format!("*[System[EventID={}]]", ids[0])
+        } else {
+            let predicates: Vec<String> = ids.iter().map(|id| format!("EventID={id}")).collect();
+            format!("*[System[{}]]", predicates.join(" or "))
+        };
+
+        if query.len() <= XPATH_MAX_LENGTH {
+            return Ok(query);
+        }
+        // Query too long — fall back to wildcard and rely on
+        // the in-process filter in build_event().
+        warn!(
+            message = "Generated XPath query exceeds maximum length, falling back to wildcard.",
+            query_len = query.len(),
+            max_len = XPATH_MAX_LENGTH,
+            num_event_ids = ids.len(),
+        );
+    }
+
+    Ok("*".to_string())
+}
+
+impl Drop for EventLogSubscription {
+    fn drop(&mut self) {
+        // Close subscription handles and signal events
+        for sub in &self.channels {
+            unsafe {
+                let _ = EvtClose(sub.subscription_handle);
+                let _ = CloseHandle(sub.signal_event);
+            }
+        }
+        // Publisher metadata handles are closed automatically by PublisherHandle::drop
+        // when the LRU cache is dropped.
+
+        // Close shutdown event
+        unsafe {
+            let _ = CloseHandle(self.shutdown_event);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn create_test_checkpointer() -> (Arc<Checkpointer>, tempfile::TempDir) {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let checkpointer = Arc::new(Checkpointer::new(temp_dir.path()).await.unwrap());
+        (checkpointer, temp_dir)
+    }
+
+    #[test]
+    fn test_rate_limiter_configuration() {
+        let mut config = WindowsEventLogConfig::default();
+        assert_eq!(config.events_per_second, 0);
+
+        config.events_per_second = 1000;
+        assert_eq!(config.events_per_second, 1000);
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiter_disabled_by_default() {
+        let config = WindowsEventLogConfig::default();
+        assert_eq!(
+            config.events_per_second, 0,
+            "Rate limiting should be disabled by default"
+        );
+    }
+
+    /// Test pull subscription creation and basic operation
+    #[tokio::test]
+    async fn test_pull_subscription_creation() {
+        let mut config = WindowsEventLogConfig::default();
+        config.channels = vec!["Application".to_string()];
+        config.event_timeout_ms = 1000;
+
+        let (checkpointer, _temp_dir) = create_test_checkpointer().await;
+
+        let subscription = EventLogSubscription::new(&config, checkpointer, false).await;
+        assert!(
+            subscription.is_ok(),
+            "Pull subscription creation should succeed: {:?}",
+            subscription.err()
+        );
+
+        let sub = subscription.unwrap();
+        assert_eq!(
+            sub.channels.len(),
+            1,
+            "Should have one channel subscription"
+        );
+    }
+
+    /// Test that wait_for_events_blocking returns timeout or events available
+    #[tokio::test]
+    async fn test_wait_for_events_timeout() {
+        let mut config = WindowsEventLogConfig::default();
+        config.channels = vec!["Application".to_string()];
+        config.read_existing_events = false;
+        config.event_timeout_ms = 100;
+
+        let (checkpointer, _temp_dir) = create_test_checkpointer().await;
+
+        let subscription = EventLogSubscription::new(&config, checkpointer, false)
+            .await
+            .expect("Subscription creation should succeed");
+
+        // Use ownership transfer pattern for spawn_blocking
+        let (subscription, result) = tokio::task::spawn_blocking(move || {
+            let r = subscription.wait_for_events_blocking(100);
+            (subscription, r)
+        })
+        .await
+        .unwrap();
+
+        // The first call may return EventsAvailable since signals are initially signaled.
+        // That's expected behavior per the pull model design.
+        match result {
+            WaitResult::EventsAvailable | WaitResult::Timeout => {}
+            WaitResult::Shutdown => panic!("Should not get shutdown"),
+        }
+
+        // Keep subscription alive until end of test
+        drop(subscription);
+    }
+
+    /// Test that signal_shutdown wakes a waiting thread
+    #[tokio::test]
+    async fn test_shutdown_signal_wakes_wait() {
+        let mut config = WindowsEventLogConfig::default();
+        config.channels = vec!["Application".to_string()];
+        config.event_timeout_ms = 500;
+
+        let (checkpointer, _temp_dir) = create_test_checkpointer().await;
+
+        let subscription = EventLogSubscription::new(&config, checkpointer, false)
+            .await
+            .expect("Subscription creation should succeed");
+
+        // First drain the initially-signaled state using ownership transfer
+        let (subscription, _) = tokio::task::spawn_blocking(move || {
+            let r = subscription.wait_for_events_blocking(50);
+            (subscription, r)
+        })
+        .await
+        .unwrap();
+
+        let shutdown_event_raw = subscription.shutdown_event_raw() as isize;
+
+        let wait_handle = tokio::task::spawn_blocking(move || {
+            let r = subscription.wait_for_events_blocking(30000);
+            (subscription, r)
+        });
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+        unsafe {
+            let handle = HANDLE(shutdown_event_raw as *mut std::ffi::c_void);
+            let _ = SetEvent(handle);
+        }
+
+        let (subscription, result) = wait_handle.await.unwrap();
+        match result {
+            WaitResult::Shutdown => {} // Expected
+            WaitResult::EventsAvailable => {
+                // Acceptable - there may have been real events
+            }
+            WaitResult::Timeout => {
+                panic!("Should not timeout - shutdown should have woken the wait");
+            }
+        }
+
+        drop(subscription);
+    }
+
+    /// Test pull_events with read_existing_events=true
+    #[tokio::test]
+    async fn test_pull_events_returns_events() {
+        let mut config = WindowsEventLogConfig::default();
+        config.channels = vec!["Application".to_string()];
+        config.read_existing_events = true;
+        config.event_timeout_ms = 2000;
+
+        let (checkpointer, _temp_dir) = create_test_checkpointer().await;
+
+        let subscription = EventLogSubscription::new(&config, checkpointer, false)
+            .await
+            .expect("Subscription creation should succeed");
+
+        // Wait and pull using ownership transfer pattern
+        let (mut subscription, wait_result) = tokio::task::spawn_blocking(move || {
+            let r = subscription.wait_for_events_blocking(2000);
+            (subscription, r)
+        })
+        .await
+        .unwrap();
+
+        match wait_result {
+            WaitResult::EventsAvailable => {
+                let events = subscription.pull_events(100).unwrap();
+                assert!(
+                    !events.is_empty(),
+                    "With read_existing_events=true, should get historical events"
+                );
+            }
+            WaitResult::Timeout => {
+                // Might happen on a system with empty Application log
+            }
+            WaitResult::Shutdown => panic!("Unexpected shutdown"),
+        }
+    }
+
+    /// Test multiple concurrent pull subscriptions
+    #[tokio::test]
+    async fn test_multiple_concurrent_subscriptions() {
+        let mut config1 = WindowsEventLogConfig::default();
+        config1.channels = vec!["Application".to_string()];
+        config1.event_timeout_ms = 1000;
+
+        let mut config2 = WindowsEventLogConfig::default();
+        config2.channels = vec!["System".to_string()];
+        config2.event_timeout_ms = 1000;
+
+        let (checkpointer1, _temp_dir1) = create_test_checkpointer().await;
+        let (checkpointer2, _temp_dir2) = create_test_checkpointer().await;
+
+        let sub1 = EventLogSubscription::new(&config1, checkpointer1, false)
+            .await
+            .expect("Subscription 1 (Application) should succeed");
+        let sub2 = EventLogSubscription::new(&config2, checkpointer2, false)
+            .await
+            .expect("Subscription 2 (System) should succeed");
+
+        // Both should be independently functional
+        assert_eq!(sub1.channels.len(), 1);
+        assert_eq!(sub2.channels.len(), 1);
+        assert_eq!(sub1.channels[0].channel, "Application");
+        assert_eq!(sub2.channels[0].channel, "System");
+    }
+
+    /// Test read_existing_events=false only receives future events
+    #[tokio::test]
+    async fn test_read_existing_events_false_only_receives_future_events() {
+        use chrono::Utc;
+
+        let mut config = WindowsEventLogConfig::default();
+        config.channels = vec!["Application".to_string()];
+        config.read_existing_events = false;
+        config.event_timeout_ms = 500;
+
+        let (checkpointer, _temp_dir) = create_test_checkpointer().await;
+        let subscription_start_time = Utc::now();
+
+        let mut subscription = EventLogSubscription::new(&config, checkpointer, false)
+            .await
+            .expect("Subscription creation should succeed");
+
+        // Brief wait then pull
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+        let events = subscription.pull_events(100).unwrap_or_default();
+
+        let tolerance = chrono::Duration::seconds(5);
+        let earliest_allowed = subscription_start_time - tolerance;
+
+        for event in &events {
+            assert!(
+                event.time_created >= earliest_allowed,
+                "Event timestamp {} is before subscription start time {} (minus tolerance). \
+                 read_existing_events=false may not be respected. Event ID: {}, Record ID: {}",
+                event.time_created,
+                subscription_start_time,
+                event.event_id,
+                event.record_id
+            );
+        }
+    }
+
+    /// Test that subscription gracefully handles an invalid/corrupted bookmark
+    /// from a checkpoint, falling back to a fresh bookmark without crashing.
+    #[tokio::test]
+    async fn test_checkpoint_with_invalid_bookmark_falls_back_gracefully() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let checkpointer = Arc::new(Checkpointer::new(temp_dir.path()).await.unwrap());
+
+        let fake_bookmark = r#"<BookmarkList><Bookmark Channel='Application' RecordId='999999999' IsCurrent='true'/></BookmarkList>"#;
+
+        checkpointer
+            .set("Application".to_string(), fake_bookmark.to_string())
+            .await
+            .expect("Should be able to set checkpoint");
+
+        let mut config = WindowsEventLogConfig::default();
+        config.channels = vec!["Application".to_string()];
+        config.read_existing_events = true;
+        config.event_timeout_ms = 500;
+
+        // The subscription should succeed even with a corrupted/invalid bookmark,
+        // gracefully falling back to a fresh bookmark.
+        let mut subscription = EventLogSubscription::new(&config, checkpointer, false)
+            .await
+            .expect("Subscription should succeed even with invalid bookmark checkpoint");
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+        // Just verify we can pull events without panicking.
+        // The bookmark format above is not a real Windows bookmark, so the
+        // subscription will fall back to reading from scratch. We only assert
+        // that the subscription is functional.
+        let _events = subscription.pull_events(100).unwrap_or_default();
+    }
+}

--- a/src/sources/windows_event_log/subscription.rs
+++ b/src/sources/windows_event_log/subscription.rs
@@ -18,9 +18,9 @@ use windows::Win32::System::EventLog::{
     EvtSubscribeStartAfterBookmark, EvtSubscribeStartAtOldestRecord, EvtSubscribeStrict,
     EvtSubscribeToFutureEvents,
 };
-#[cfg(test)]
-use windows::Win32::System::Threading::SetEvent;
-use windows::Win32::System::Threading::{CreateEventW, ResetEvent, WaitForMultipleObjects};
+use windows::Win32::System::Threading::{
+    CreateEventW, ResetEvent, SetEvent, WaitForMultipleObjects,
+};
 use windows::core::HSTRING;
 
 use super::{
@@ -29,6 +29,19 @@ use super::{
 };
 
 use crate::internal_events::WindowsEventLogBookmarkError;
+
+/// Test-only hook called inside the `pull_events` drain loop after each
+/// `EvtNext` invocation. Used by the lost-wakeup regression test
+/// (see `test_pull_events_preserves_setevent_during_drain`) to race a
+/// `SetEvent` against the drain without relying on thread-timing.
+/// No-op and zero-cost in non-test builds.
+///
+/// Only one test should install a hook at a time; tests that install a hook
+/// must use `#[serial_test::serial]` or equivalent serialization to prevent
+/// concurrent tests from triggering each other's hook.
+#[cfg(test)]
+static DRAIN_STEP_HOOK: std::sync::Mutex<Option<std::sync::Arc<dyn Fn(HANDLE) + Send + Sync>>> =
+    std::sync::Mutex::new(None);
 
 /// Maximum number of entries in the EvtFormatMessage result cache.
 pub const FORMAT_CACHE_CAPACITY: usize = 10_000;
@@ -80,6 +93,7 @@ struct ChannelSubscription {
 
 // SAFETY: Same rationale as EventLogSubscription - Windows kernel handles are thread-safe.
 unsafe impl Send for ChannelSubscription {}
+unsafe impl Sync for ChannelSubscription {}
 
 /// Result of waiting for events across all channels.
 pub enum WaitResult {
@@ -130,8 +144,10 @@ pub struct EventLogSubscription {
 
 // SAFETY: Windows HANDLE and EVT_HANDLE are kernel objects safe to use across
 // threads. In windows 0.58, HANDLE wraps *mut c_void which is !Send/!Sync,
-// but the underlying kernel handles are thread-safe.
+// but the underlying kernel handles are thread-safe. All mutation requires
+// &mut self; &self methods are read-only or delegate to Sync types (RateLimiter).
 unsafe impl Send for EventLogSubscription {}
+unsafe impl Sync for EventLogSubscription {}
 
 impl EventLogSubscription {
     /// Create a new pull-model subscription for all configured channels.
@@ -415,21 +431,20 @@ impl EventLogSubscription {
     /// Wait for events to become available on any channel, or for shutdown.
     ///
     /// Uses `WaitForMultipleObjects` via `spawn_blocking` to avoid blocking the
-    /// Tokio runtime. The wait array includes all channel signal events plus the
-    /// shutdown event.
+    /// Tokio runtime. The wait array puts shutdown first so a stop request wins
+    /// over any channel that is already signaled.
     pub fn wait_for_events_blocking(&self, timeout_ms: u32) -> WaitResult {
-        // Build wait handle array: [channel0_signal, channel1_signal, ..., shutdown_event]
-        let mut handles: Vec<HANDLE> = self.channels.iter().map(|c| c.signal_event).collect();
+        // Build wait handle array: [shutdown_event, channel0_signal, channel1_signal, ...]
+        let mut handles = Vec::with_capacity(self.channels.len() + 1);
         handles.push(self.shutdown_event);
+        handles.extend(self.channels.iter().map(|c| c.signal_event));
 
         let result = unsafe { WaitForMultipleObjects(&handles, false, timeout_ms) };
 
-        let shutdown_index = (self.channels.len()) as u32;
-
         match result {
             r if r == WAIT_TIMEOUT => WaitResult::Timeout,
-            r if r.0 < WAIT_OBJECT_0.0 + shutdown_index => WaitResult::EventsAvailable,
-            r if r.0 == WAIT_OBJECT_0.0 + shutdown_index => WaitResult::Shutdown,
+            r if r == WAIT_OBJECT_0 => WaitResult::Shutdown,
+            r if r.0 <= WAIT_OBJECT_0.0 + self.channels.len() as u32 => WaitResult::EventsAvailable,
             _ => {
                 // WAIT_FAILED or unexpected - treat as timeout to avoid tight loop
                 warn!(
@@ -460,6 +475,28 @@ impl EventLogSubscription {
         &mut self,
         max_events: usize,
     ) -> Result<Vec<xml_parser::WindowsEvent>, WindowsEventLogError> {
+        self.pull_events_inner(max_events, true)
+    }
+
+    /// Pull events for timeout-based speculative recovery.
+    ///
+    /// This keeps the same event-drain behavior as `pull_events`, but avoids
+    /// refreshing per-channel record-count gauges for channels that were empty.
+    /// Timeout pulls can run repeatedly while the host is idle, so skipping
+    /// those metadata queries prevents steady `EvtOpenLog`/`EvtGetLogInfo`
+    /// churn without changing event recovery behavior.
+    pub fn pull_events_speculative(
+        &mut self,
+        max_events: usize,
+    ) -> Result<Vec<xml_parser::WindowsEvent>, WindowsEventLogError> {
+        self.pull_events_inner(max_events, false)
+    }
+
+    fn pull_events_inner(
+        &mut self,
+        max_events: usize,
+        update_records_for_empty_channels: bool,
+    ) -> Result<Vec<xml_parser::WindowsEvent>, WindowsEventLogError> {
         let mut all_events = Vec::with_capacity(max_events.min(1000));
         let num_channels = self.channels.len().max(1);
         let per_channel_budget = (max_events / num_channels).max(1);
@@ -479,9 +516,25 @@ impl EventLogSubscription {
             let mut bookmark_failed = false;
             let mut channel_count = 0usize;
 
-            // Drain loop: keep calling EvtNext until ERROR_NO_MORE_ITEMS or channel budget.
-            // Only reset the signal once the channel is fully drained; if we hit the
-            // budget limit the signal stays set so WaitForMultipleObjects returns immediately.
+            // Reset the signal BEFORE draining to avoid a lost-wakeup race
+            // (see vectordotdev/vector#25194). The Windows Event Log service
+            // signals this manual-reset event via SetEvent each time a new
+            // matching event is recorded; SetEvent on an already-signaled
+            // event is a no-op, so if we reset AFTER draining, any signal
+            // that arrives between our last EvtNext and ResetEvent is lost
+            // — the subscription then hangs until the next event arrives.
+            // Resetting first means any signal raised during the drain is
+            // preserved, causing the next WaitForMultipleObjects to return
+            // immediately.
+            //
+            // If we exit the drain loop early (channel budget exhausted or
+            // bookmark update failed mid-batch), we re-SetEvent at the end
+            // of this iteration so the next pull_events call revisits this
+            // channel without waiting for a fresh OS signal.
+            unsafe {
+                let _ = ResetEvent(channel_sub.signal_event);
+            }
+
             'drain: loop {
                 if channel_count >= channel_limit {
                     break;
@@ -501,6 +554,17 @@ impl EventLogSubscription {
                     )
                 };
 
+                // Test-only hook: lets the lost-wakeup regression test race
+                // a SetEvent against the drain without thread-timing. No-op
+                // and zero-cost in non-test builds.
+                #[cfg(test)]
+                {
+                    let hook = DRAIN_STEP_HOOK.lock().unwrap().clone();
+                    if let Some(h) = hook {
+                        h(channel_sub.signal_event);
+                    }
+                }
+
                 if let Err(err) = result {
                     let code = (err.code().0 as u32) & 0xFFFF;
                     if code == ERROR_NO_MORE_ITEMS {
@@ -513,6 +577,8 @@ impl EventLogSubscription {
                             channel = %channel_sub.channel
                         );
                         channel_drained = true;
+                        // Speculative pull on timeout in mod.rs is a safety net if the
+                        // re-subscribed channel does not immediately re-signal.
                         break;
                     }
                     if code == ERROR_EVT_QUERY_RESULT_INVALID_POSITION {
@@ -526,7 +592,9 @@ impl EventLogSubscription {
                                     message = "Re-subscription succeeded after stale query.",
                                     channel = %channel_sub.channel
                                 );
-                                // Retry from fresh subscription — the signal will fire again
+                                // Retry from fresh subscription — the signal will fire again.
+                                // Speculative pull on timeout in mod.rs is a safety net if
+                                // the new subscription does not immediately re-signal.
                                 channel_drained = true;
                                 break;
                             }
@@ -538,9 +606,22 @@ impl EventLogSubscription {
                                 );
                                 channel_sub.subscription_active_gauge.set(0.0);
                                 channel_drained = true;
+                                // Speculative pull on timeout in mod.rs is a safety net if
+                                // the failed channel does not re-signal after recovery.
                                 break;
                             }
                         }
+                    }
+                    // Re-arm the signal before returning. We reset it pre-drain
+                    // but are bailing out without confirming the drain completed,
+                    // so if events were left un-drained the next pull_events must
+                    // still revisit this channel without waiting for a fresh OS
+                    // signal. This mirrors the `else` branch below that handles
+                    // budget-exhaustion and bookmark-failure early breaks, and
+                    // avoids the same lost-wakeup symptom (vectordotdev/vector#25194)
+                    // on transient EvtNext failures.
+                    unsafe {
+                        let _ = SetEvent(channel_sub.signal_event);
                     }
                     return Err(WindowsEventLogError::PullEventsError {
                         channel: channel_sub.channel.clone(),
@@ -697,15 +778,22 @@ impl EventLogSubscription {
             }
 
             if channel_drained && !bookmark_failed {
-                unsafe {
-                    let _ = ResetEvent(channel_sub.signal_event);
-                }
-
                 // Update channel record count gauge for lag detection.
-                super::render::update_channel_records(
-                    &channel_sub.channel,
-                    &channel_sub.channel_records_gauge,
-                );
+                if update_records_for_empty_channels || channel_count > 0 {
+                    super::render::update_channel_records(
+                        &channel_sub.channel,
+                        &channel_sub.channel_records_gauge,
+                    );
+                }
+            } else {
+                // Drain exited early (budget exhausted or bookmark_failed
+                // mid-batch). Re-arm the signal so the next pull_events
+                // revisits this channel immediately without waiting for a
+                // fresh OS notification. Pairs with the pre-drain ResetEvent
+                // above.
+                unsafe {
+                    let _ = SetEvent(channel_sub.signal_event);
+                }
             }
         }
 
@@ -814,6 +902,15 @@ impl EventLogSubscription {
     /// handle is open (which this subscription maintains until Drop).
     pub const fn shutdown_event_raw(&self) -> *mut std::ffi::c_void {
         self.shutdown_event.0
+    }
+
+    /// Test-only accessor for the first channel's signal event handle. Used
+    /// by the lost-wakeup regression test to scope its drain-loop hook to
+    /// exactly this subscription, so it does not fire on concurrent
+    /// `pull_events` calls from other tests in the same process.
+    #[cfg(test)]
+    pub(super) fn first_channel_signal_raw(&self) -> isize {
+        self.channels[0].signal_event.0 as isize
     }
 
     /// Returns a reference to the rate limiter, if configured.
@@ -1005,6 +1102,7 @@ impl Drop for EventLogSubscription {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     async fn create_test_checkpointer() -> (Arc<Checkpointer>, tempfile::TempDir) {
         let temp_dir = tempfile::TempDir::new().unwrap();
@@ -1134,6 +1232,31 @@ mod tests {
         }
 
         drop(subscription);
+    }
+
+    /// Test that shutdown wins when both shutdown and channel handles are signaled.
+    #[tokio::test]
+    async fn test_shutdown_signal_takes_priority_over_channel_signal() {
+        let mut config = WindowsEventLogConfig::default();
+        config.channels = vec!["Application".to_string()];
+        config.event_timeout_ms = 500;
+
+        let (checkpointer, _temp_dir) = create_test_checkpointer().await;
+
+        let subscription = EventLogSubscription::new(&config, checkpointer, false)
+            .await
+            .expect("Subscription creation should succeed");
+
+        unsafe {
+            let handle = HANDLE(subscription.shutdown_event_raw());
+            let _ = SetEvent(handle);
+        }
+
+        let result = subscription.wait_for_events_blocking(0);
+        assert!(
+            matches!(result, WaitResult::Shutdown),
+            "shutdown should take priority over already-signaled channels"
+        );
     }
 
     /// Test pull_events with read_existing_events=true
@@ -1271,5 +1394,210 @@ mod tests {
         // subscription will fall back to reading from scratch. We only assert
         // that the subscription is functional.
         let _events = subscription.pull_events(100).unwrap_or_default();
+    }
+
+    /// Proves that `pull_events` works independently of signal state — the
+    /// invariant the speculative timeout pull in mod.rs relies on.
+    ///
+    /// Steps:
+    /// 1. Subscribe to the Application log with `read_existing_events = true`.
+    /// 2. Manually clear the channel signal via `ResetEvent`, simulating a lost wakeup.
+    /// 3. Assert `wait_for_events_blocking` times out (signal cleared, no OS wake-up).
+    /// 4. Assert `pull_events` still returns events — `EvtNext` fetches from the queue
+    ///    regardless of signal state, so the speculative pull in mod.rs self-heals.
+    #[tokio::test]
+    #[serial]
+    async fn test_pull_events_works_with_cleared_signal() {
+        // Seed the Application log with a record so the "events remain
+        // available despite cleared signal" assertion below does not depend
+        // on whatever backlog the runner happens to have. Freshly provisioned
+        // CI images can have an empty Application log, which would otherwise
+        // make `pull_events` legitimately return empty and produce a spurious
+        // failure unrelated to the invariant under test.
+        let seed_output = std::process::Command::new("eventcreate")
+            .args([
+                "/T",
+                "INFORMATION",
+                "/ID",
+                "100",
+                "/L",
+                "APPLICATION",
+                "/SO",
+                "VectorTestSpeculativePullSeed",
+                "/D",
+                "seed event for #25194 speculative-pull regression test",
+            ])
+            .output()
+            .expect("failed to spawn eventcreate — required for deterministic seeding");
+        assert!(
+            seed_output.status.success(),
+            "eventcreate failed to seed Application log (exit={:?}): stdout={:?} stderr={:?}. \
+             This test requires a seeded event to be deterministic; a locked-down runner \
+             without the privilege to write to Application cannot run this test reliably.",
+            seed_output.status.code(),
+            String::from_utf8_lossy(&seed_output.stdout),
+            String::from_utf8_lossy(&seed_output.stderr),
+        );
+        // Give the service a moment to persist the record before we subscribe.
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        let mut config = WindowsEventLogConfig::default();
+        config.channels = vec!["Application".to_string()];
+        config.read_existing_events = true;
+        config.event_timeout_ms = 500;
+
+        let (checkpointer, _temp_dir) = create_test_checkpointer().await;
+
+        let mut subscription = EventLogSubscription::new(&config, checkpointer, false)
+            .await
+            .expect("Subscription creation should succeed");
+
+        // Manually clear the signal to simulate a lost wakeup. The seeded
+        // event above guarantees at least one record is queued in EvtNext
+        // regardless of the runner's pre-existing log state.
+        let signal_raw = subscription.first_channel_signal_raw();
+        unsafe {
+            let _ = ResetEvent(HANDLE(signal_raw as *mut std::ffi::c_void));
+        }
+
+        // Signal is cleared: an immediate (0ms) poll must report Timeout.
+        // A 0ms wait reads only the current signal state with no grace
+        // window, so unrelated Windows system events arriving between the
+        // `ResetEvent` above and the poll cannot re-signal the handle and
+        // cause a spurious failure.
+        let wait_result = subscription.wait_for_events_blocking(0);
+
+        assert!(
+            matches!(wait_result, WaitResult::Timeout),
+            "expected Timeout after manual ResetEvent; signal was not cleared"
+        );
+
+        // Despite the cleared signal, pull_events must still return events.
+        // This is the invariant the speculative timeout pull in mod.rs depends on.
+        let events = subscription.pull_events(100).unwrap_or_default();
+        assert!(
+            !events.is_empty(),
+            "pull_events must return events independently of signal state; \
+             this is the invariant the speculative timeout pull in mod.rs depends on"
+        );
+    }
+
+    /// Regression test for vectordotdev/vector#25194.
+    ///
+    /// The Windows Event Log service signals the pull-mode wait handle via
+    /// `SetEvent` each time a new matching event is recorded. Because the
+    /// handle is manual-reset, `SetEvent` on an already-signaled handle is
+    /// a no-op. If `pull_events` resets the signal *after* draining events
+    /// via `EvtNext`, any signal that fires between the last `EvtNext` and
+    /// the `ResetEvent` call is silently lost — the subscription then
+    /// permanently hangs until a subsequent event arrives.
+    ///
+    /// The fix is to reset the signal *before* the drain loop, so signals
+    /// raised during the drain are preserved and the next wait returns
+    /// immediately.
+    ///
+    /// This test pins that invariant by driving the real `pull_events`
+    /// against a real `EvtSubscribe` handle. It installs a
+    /// `DRAIN_STEP_HOOK` that runs inside the drain loop after each
+    /// `EvtNext` and fires `SetEvent` on the subscription's signal
+    /// handle — simulating the OS signaling a new event arrival during
+    /// the drain window. After `pull_events` returns, the signal must
+    /// still be set — observed via a 0ms `wait_for_events_blocking`
+    /// so the check measures only the reset/preserve behavior of
+    /// `pull_events` and is not contaminated by unrelated Windows
+    /// system events arriving during a nonzero wait. Under the old
+    /// post-drain `ResetEvent` order, the hook's `SetEvent` would be
+    /// clobbered by the reset and the immediate poll would return
+    /// `Timeout` — which is exactly what #25194 reports.
+    #[tokio::test]
+    #[serial]
+    async fn test_pull_events_preserves_setevent_during_drain() {
+        use std::sync::Arc as StdArc;
+
+        let mut config = WindowsEventLogConfig::default();
+        config.channels = vec!["Application".to_string()];
+        config.read_existing_events = true;
+        config.event_timeout_ms = 1000;
+
+        let (checkpointer, _temp_dir) = create_test_checkpointer().await;
+
+        let mut subscription = EventLogSubscription::new(&config, checkpointer, false)
+            .await
+            .expect("Subscription creation should succeed");
+
+        // Capture THIS subscription's signal handle so the hook can scope
+        // itself to this test. DRAIN_STEP_HOOK is a process-global, and
+        // cargo runs tests in parallel by default; without handle-keying,
+        // a concurrent test's pull_events could trigger our one-shot
+        // hook first, flip `fired`, and SetEvent on the wrong handle.
+        let target_signal_raw = subscription.first_channel_signal_raw();
+
+        // Install the drain-loop hook: every EvtNext call inside
+        // pull_events fires SetEvent on the subscription's signal
+        // handle. This simulates the OS signaling a fresh event
+        // mid-drain, which is exactly the race window #25194 exposes.
+        // The hook only needs to fire once to prove the invariant; we
+        // use an AtomicBool to keep it deterministic. The hook is keyed
+        // to `target_signal_raw` so concurrent pull_events calls from
+        // other tests no-op here.
+        let fired = StdArc::new(std::sync::atomic::AtomicBool::new(false));
+        {
+            let fired = StdArc::clone(&fired);
+            let hook: StdArc<dyn Fn(HANDLE) + Send + Sync> = StdArc::new(move |signal: HANDLE| {
+                if signal.0 as isize != target_signal_raw {
+                    return;
+                }
+                if !fired.swap(true, std::sync::atomic::Ordering::SeqCst) {
+                    unsafe {
+                        let _ = SetEvent(signal);
+                    }
+                }
+            });
+            *DRAIN_STEP_HOOK.lock().unwrap() = Some(hook);
+        }
+
+        // Drop-guard: clear the hook even if the test panics, so it
+        // doesn't contaminate other tests in the same process.
+        struct HookGuard;
+        impl Drop for HookGuard {
+            fn drop(&mut self) {
+                *DRAIN_STEP_HOOK.lock().unwrap() = None;
+            }
+        }
+        let _guard = HookGuard;
+
+        // Drive pull_events with a very large budget so the drain
+        // exits via ERROR_NO_MORE_ITEMS (channel_drained = true),
+        // which is the path that ran the post-drain ResetEvent in the
+        // old buggy code. Exiting via budget exhaustion would skip
+        // that reset and cause this test to false-pass against the
+        // pre-fix code.
+        let _ = subscription.pull_events(usize::MAX).unwrap_or_default();
+
+        assert!(
+            fired.load(std::sync::atomic::Ordering::SeqCst),
+            "drain-loop hook never ran — pull_events must call EvtNext \
+             at least once even on an empty channel"
+        );
+
+        // Observe the signal state IMMEDIATELY with a 0ms wait. We want
+        // to know whether pull_events's reset clobbered the hook's
+        // SetEvent — NOT whether new real events arrive during some
+        // wait window. A nonzero timeout against the live Application
+        // channel lets arbitrary Windows system events re-signal us
+        // and false-pass against the pre-fix code. 0ms = WaitForMultiple-
+        // Objects returns the current state with no grace period, so
+        // only the reset/preserve behavior of pull_events is measured.
+        let result = subscription.wait_for_events_blocking(0);
+
+        match result {
+            WaitResult::EventsAvailable => {}
+            WaitResult::Timeout => panic!(
+                "signal set during the drain window was lost — this is the \
+                 lost-wakeup race from vectordotdev/vector#25194. \
+                 pull_events must call ResetEvent BEFORE draining, not after."
+            ),
+            WaitResult::Shutdown => panic!("unexpected shutdown"),
+        }
     }
 }

--- a/src/sources/windows_event_log/subscription.rs
+++ b/src/sources/windows_event_log/subscription.rs
@@ -656,15 +656,15 @@ impl EventLogSubscription {
                             // the expensive resolve_event_metadata / format_event_message
                             // calls. This guarantees improved performance even when
                             // XPath-level filtering is not applied (e.g. large ID lists).
-                            if let Some(ref only_ids) = self.config.only_event_ids
-                                && !only_ids.contains(&system_fields.event_id)
-                            {
-                                counter!("windows_event_log_events_filtered_total", "reason" => "event_id_prefilter")
-                                    .increment(1);
-                                unsafe {
-                                    let _ = EvtClose(event_handle);
+                            if let Some(ref only_ids) = self.config.only_event_ids {
+                                if !only_ids.contains(&system_fields.event_id) {
+                                    counter!("windows_event_log_events_filtered_total", "reason" => "event_id_prefilter")
+                                        .increment(1);
+                                    unsafe {
+                                        let _ = EvtClose(event_handle);
+                                    }
+                                    continue;
                                 }
-                                continue;
                             }
                             if self
                                 .config
@@ -1054,27 +1054,29 @@ pub(super) fn build_xpath_query(
     }
 
     // Generate XPath from only_event_ids if present and non-empty.
-    if let Some(ref ids) = config.only_event_ids
-        && !ids.is_empty()
-    {
-        let query = if ids.len() == 1 {
-            format!("*[System[EventID={}]]", ids[0])
-        } else {
-            let predicates: Vec<String> = ids.iter().map(|id| format!("EventID={id}")).collect();
-            format!("*[System[{}]]", predicates.join(" or "))
-        };
+    if let Some(ref ids) = config.only_event_ids {
+        if !ids.is_empty() {
+            let query = if ids.len() == 1 {
+                format!("*[System[EventID={}]]", ids[0])
+            } else {
+                let predicates: Vec<String> =
+                    ids.iter().map(|id| format!("EventID={id}")).collect();
+                format!("*[System[{}]]", predicates.join(" or "))
+            };
 
-        if query.len() <= XPATH_MAX_LENGTH {
-            return Ok(query);
+            if query.len() <= XPATH_MAX_LENGTH {
+                return Ok(query);
+            }
+            // Query too long — fall back to wildcard and rely on
+            // the in-process filter in build_event().
+            warn!(
+                message =
+                    "Generated XPath query exceeds maximum length, falling back to wildcard.",
+                query_len = query.len(),
+                max_len = XPATH_MAX_LENGTH,
+                num_event_ids = ids.len(),
+            );
         }
-        // Query too long — fall back to wildcard and rely on
-        // the in-process filter in build_event().
-        warn!(
-            message = "Generated XPath query exceeds maximum length, falling back to wildcard.",
-            query_len = query.len(),
-            max_len = XPATH_MAX_LENGTH,
-            num_event_ids = ids.len(),
-        );
     }
 
     Ok("*".to_string())

--- a/src/sources/windows_event_log/tests.rs
+++ b/src/sources/windows_event_log/tests.rs
@@ -1,0 +1,1648 @@
+use std::{collections::HashMap, time::Duration};
+
+use chrono::Utc;
+use vector_lib::config::LogNamespace;
+use vrl::value::Value;
+
+use super::{config::*, error::*, parser::*, xml_parser::*};
+use crate::{
+    config::SourceConfig,
+    test_util::components::{SOURCE_TAGS, run_and_assert_source_compliance},
+};
+
+fn create_test_config() -> WindowsEventLogConfig {
+    WindowsEventLogConfig {
+        channels: vec!["System".to_string(), "Application".to_string()],
+        event_query: None,
+        connection_timeout_secs: 30,
+        read_existing_events: false,
+        batch_size: 10,
+        include_xml: false,
+        event_data_format: HashMap::new(),
+        ignore_event_ids: vec![],
+        only_event_ids: None,
+        max_event_age_secs: None,
+        event_timeout_ms: 5000,
+        log_namespace: Some(false),
+        field_filter: FieldFilter::default(),
+        data_dir: None, // Use Vector's global data_dir
+        events_per_second: 0,
+        max_event_data_length: 0,
+        checkpoint_interval_secs: 5,
+        acknowledgements: Default::default(),
+        render_message: false,
+    }
+}
+
+/// Creates a realistic Security audit event (4624 = successful logon) for integration-level tests.
+/// Note: parser.rs has its own simpler create_test_event() for unit testing parser logic.
+fn create_test_event() -> WindowsEvent {
+    let mut event_data = HashMap::new();
+    event_data.insert("TargetUserName".to_string(), "admin".to_string());
+    event_data.insert("LogonType".to_string(), "2".to_string());
+
+    WindowsEvent {
+        record_id: 12345,
+        event_id: 4624,
+        level: 4,
+        task: 12544,
+        opcode: 0,
+        keywords: 0x8020000000000000,
+        time_created: Utc::now(),
+        provider_name: "Microsoft-Windows-Security-Auditing".to_string(),
+        provider_guid: Some("{54849625-5478-4994-a5ba-3e3b0328c30d}".to_string()),
+        channel: "Security".to_string(),
+        computer: "WIN-SERVER-01".to_string(),
+        user_id: Some("S-1-5-18".to_string()),
+        process_id: 716,
+        thread_id: 796,
+        activity_id: Some("{b25f4adf-d920-0000-0000-000000000000}".to_string()),
+        related_activity_id: None,
+        raw_xml: r#"<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+            <System>
+                <Provider Name="Microsoft-Windows-Security-Auditing" Guid="{54849625-5478-4994-a5ba-3e3b0328c30d}" />
+                <EventID>4624</EventID>
+                <Level>0</Level>
+                <Task>12544</Task>
+                <Opcode>0</Opcode>
+                <Keywords>0x8020000000000000</Keywords>
+                <TimeCreated SystemTime="2023-01-01T00:00:00.000000Z" />
+                <EventRecordID>12345</EventRecordID>
+                <Correlation ActivityID="{b25f4adf-d920-0000-0000-000000000000}" />
+                <Execution ProcessID="716" ThreadID="796" />
+                <Channel>Security</Channel>
+                <Computer>WIN-SERVER-01</Computer>
+                <Security UserID="S-1-5-18" />
+            </System>
+            <EventData>
+                <Data Name="TargetUserName">admin</Data>
+                <Data Name="LogonType">2</Data>
+            </EventData>
+        </Event>"#.to_string(),
+        rendered_message: Some("An account was successfully logged on.".to_string()),
+        event_data,
+        user_data: HashMap::new(),
+        task_name: None,
+        opcode_name: None,
+        keyword_names: Vec::new(),
+        user_name: None,
+        version: Some(1),
+        qualifiers: Some(0),
+        string_inserts: vec!["admin".to_string(), "2".to_string()],
+    }
+}
+
+#[cfg(test)]
+mod config_tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_default_config_creation() {
+        let config = WindowsEventLogConfig::default();
+
+        assert_eq!(config.channels, vec!["System", "Application"]);
+        assert_eq!(config.connection_timeout_secs, 30);
+        assert_eq!(config.event_timeout_ms, 5000);
+        assert!(!config.read_existing_events);
+        assert_eq!(config.batch_size, 100);
+        assert!(!config.include_xml);
+        assert!(config.render_message);
+        assert!(config.field_filter.include_system_fields);
+        assert!(config.field_filter.include_event_data);
+        assert!(config.field_filter.include_user_data);
+    }
+
+    #[test]
+    fn generate_config() {
+        crate::test_util::test_generate_config::<WindowsEventLogConfig>();
+    }
+
+    #[test]
+    fn test_config_validation_success() {
+        let config = create_test_config();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_config_validation_empty_channels() {
+        let mut config = create_test_config();
+        config.channels = vec![];
+
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("At least one channel")
+        );
+    }
+
+    #[test]
+    fn test_config_validation_zero_connection_timeout() {
+        let mut config = create_test_config();
+        config.connection_timeout_secs = 0;
+
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Connection timeout must be between")
+        );
+    }
+
+    #[test]
+    fn test_config_validation_zero_event_timeout() {
+        let mut config = create_test_config();
+        config.event_timeout_ms = 0;
+
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Event timeout must be between")
+        );
+    }
+
+    #[test]
+    fn test_config_validation_zero_batch_size() {
+        let mut config = create_test_config();
+        config.batch_size = 0;
+
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Batch size must be between 1 and")
+        );
+    }
+
+    #[test]
+    fn test_config_validation_empty_channel_name() {
+        let mut config = create_test_config();
+        config.channels = vec!["System".to_string(), "".to_string()];
+
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Channel names cannot be empty")
+        );
+    }
+
+    #[test]
+    fn test_config_validation_empty_query() {
+        let mut config = create_test_config();
+        config.event_query = Some("".to_string());
+
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Event query cannot be empty")
+        );
+    }
+
+    #[test]
+    fn test_config_serialization() {
+        let config = create_test_config();
+
+        let serialized = serde_json::to_string(&config).unwrap();
+        let deserialized: WindowsEventLogConfig = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(config.channels, deserialized.channels);
+        assert_eq!(
+            config.connection_timeout_secs,
+            deserialized.connection_timeout_secs
+        );
+        assert_eq!(config.event_timeout_ms, deserialized.event_timeout_ms);
+        assert_eq!(config.batch_size, deserialized.batch_size);
+    }
+
+    #[test]
+    fn test_field_filter_configuration() {
+        let mut config = create_test_config();
+        config.field_filter = FieldFilter {
+            include_fields: Some(vec!["event_id".to_string(), "level".to_string()]),
+            exclude_fields: Some(vec!["raw_xml".to_string()]),
+            include_system_fields: false,
+            include_event_data: true,
+            include_user_data: false,
+        };
+
+        assert!(config.validate().is_ok());
+        assert!(!config.field_filter.include_system_fields);
+        assert!(config.field_filter.include_event_data);
+        assert!(!config.field_filter.include_user_data);
+    }
+
+    #[test]
+    fn test_event_data_format_configuration() {
+        let mut config = create_test_config();
+        config
+            .event_data_format
+            .insert("event_id".to_string(), EventDataFormat::String);
+        config
+            .event_data_format
+            .insert("process_id".to_string(), EventDataFormat::Integer);
+        config
+            .event_data_format
+            .insert("enabled".to_string(), EventDataFormat::Boolean);
+
+        assert!(config.validate().is_ok());
+        assert_eq!(config.event_data_format.len(), 3);
+    }
+
+    #[test]
+    fn test_filtering_options() {
+        let mut config = create_test_config();
+        config.ignore_event_ids = vec![4624, 4634];
+        config.only_event_ids = Some(vec![1000, 1001, 1002]);
+        config.max_event_age_secs = Some(86400);
+
+        assert!(config.validate().is_ok());
+        assert_eq!(config.ignore_event_ids.len(), 2);
+        assert!(config.only_event_ids.is_some());
+        assert_eq!(config.max_event_age_secs, Some(86400));
+    }
+}
+
+#[cfg(test)]
+mod parser_tests {
+    use super::*;
+
+    #[test]
+    fn test_parser_creation() {
+        let config = create_test_config();
+        let _parser = EventLogParser::new(&config, LogNamespace::Legacy);
+
+        // Should create without error - parser creation succeeds
+        // Note: Cannot test private fields directly
+    }
+
+    #[test]
+    fn test_parse_basic_event() {
+        let config = create_test_config();
+        let parser = EventLogParser::new(&config, LogNamespace::Legacy);
+        let event = create_test_event();
+
+        let log_event = parser.parse_event(event.clone()).unwrap();
+
+        // Check core fields
+        assert_eq!(log_event.get("event_id"), Some(&Value::Integer(4624)));
+        assert_eq!(log_event.get("record_id"), Some(&Value::Integer(12345)));
+        assert_eq!(
+            log_event.get("level"),
+            Some(&Value::Bytes("Information".into()))
+        );
+        assert_eq!(log_event.get("level_value"), Some(&Value::Integer(4)));
+        assert_eq!(
+            log_event.get("channel"),
+            Some(&Value::Bytes("Security".into()))
+        );
+        assert_eq!(
+            log_event.get("provider_name"),
+            Some(&Value::Bytes("Microsoft-Windows-Security-Auditing".into()))
+        );
+        assert_eq!(
+            log_event.get("computer"),
+            Some(&Value::Bytes("WIN-SERVER-01".into()))
+        );
+        assert_eq!(log_event.get("process_id"), Some(&Value::Integer(716)));
+        assert_eq!(log_event.get("thread_id"), Some(&Value::Integer(796)));
+    }
+
+    #[test]
+    fn test_parse_event_with_xml() {
+        let mut config = create_test_config();
+        config.include_xml = true;
+
+        let parser = EventLogParser::new(&config, LogNamespace::Legacy);
+        let event = create_test_event();
+
+        let log_event = parser.parse_event(event.clone()).unwrap();
+
+        // XML should be included
+        assert!(log_event.get("xml").is_some());
+        if let Some(Value::Bytes(xml_bytes)) = log_event.get("xml") {
+            let xml_string = String::from_utf8_lossy(xml_bytes);
+            assert!(xml_string.contains("<Event xmlns"));
+            assert!(xml_string.contains("EventID>4624<"));
+        }
+    }
+
+    #[test]
+    fn test_parse_event_with_event_data() {
+        let mut config = create_test_config();
+        config.field_filter.include_event_data = true;
+
+        let parser = EventLogParser::new(&config, LogNamespace::Legacy);
+        let event = create_test_event();
+
+        let log_event = parser.parse_event(event.clone()).unwrap();
+
+        // Event data should be included
+        if let Some(Value::Object(event_data)) = log_event.get("event_data") {
+            assert_eq!(
+                event_data.get("TargetUserName"),
+                Some(&Value::Bytes("admin".into()))
+            );
+            assert_eq!(event_data.get("LogonType"), Some(&Value::Bytes("2".into())));
+        } else {
+            panic!("event_data should be present and be an object");
+        }
+    }
+
+    #[test]
+    fn test_parse_event_with_custom_formatting() {
+        let mut config = create_test_config();
+        config
+            .event_data_format
+            .insert("event_id".to_string(), EventDataFormat::String);
+        config
+            .event_data_format
+            .insert("process_id".to_string(), EventDataFormat::Float);
+
+        let parser = EventLogParser::new(&config, LogNamespace::Legacy);
+        let event = create_test_event();
+
+        let log_event = parser.parse_event(event.clone()).unwrap();
+
+        // event_id should be formatted as string
+        assert_eq!(
+            log_event.get("event_id"),
+            Some(&Value::Bytes("4624".into()))
+        );
+
+        // process_id should be formatted as float
+        if let Some(Value::Float(process_id)) = log_event.get("process_id") {
+            assert_eq!(process_id.into_inner(), 716.0);
+        } else {
+            panic!("process_id should be formatted as float");
+        }
+    }
+
+    #[test]
+    fn test_windows_event_level_names() {
+        let mut event = create_test_event();
+
+        // Level 0 (LogAlways / Security audit) maps to "Information"
+        event.level = 0;
+        assert_eq!(event.level_name(), "Information");
+
+        event.level = 1;
+        assert_eq!(event.level_name(), "Critical");
+
+        event.level = 2;
+        assert_eq!(event.level_name(), "Error");
+
+        event.level = 3;
+        assert_eq!(event.level_name(), "Warning");
+
+        event.level = 4;
+        assert_eq!(event.level_name(), "Information");
+
+        event.level = 5;
+        assert_eq!(event.level_name(), "Verbose");
+
+        event.level = 99;
+        assert_eq!(event.level_name(), "Unknown");
+    }
+}
+
+#[cfg(test)]
+mod error_tests {
+    use super::*;
+
+    #[test]
+    fn test_error_recoverability() {
+        // Recoverable errors
+        let recoverable_errors = vec![
+            WindowsEventLogError::TimeoutError { timeout_secs: 30 },
+            WindowsEventLogError::ResourceExhaustedError {
+                message: "test".to_string(),
+            },
+            WindowsEventLogError::IoError {
+                source: std::io::Error::new(std::io::ErrorKind::TimedOut, "timeout"),
+            },
+        ];
+
+        for error in recoverable_errors {
+            assert!(
+                error.is_recoverable(),
+                "Error should be recoverable: {}",
+                error
+            );
+        }
+
+        // Non-recoverable errors
+        let non_recoverable_errors = vec![
+            WindowsEventLogError::AccessDeniedError {
+                channel: "Security".to_string(),
+            },
+            WindowsEventLogError::ChannelNotFoundError {
+                channel: "NonExistent".to_string(),
+            },
+            WindowsEventLogError::InvalidXPathQuery {
+                query: "invalid".to_string(),
+                message: "syntax error".to_string(),
+            },
+            WindowsEventLogError::ConfigError {
+                message: "invalid config".to_string(),
+            },
+        ];
+
+        for error in non_recoverable_errors {
+            assert!(
+                !error.is_recoverable(),
+                "Error should not be recoverable: {}",
+                error
+            );
+        }
+    }
+
+    #[test]
+    fn test_error_user_messages() {
+        let error = WindowsEventLogError::AccessDeniedError {
+            channel: "Security".to_string(),
+        };
+        let message = error.user_message();
+        assert!(message.contains("Access denied"));
+        assert!(message.contains("Administrator"));
+
+        let error = WindowsEventLogError::ChannelNotFoundError {
+            channel: "NonExistent".to_string(),
+        };
+        let message = error.user_message();
+        assert!(message.contains("not found"));
+        assert!(message.contains("NonExistent"));
+
+        let error = WindowsEventLogError::InvalidXPathQuery {
+            query: "*[invalid]".to_string(),
+            message: "syntax error".to_string(),
+        };
+        let message = error.user_message();
+        assert!(message.contains("Invalid XPath query"));
+        assert!(message.contains("*[invalid]"));
+    }
+
+    #[test]
+    fn test_error_conversions() {
+        // Test conversion from quick_xml::Error
+        let xml_error = quick_xml::Error::UnexpectedEof("test".to_string());
+        let converted: WindowsEventLogError = xml_error.into();
+        assert!(matches!(
+            converted,
+            WindowsEventLogError::ParseXmlError { .. }
+        ));
+
+        // Test conversion from std::io::Error
+        let io_error = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "test");
+        let converted: WindowsEventLogError = io_error.into();
+        assert!(matches!(converted, WindowsEventLogError::IoError { .. }));
+    }
+}
+
+#[cfg(test)]
+mod subscription_tests {
+    use super::super::subscription::build_xpath_query;
+    use super::*;
+
+    // Note: test_not_supported_error is in subscription.rs to avoid duplication
+
+    #[test]
+    fn test_build_xpath_query_default_wildcard() {
+        let config = create_test_config();
+        let query = build_xpath_query(&config).unwrap();
+        assert_eq!(
+            query, "*",
+            "Default config with no event_query and no only_event_ids should return wildcard"
+        );
+    }
+
+    #[test]
+    fn test_build_xpath_query_explicit_event_query_takes_precedence() {
+        let mut config = create_test_config();
+        config.event_query = Some("*[System[Provider[@Name='MyApp']]]".to_string());
+        config.only_event_ids = Some(vec![4624, 4625]);
+
+        let query = build_xpath_query(&config).unwrap();
+        assert_eq!(
+            query, "*[System[Provider[@Name='MyApp']]]",
+            "Explicit event_query should take precedence over only_event_ids"
+        );
+    }
+
+    #[test]
+    fn test_build_xpath_query_single_event_id() {
+        let mut config = create_test_config();
+        config.only_event_ids = Some(vec![4624]);
+
+        let query = build_xpath_query(&config).unwrap();
+        assert_eq!(query, "*[System[EventID=4624]]");
+    }
+
+    #[test]
+    fn test_build_xpath_query_multiple_event_ids() {
+        let mut config = create_test_config();
+        config.only_event_ids = Some(vec![4624, 4625, 4634]);
+
+        let query = build_xpath_query(&config).unwrap();
+        assert_eq!(
+            query,
+            "*[System[EventID=4624 or EventID=4625 or EventID=4634]]"
+        );
+    }
+
+    #[test]
+    fn test_build_xpath_query_empty_only_event_ids_returns_wildcard() {
+        let mut config = create_test_config();
+        config.only_event_ids = Some(vec![]);
+
+        let query = build_xpath_query(&config).unwrap();
+        assert_eq!(
+            query, "*",
+            "Empty only_event_ids list should return wildcard"
+        );
+    }
+
+    #[test]
+    fn test_build_xpath_query_large_list_falls_back_to_wildcard() {
+        let mut config = create_test_config();
+        // Generate enough IDs to exceed 4096-char XPath limit.
+        // Each "EventID=NNNNN" is ~12 chars, " or " is 4, so ~16 per ID.
+        // 4096 / 16 ≈ 256, so 300 IDs should exceed the limit.
+        config.only_event_ids = Some((10000..10300).collect());
+
+        let query = build_xpath_query(&config).unwrap();
+        assert_eq!(
+            query, "*",
+            "Large ID list exceeding 4096 chars should fall back to wildcard"
+        );
+    }
+
+    #[test]
+    fn test_build_xpath_query_moderate_list_generates_xpath() {
+        let mut config = create_test_config();
+        // 10 IDs should comfortably fit within 4096 chars.
+        config.only_event_ids = Some(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        let query = build_xpath_query(&config).unwrap();
+        assert!(
+            query.starts_with("*[System["),
+            "Query should be XPath, got: {query}"
+        );
+        assert!(
+            query.contains("EventID=1"),
+            "Query should contain EventID=1"
+        );
+        assert!(
+            query.contains("EventID=10"),
+            "Query should contain EventID=10"
+        );
+        assert!(query.len() <= 4096, "Query should fit within XPath limit");
+    }
+
+    #[test]
+    fn test_event_filtering_by_id() {
+        let mut config = create_test_config();
+        config.ignore_event_ids = vec![4624, 4625];
+        config.only_event_ids = Some(vec![1000, 1001]);
+
+        // Configuration should be valid
+        assert!(config.validate().is_ok());
+
+        // Test event should be filtered out (4624 is in ignore list)
+        let event = create_test_event(); // event_id = 4624
+        assert!(config.ignore_event_ids.contains(&event.event_id));
+
+        // Test only_event_ids filtering
+        if let Some(ref only_ids) = config.only_event_ids {
+            assert!(!only_ids.contains(&event.event_id));
+        }
+    }
+
+    #[test]
+    fn test_only_and_ignore_event_ids_interaction() {
+        // When both filters are set, only_event_ids narrows first,
+        // then ignore_event_ids can further exclude from that set.
+        let mut config = create_test_config();
+        config.only_event_ids = Some(vec![1000, 1001, 1002]);
+        config.ignore_event_ids = vec![1001];
+
+        assert!(config.validate().is_ok());
+
+        // 1000 passes only_event_ids and is not in ignore list → accepted
+        assert!(config.only_event_ids.as_ref().unwrap().contains(&1000));
+        assert!(!config.ignore_event_ids.contains(&1000));
+
+        // 1001 passes only_event_ids but is in ignore list → rejected
+        assert!(config.only_event_ids.as_ref().unwrap().contains(&1001));
+        assert!(config.ignore_event_ids.contains(&1001));
+
+        // 9999 fails only_event_ids → rejected before ignore check
+        assert!(!config.only_event_ids.as_ref().unwrap().contains(&9999));
+    }
+
+    #[test]
+    fn test_only_event_ids_with_max_event_age() {
+        let mut config = create_test_config();
+        config.only_event_ids = Some(vec![4624, 4625]);
+        config.max_event_age_secs = Some(3600);
+
+        assert!(config.validate().is_ok());
+
+        // Both filters should be set independently
+        assert_eq!(config.only_event_ids.as_ref().unwrap().len(), 2);
+        assert_eq!(config.max_event_age_secs, Some(3600));
+    }
+
+    #[test]
+    fn test_build_xpath_query_with_ignore_event_ids_only() {
+        // ignore_event_ids does NOT generate XPath — it's handled in-process
+        // because XPath has no "NOT EventID=X" syntax.
+        let mut config = create_test_config();
+        config.ignore_event_ids = vec![4624, 4625];
+
+        let query = build_xpath_query(&config).unwrap();
+        assert_eq!(
+            query, "*",
+            "ignore_event_ids alone should not generate XPath filter"
+        );
+    }
+
+    #[test]
+    fn test_event_age_filtering() {
+        let mut config = create_test_config();
+        config.max_event_age_secs = Some(86400); // 24 hours
+
+        let mut event = create_test_event();
+
+        // Event from now should pass
+        event.time_created = Utc::now();
+        let age = Utc::now().signed_duration_since(event.time_created);
+        assert!(age.num_seconds() <= 86400);
+
+        // Event from 2 days ago should be filtered
+        event.time_created = Utc::now() - chrono::Duration::days(2);
+        let age = Utc::now().signed_duration_since(event.time_created);
+        assert!(age.num_seconds() > 86400);
+    }
+
+    #[test]
+    fn test_xml_parsing_helpers() {
+        let xml = r#"
+        <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+            <System>
+                <Provider Name="Microsoft-Windows-Kernel-General" Guid="{A68CA8B7-004F-D7B6-A698-07E2DE0F1F5D}"/>
+                <EventID>1</EventID>
+                <Level>4</Level>
+                <EventRecordID>12345</EventRecordID>
+                <Channel>System</Channel>
+                <Computer>TEST-MACHINE</Computer>
+            </System>
+        </Event>
+        "#;
+
+        assert_eq!(extract_xml_value(xml, "EventID"), Some("1".to_string()));
+        assert_eq!(extract_xml_value(xml, "Level"), Some("4".to_string()));
+        assert_eq!(
+            extract_xml_value(xml, "EventRecordID"),
+            Some("12345".to_string())
+        );
+        assert_eq!(
+            extract_xml_value(xml, "Channel"),
+            Some("System".to_string())
+        );
+        assert_eq!(
+            extract_xml_value(xml, "Computer"),
+            Some("TEST-MACHINE".to_string())
+        );
+        assert_eq!(extract_xml_value(xml, "NonExistent"), None);
+    }
+
+    #[test]
+    fn test_xml_attribute_parsing() {
+        let xml = r#"
+        <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+            <System>
+                <Provider Name="Microsoft-Windows-Kernel-General" Guid="{A68CA8B7-004F-D7B6-A698-07E2DE0F1F5D}"/>
+                <TimeCreated SystemTime="2025-08-29T00:15:41.123456Z"/>
+            </System>
+        </Event>
+        "#;
+
+        assert_eq!(
+            extract_xml_attribute(xml, "Name"),
+            Some("Microsoft-Windows-Kernel-General".to_string())
+        );
+        assert_eq!(
+            extract_xml_attribute(xml, "SystemTime"),
+            Some("2025-08-29T00:15:41.123456Z".to_string())
+        );
+        assert_eq!(extract_xml_attribute(xml, "NonExistent"), None);
+    }
+
+    #[test]
+    fn test_event_data_extraction() {
+        let xml = r#"
+            <Event>
+                <EventData>
+                    <Data Name="TargetUserName">administrator</Data>
+                    <Data Name="TargetLogonId">0x3e7</Data>
+                    <Data Name="LogonType">2</Data>
+                    <Data Name="WorkstationName">WIN-TEST</Data>
+                </EventData>
+            </Event>
+        "#;
+
+        let config = WindowsEventLogConfig::default();
+        let event_data = extract_event_data(xml, &config);
+
+        assert_eq!(
+            event_data.structured_data.get("TargetUserName"),
+            Some(&"administrator".to_string())
+        );
+        assert_eq!(
+            event_data.structured_data.get("TargetLogonId"),
+            Some(&"0x3e7".to_string())
+        );
+        assert_eq!(
+            event_data.structured_data.get("LogonType"),
+            Some(&"2".to_string())
+        );
+        assert_eq!(
+            event_data.structured_data.get("WorkstationName"),
+            Some(&"WIN-TEST".to_string())
+        );
+    }
+
+    #[test]
+    fn test_security_limits() {
+        // Test XML element extraction with size limits
+        let large_xml = format!(
+            r#"
+        <Event>
+            <System>
+                <EventID>{}</EventID>
+            </System>
+        </Event>
+        "#,
+            "x".repeat(10000)
+        ); // Very large content
+
+        // Should not panic or consume excessive memory
+        let result = extract_xml_value(&large_xml, "EventID");
+        // Should either truncate or return None, but not crash
+        match result {
+            Some(value) => assert!(value.len() <= 4096, "Should limit extracted text size"),
+            None => {} // Acceptable if parsing fails due to size limits
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_source_output_schema() {
+    let config = create_test_config();
+
+    // Test legacy namespace
+    let outputs = config.outputs(LogNamespace::Legacy);
+    assert_eq!(outputs.len(), 1);
+
+    // Test vector namespace
+    let outputs = config.outputs(LogNamespace::Vector);
+    assert_eq!(outputs.len(), 1);
+}
+
+#[tokio::test]
+async fn test_source_resources() {
+    let config = create_test_config();
+    let resources = config.resources();
+
+    assert_eq!(resources.len(), 2);
+    assert!(resources.iter().any(|r| r.to_string().contains("System")));
+    assert!(
+        resources
+            .iter()
+            .any(|r| r.to_string().contains("Application"))
+    );
+}
+
+#[tokio::test]
+async fn test_source_acknowledgements() {
+    let config = create_test_config();
+
+    // Windows Event Log source supports acknowledgements
+    assert!(config.can_acknowledge());
+}
+
+// Compliance tests
+#[tokio::test]
+async fn test_source_compliance() {
+    let data_dir = tempfile::tempdir().expect("failed to create temp data_dir");
+    let mut config = create_test_config();
+    config.data_dir = Some(data_dir.path().to_path_buf());
+    run_and_assert_source_compliance(config, Duration::from_millis(100), &SOURCE_TAGS).await;
+}
+
+// ================================================================================================
+// SECURITY TESTS - Critical security attack vector validation
+// ================================================================================================
+
+#[cfg(test)]
+mod security_tests {
+    use super::*;
+
+    /// Test XPath injection attack prevention
+    #[test]
+    fn test_xpath_injection_prevention() {
+        let mut config = create_test_config();
+
+        // Test JavaScript injection attempts
+        let javascript_attacks = vec![
+            "javascript:alert('xss')",
+            "*[javascript:eval('malicious')]",
+            "System[javascript:document.write('attack')]",
+            "*[System[javascript:window.open()]]",
+        ];
+
+        for attack in javascript_attacks {
+            config.event_query = Some(attack.to_string());
+            let result = config.validate();
+            assert!(
+                result.is_err(),
+                "JavaScript injection '{}' should be blocked",
+                attack
+            );
+            assert!(
+                result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("potentially unsafe pattern"),
+                "Error should mention unsafe pattern for: {}",
+                attack
+            );
+        }
+
+        // Test valid XPath queries should still work
+        let valid_queries = vec![
+            "*[System[Level=1 or Level=2]]",
+            "*[System[(Level=1 or Level=2) and TimeCreated[timediff(@SystemTime) <= 86400000]]]",
+            "*[System[Provider[@Name='Microsoft-Windows-Security-Auditing']]]",
+            "Event/System[EventID=4624]",
+        ];
+
+        for valid_query in valid_queries {
+            config.event_query = Some(valid_query.to_string());
+            let result = config.validate();
+            assert!(
+                result.is_ok(),
+                "Valid XPath query '{}' should be allowed",
+                valid_query
+            );
+        }
+    }
+
+    /// Test resource exhaustion attack prevention
+    #[test]
+    fn test_resource_exhaustion_prevention() {
+        let mut config = create_test_config();
+
+        // Test excessive connection timeout (DoS prevention)
+        config.connection_timeout_secs = 0;
+        assert!(
+            config.validate().is_err(),
+            "Zero connection timeout should be rejected"
+        );
+
+        config.connection_timeout_secs = u64::MAX;
+        assert!(
+            config.validate().is_err(),
+            "Excessive connection timeout should be rejected"
+        );
+
+        config.connection_timeout_secs = 7200; // 2 hours
+        assert!(
+            config.validate().is_err(),
+            "Connection timeout > 3600 seconds should be rejected"
+        );
+
+        // Test excessive event timeout
+        config.connection_timeout_secs = 30; // Reset to valid value
+        config.event_timeout_ms = 0;
+        assert!(
+            config.validate().is_err(),
+            "Zero event timeout should be rejected"
+        );
+
+        config.event_timeout_ms = 100000; // 100 seconds
+        assert!(
+            config.validate().is_err(),
+            "Excessive event timeout should be rejected"
+        );
+
+        // Test excessive batch sizes (memory exhaustion prevention)
+        config.event_timeout_ms = 5000; // Reset to valid value
+        config.batch_size = 0;
+        assert!(
+            config.validate().is_err(),
+            "Zero batch size should be rejected"
+        );
+
+        config.batch_size = 100000;
+        assert!(
+            config.validate().is_err(),
+            "Excessive batch size should be rejected"
+        );
+    }
+
+    /// Test channel name validation (injection prevention)
+    #[test]
+    fn test_channel_name_security_validation() {
+        let mut config = create_test_config();
+
+        // Test dangerous channel names that config validation actually rejects:
+        // empty/whitespace, control characters (null, CRLF), and excessive length.
+        // Note: HTML tags, SQL fragments, and shell metacharacters are not rejected
+        // at config validation time — the Windows API handles those at subscription.
+        let excessive_length = "A".repeat(300);
+        let dangerous_channels = vec![
+            "",                    // Empty channel
+            "   ",                 // Whitespace only
+            "System\0",            // Null byte injection
+            "System\r\nmalicious", // CRLF injection
+            &excessive_length,     // Excessive length
+        ];
+
+        for dangerous_channel in &dangerous_channels {
+            config.channels = vec!["System".to_string(), dangerous_channel.to_string()];
+            let result = config.validate();
+            assert!(
+                result.is_err(),
+                "Dangerous channel name '{}' should be rejected",
+                dangerous_channel.escape_debug()
+            );
+        }
+
+        // Test valid channel names should work
+        let valid_channels = vec![
+            "System",
+            "Application",
+            "Security",
+            "Windows PowerShell",
+            "Microsoft-Windows-Security-Auditing/Operational",
+            "Custom-Application_Log",
+            "Service-Name/Admin",
+            "Application and Services Logs/Custom",
+        ];
+
+        for valid_channel in valid_channels {
+            config.channels = vec!["System".to_string(), valid_channel.to_string()];
+            let result = config.validate();
+            assert!(
+                result.is_ok(),
+                "Valid channel name '{}' should be allowed",
+                valid_channel
+            );
+        }
+    }
+
+    /// Test excessive query length prevention
+    #[test]
+    fn test_excessive_query_length_prevention() {
+        let mut config = create_test_config();
+
+        // Test query length limits
+        let long_query = "*[System[".to_string() + &"Level=1 and ".repeat(1000) + "Level=2]]";
+        config.event_query = Some(long_query);
+        let result = config.validate();
+        assert!(result.is_err(), "Excessively long query should be rejected");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("exceeds maximum length"),
+            "Error should mention length limit"
+        );
+
+        // Test reasonable query length should work
+        let reasonable_query = "*[System[Level=1 or Level=2 or Level=3]]".to_string();
+        config.event_query = Some(reasonable_query);
+        assert!(
+            config.validate().is_ok(),
+            "Reasonable length query should be allowed"
+        );
+    }
+}
+
+// ================================================================================================
+// BUFFER OVERFLOW AND MEMORY SAFETY TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod buffer_safety_tests {
+    use super::*;
+
+    /// Test XML parsing with malicious buffer sizes
+    #[test]
+    fn test_malformed_xml_buffer_safety() {
+        // Test extremely large XML documents (should be handled gracefully)
+        let large_xml = format!(
+            "<Event><EventData>{}</EventData></Event>",
+            "<Data Name='field'>value</Data>".repeat(1000) // Reduced from 10000 for memory safety
+        );
+
+        // This should not panic or cause memory issues
+        let config = WindowsEventLogConfig::default();
+        let result = extract_event_data(&large_xml, &config);
+
+        // Should have some reasonable limit on parsed data
+        assert!(
+            result.structured_data.len() <= 100,
+            "Should limit parsed data size to prevent DoS"
+        );
+    }
+
+    /// Test XML parsing with deeply nested structures
+    #[test]
+    fn test_deeply_nested_xml_protection() {
+        // Create deeply nested XML structure (reduced nesting for memory safety)
+        let mut nested_xml = "<Event>".to_string();
+        for i in 0..100 {
+            // Reduced from 1000
+            nested_xml.push_str(&format!("<Level{}>", i));
+        }
+        nested_xml.push_str("<EventData><Data Name='test'>value</Data></EventData>");
+        for i in (0..100).rev() {
+            nested_xml.push_str(&format!("</Level{}>", i));
+        }
+        nested_xml.push_str("</Event>");
+
+        // This should not cause stack overflow or excessive memory usage
+        let config = WindowsEventLogConfig::default();
+        let result = extract_event_data(&nested_xml, &config);
+
+        // Should handle gracefully - either succeeds or fails safely
+        // The key is that it doesn't crash or consume excessive resources
+        assert!(
+            result.structured_data.len() <= 100,
+            "Should limit parsed data for deeply nested XML"
+        );
+    }
+
+    /// Test handling of XML with excessive attributes
+    #[test]
+    fn test_excessive_xml_attributes_handling() {
+        // Create XML with many attributes (reduced count for safety)
+        let mut xml_with_attrs = "<Event><EventData>".to_string();
+        for i in 0..200 {
+            // Reduced from 5000
+            xml_with_attrs.push_str(&format!(
+                "<Data Name='attr{}' Value='value{}'>data{}</Data>",
+                i, i, i
+            ));
+        }
+        xml_with_attrs.push_str("</EventData></Event>");
+
+        // Should handle gracefully without memory exhaustion
+        let config = WindowsEventLogConfig::default();
+        let result = extract_event_data(&xml_with_attrs, &config);
+
+        // Should parse without panicking or memory exhaustion.
+        // extract_event_data does not impose an attribute count cap;
+        // it parses all well-formed Data elements present in the XML.
+        assert!(
+            result.structured_data.len() <= 200,
+            "Should parse attributes without memory issues"
+        );
+    }
+}
+
+// ================================================================================================
+// CONCURRENCY AND RACE CONDITION TESTS
+// ================================================================================================
+
+// ================================================================================================
+// ERROR INJECTION AND FAULT TOLERANCE TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod fault_tolerance_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_invalid_xml_handling() {
+        let invalid_xml = "not valid xml <tag>";
+        let config = WindowsEventLogConfig::default();
+        let result = extract_event_data(invalid_xml, &config);
+        // Should return empty result or handle gracefully without crashing
+        assert!(
+            result.structured_data.len() == 0,
+            "Invalid XML should result in empty data"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_malicious_xml_handling() {
+        // Test various malicious XML patterns
+        let malicious_xmls = vec![
+            "<?xml version='1.0'?><!DOCTYPE test [<!ENTITY xxe SYSTEM 'file:///etc/passwd'>]><test>&xxe;</test>".to_string(),
+            format!("<Event><![CDATA[{}]]></Event>", "x".repeat(100000)), // Large CDATA
+            format!("<Event>{}data{}</Event>", "<nested>".repeat(1000), "</nested>".repeat(1000)), // Deep nesting
+        ];
+
+        let config = WindowsEventLogConfig::default();
+        for malicious_xml in &malicious_xmls {
+            let result = extract_event_data(&malicious_xml, &config);
+            // Should handle without crashing or excessive resource usage
+            assert!(
+                result.structured_data.len() <= 100,
+                "Malicious XML should be limited in processing"
+            );
+        }
+    }
+}
+
+// ================================================================================================
+// ACKNOWLEDGMENT TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod acknowledgement_tests {
+    use super::*;
+    use crate::config::{SourceAcknowledgementsConfig, SourceConfig};
+
+    #[test]
+    fn test_acknowledgements_config_default_disabled() {
+        let config = WindowsEventLogConfig::default();
+        // Acknowledgements should be disabled by default
+        assert!(
+            !config.acknowledgements.enabled(),
+            "Acknowledgements should be disabled by default"
+        );
+    }
+
+    #[test]
+    fn test_acknowledgements_config_enabled() {
+        let mut config = create_test_config();
+        config.acknowledgements = SourceAcknowledgementsConfig::from(true);
+        assert!(
+            config.acknowledgements.enabled(),
+            "Acknowledgements should be enabled when configured"
+        );
+    }
+
+    #[test]
+    fn test_can_acknowledge_returns_true() {
+        let config = WindowsEventLogConfig::default();
+        assert!(
+            config.can_acknowledge(),
+            "can_acknowledge() should return true to support acknowledgements"
+        );
+    }
+
+    #[test]
+    fn test_acknowledgements_config_serialization() {
+        // Test that acknowledgements config serializes correctly
+        let config = WindowsEventLogConfig {
+            acknowledgements: SourceAcknowledgementsConfig::from(true),
+            ..Default::default()
+        };
+
+        let serialized = serde_json::to_string(&config).expect("serialization should succeed");
+        assert!(
+            serialized.contains("acknowledgements"),
+            "Serialized config should contain acknowledgements field"
+        );
+
+        // Test deserialization
+        let deserialized: WindowsEventLogConfig =
+            serde_json::from_str(&serialized).expect("deserialization should succeed");
+        assert!(
+            deserialized.acknowledgements.enabled(),
+            "Acknowledgements should be enabled after deserialization"
+        );
+    }
+
+    #[test]
+    fn test_acknowledgements_toml_parsing() {
+        // Test parsing from TOML with acknowledgements enabled
+        let toml_with_acks = r#"
+            channels = ["System"]
+            acknowledgements = true
+        "#;
+        let config: WindowsEventLogConfig =
+            toml::from_str(toml_with_acks).expect("TOML parsing should succeed");
+        assert!(
+            config.acknowledgements.enabled(),
+            "Acknowledgements should be enabled from TOML"
+        );
+
+        // Test parsing with acknowledgements as struct
+        let toml_with_acks_struct = r#"
+            channels = ["System"]
+            [acknowledgements]
+            enabled = true
+        "#;
+        let config: WindowsEventLogConfig =
+            toml::from_str(toml_with_acks_struct).expect("TOML parsing should succeed");
+        assert!(
+            config.acknowledgements.enabled(),
+            "Acknowledgements should be enabled from TOML struct"
+        );
+
+        // Test parsing without acknowledgements (default)
+        let toml_without_acks = r#"
+            channels = ["System"]
+        "#;
+        let config: WindowsEventLogConfig =
+            toml::from_str(toml_without_acks).expect("TOML parsing should succeed");
+        assert!(
+            !config.acknowledgements.enabled(),
+            "Acknowledgements should be disabled by default"
+        );
+    }
+}
+
+// ================================================================================================
+// RATE LIMITING TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod rate_limiting_tests {
+    use super::*;
+
+    #[test]
+    fn test_rate_limiting_config_default_disabled() {
+        let config = WindowsEventLogConfig::default();
+        assert_eq!(
+            config.events_per_second, 0,
+            "Rate limiting should be disabled by default (0)"
+        );
+    }
+
+    #[test]
+    fn test_rate_limiting_config_enabled() {
+        let mut config = create_test_config();
+        config.events_per_second = 100;
+        assert!(
+            config.validate().is_ok(),
+            "Rate limiting config should be valid"
+        );
+        assert_eq!(config.events_per_second, 100);
+    }
+
+    #[test]
+    fn test_rate_limiting_toml_parsing() {
+        let toml_with_rate_limit = r#"
+            channels = ["System"]
+            events_per_second = 50
+        "#;
+        let config: WindowsEventLogConfig =
+            toml::from_str(toml_with_rate_limit).expect("TOML parsing should succeed");
+        assert_eq!(
+            config.events_per_second, 50,
+            "Rate limiting should be parsed from TOML"
+        );
+    }
+
+    #[test]
+    fn test_rate_limiting_serialization() {
+        let mut config = create_test_config();
+        config.events_per_second = 100;
+
+        let serialized = serde_json::to_string(&config).expect("serialization should succeed");
+        assert!(
+            serialized.contains("events_per_second"),
+            "Serialized config should contain events_per_second"
+        );
+
+        let deserialized: WindowsEventLogConfig =
+            serde_json::from_str(&serialized).expect("deserialization should succeed");
+        assert_eq!(
+            deserialized.events_per_second, 100,
+            "events_per_second should be preserved after serialization"
+        );
+    }
+}
+
+// ================================================================================================
+// CHECKPOINT TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod checkpoint_tests {
+    use super::*;
+
+    #[test]
+    fn test_checkpoint_data_dir_config() {
+        let mut config = create_test_config();
+        config.data_dir = Some(std::path::PathBuf::from("/tmp/vector-test"));
+        assert!(
+            config.validate().is_ok(),
+            "Config with data_dir should be valid"
+        );
+    }
+
+    #[test]
+    fn test_checkpoint_toml_parsing() {
+        let toml_with_data_dir = r#"
+            channels = ["System"]
+            data_dir = "/var/lib/vector/wineventlog"
+        "#;
+        let config: WindowsEventLogConfig =
+            toml::from_str(toml_with_data_dir).expect("TOML parsing should succeed");
+        assert!(
+            config.data_dir.is_some(),
+            "data_dir should be parsed from TOML"
+        );
+    }
+
+    #[test]
+    fn test_checkpoint_path_construction() {
+        // Verify that the checkpoint module exists and can be used
+        let _ = std::mem::size_of::<super::super::checkpoint::Checkpointer>();
+        // The actual file operations would require Windows, so we only validate type availability.
+    }
+}
+
+// ================================================================================================
+// MESSAGE RENDERING TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod message_rendering_tests {
+    use super::*;
+
+    #[test]
+    fn test_render_message_config_default() {
+        let config = WindowsEventLogConfig::default();
+        assert!(
+            config.render_message,
+            "render_message should be enabled by default for compatibility with Event Viewer"
+        );
+    }
+
+    #[test]
+    fn test_render_message_config_enabled() {
+        let toml_with_render = r#"
+            channels = ["System"]
+            render_message = true
+        "#;
+        let config: WindowsEventLogConfig =
+            toml::from_str(toml_with_render).expect("TOML parsing should succeed");
+        assert!(
+            config.render_message,
+            "render_message should be enabled from TOML"
+        );
+    }
+
+    #[test]
+    fn test_render_message_false_uses_fallback() {
+        // When render_message is false, the parser should use fallback message
+        let config = WindowsEventLogConfig {
+            render_message: false,
+            ..Default::default()
+        };
+        let parser = EventLogParser::new(&config, LogNamespace::Legacy);
+
+        // Create event without rendered_message
+        let mut event = create_test_event();
+        event.rendered_message = None;
+        event.event_data.clear(); // No message in event_data either
+        event.string_inserts.clear(); // Clear string inserts to reach fallback path
+
+        let log_event = parser.parse_event(event.clone()).unwrap();
+
+        // Should have fallback message format: "Event ID X from Provider on Computer"
+        if let Some(message) = log_event.get("message") {
+            let msg_str = message.to_string_lossy();
+            assert!(
+                msg_str.contains("Event ID") || msg_str.contains(&event.event_id.to_string()),
+                "Fallback message should contain Event ID: got '{}'",
+                msg_str
+            );
+        }
+    }
+
+    #[test]
+    fn test_render_message_true_uses_rendered() {
+        // When render_message is true and rendered_message is available, use it
+        let config = WindowsEventLogConfig {
+            render_message: true,
+            ..Default::default()
+        };
+        let parser = EventLogParser::new(&config, LogNamespace::Legacy);
+
+        // Create event with rendered_message
+        let mut event = create_test_event();
+        event.rendered_message = Some("The service started successfully.".to_string());
+
+        let log_event = parser.parse_event(event).unwrap();
+
+        if let Some(message) = log_event.get("message") {
+            let msg_str = message.to_string_lossy();
+            assert_eq!(
+                msg_str, "The service started successfully.",
+                "Should use rendered_message when available"
+            );
+        }
+    }
+
+    #[test]
+    fn test_render_message_serialization() {
+        let mut config = create_test_config();
+        config.render_message = true;
+
+        let serialized = serde_json::to_string(&config).expect("serialization should succeed");
+        assert!(
+            serialized.contains("render_message"),
+            "Serialized config should contain render_message"
+        );
+
+        let deserialized: WindowsEventLogConfig =
+            serde_json::from_str(&serialized).expect("deserialization should succeed");
+        assert!(
+            deserialized.render_message,
+            "render_message should be preserved after serialization"
+        );
+    }
+}
+
+// ================================================================================================
+// TRUNCATION TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod truncation_tests {
+    use super::*;
+
+    #[test]
+    fn test_max_event_data_length_config() {
+        let mut config = create_test_config();
+        config.max_event_data_length = 100;
+        assert!(
+            config.validate().is_ok(),
+            "Config with max_event_data_length should be valid"
+        );
+    }
+
+    #[test]
+    fn test_max_event_data_length_toml_parsing() {
+        let toml_with_truncation = r#"
+            channels = ["System"]
+            max_event_data_length = 256
+        "#;
+        let config: WindowsEventLogConfig =
+            toml::from_str(toml_with_truncation).expect("TOML parsing should succeed");
+        assert_eq!(
+            config.max_event_data_length, 256,
+            "max_event_data_length should be parsed from TOML"
+        );
+    }
+
+    #[test]
+    fn test_truncation_marker_format() {
+        // max_event_data_length applies to event_data/user_data values,
+        // not to string_inserts which are passed through verbatim.
+        // Verify string_inserts are preserved at full length.
+        let config = WindowsEventLogConfig {
+            max_event_data_length: 50,
+            ..Default::default()
+        };
+
+        let mut event = create_test_event();
+        event.string_inserts = vec!["A".repeat(200)];
+
+        let parser = EventLogParser::new(&config, LogNamespace::Legacy);
+        let log_event = parser.parse_event(event).unwrap();
+
+        let inserts = log_event
+            .get("string_inserts")
+            .expect("string_inserts should be present");
+        if let Value::Array(arr) = inserts {
+            assert!(!arr.is_empty(), "string_inserts should not be empty");
+            let first = arr[0].to_string_lossy();
+            assert_eq!(
+                first.len(),
+                200,
+                "string_inserts should be preserved at full length"
+            );
+        } else {
+            panic!("string_inserts should be an array");
+        }
+    }
+
+    #[test]
+    fn test_xml_truncation_limit() {
+        // XML should be truncated at 32KB limit
+        let mut config = create_test_config();
+        config.include_xml = true;
+
+        let parser = EventLogParser::new(&config, LogNamespace::Legacy);
+
+        // Create event with large XML
+        let mut event = create_test_event();
+        event.raw_xml = "A".repeat(40000); // 40KB, exceeds limit
+
+        let log_event = parser.parse_event(event).unwrap();
+
+        if let Some(Value::Bytes(xml)) = log_event.get("xml") {
+            // XML should be truncated or limited
+            assert!(
+                xml.len() <= 40000,
+                "XML should be handled without memory issues"
+            );
+        }
+    }
+
+    #[test]
+    fn test_config_validation_max_channels() {
+        let mut config = create_test_config();
+
+        // 63 channels should be fine (MAXIMUM_WAIT_OBJECTS - 1 for shutdown event)
+        config.channels = (0..63).map(|i| format!("Channel{i}")).collect();
+        assert!(config.validate().is_ok(), "63 channels should be accepted");
+
+        // 64 channels should fail
+        config.channels = (0..64).map(|i| format!("Channel{i}")).collect();
+        let result = config.validate();
+        assert!(result.is_err(), "64 channels should be rejected");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Too many channels"),
+            "Error should mention too many channels"
+        );
+    }
+
+    #[test]
+    fn test_config_validation_channel_name_at_max_length() {
+        let mut config = create_test_config();
+        // 256 chars is exactly at the limit — should pass
+        config.channels = vec!["A".repeat(256)];
+        assert!(
+            config.validate().is_ok(),
+            "256-char channel name should be accepted"
+        );
+
+        // 257 chars exceeds the limit — should fail
+        config.channels = vec!["A".repeat(257)];
+        assert!(
+            config.validate().is_err(),
+            "257-char channel name should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_config_validation_xpath_query_at_max_length() {
+        let mut config = create_test_config();
+        // Exactly 4096 chars — should pass
+        let padded = format!("*{}", "x".repeat(4095));
+        assert_eq!(padded.len(), 4096);
+        config.event_query = Some(padded);
+        assert!(
+            config.validate().is_ok(),
+            "4096-char XPath query should be accepted"
+        );
+
+        // 4097 chars — should fail
+        let padded = format!("*{}", "x".repeat(4096));
+        assert_eq!(padded.len(), 4097);
+        config.event_query = Some(padded);
+        assert!(
+            config.validate().is_err(),
+            "4097-char XPath query should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_config_validation_event_ids_at_max_size() {
+        let mut config = create_test_config();
+        // 1000 IDs is exactly at the limit — should pass
+        config.only_event_ids = Some((1..=1000).collect());
+        assert!(
+            config.validate().is_ok(),
+            "1000 event IDs should be accepted"
+        );
+
+        // 1001 IDs exceeds the limit — should fail
+        config.only_event_ids = Some((1..=1001).collect());
+        assert!(
+            config.validate().is_err(),
+            "1001 event IDs should be rejected"
+        );
+    }
+}

--- a/src/sources/windows_event_log/xml_parser.rs
+++ b/src/sources/windows_event_log/xml_parser.rs
@@ -1,0 +1,1134 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use metrics::counter;
+use quick_xml::{Reader, events::Event as XmlEvent};
+
+use super::config::WindowsEventLogConfig;
+use super::error::*;
+
+/// Truncate a string at a UTF-8 safe boundary, appending a suffix.
+pub(crate) fn truncate_utf8(s: &mut String, max_bytes: usize) {
+    if s.len() <= max_bytes {
+        return;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s.truncate(end);
+    s.push_str("...[truncated]");
+}
+
+/// System fields extracted from Windows Event Log XML via single-pass parsing.
+#[derive(Debug, Clone, Default)]
+pub struct SystemFields {
+    pub event_id: u32,
+    pub level: u8,
+    pub task: u16,
+    pub opcode: u8,
+    pub keywords: u64,
+    pub version: Option<u8>,
+    pub qualifiers: Option<u16>,
+    pub record_id: u64,
+    pub activity_id: Option<String>,
+    pub related_activity_id: Option<String>,
+    pub process_id: u32,
+    pub thread_id: u32,
+    pub channel: String,
+    pub computer: String,
+    pub user_id: Option<String>,
+    pub provider_name: String,
+    pub provider_guid: Option<String>,
+    /// Raw timestamp string from TimeCreated/@SystemTime.
+    pub system_time: Option<String>,
+}
+
+/// Result from EventData parsing (supports both named and positional formats).
+#[derive(Debug, Clone)]
+pub struct EventDataResult {
+    pub structured_data: HashMap<String, String>,
+    pub string_inserts: Vec<String>,
+    pub user_data: HashMap<String, String>,
+}
+
+/// Represents a Windows Event Log event.
+#[derive(Debug, Clone)]
+pub struct WindowsEvent {
+    pub record_id: u64,
+    pub event_id: u32,
+    pub level: u8,
+    pub task: u16,
+    pub opcode: u8,
+    pub keywords: u64,
+    pub time_created: DateTime<Utc>,
+    pub provider_name: String,
+    pub provider_guid: Option<String>,
+    pub channel: String,
+    pub computer: String,
+    pub user_id: Option<String>,
+    pub process_id: u32,
+    pub thread_id: u32,
+    pub activity_id: Option<String>,
+    pub related_activity_id: Option<String>,
+    pub raw_xml: String,
+    pub rendered_message: Option<String>,
+    pub event_data: HashMap<String, String>,
+    pub user_data: HashMap<String, String>,
+    pub task_name: Option<String>,
+    pub opcode_name: Option<String>,
+    pub keyword_names: Vec<String>,
+    /// Resolved account name from user_id SID (e.g. "NT AUTHORITY\SYSTEM").
+    pub user_name: Option<String>,
+    pub version: Option<u8>,
+    pub qualifiers: Option<u16>,
+    pub string_inserts: Vec<String>,
+}
+
+impl WindowsEvent {
+    /// Returns the human-readable level name for this event.
+    ///
+    /// Level 0 maps to "Information" per standard convention. Windows uses
+    /// Level=0 for "LogAlways" and for all Security audit events. Mapping it to
+    /// "Information" prevents SOC analysts from seeing "Unknown" on every logon event.
+    pub const fn level_name(&self) -> &'static str {
+        match self.level {
+            0 => "Information",
+            1 => "Critical",
+            2 => "Error",
+            3 => "Warning",
+            4 => "Information",
+            5 => "Verbose",
+            _ => "Unknown",
+        }
+    }
+}
+
+/// Tracks which element's text content we are currently collecting.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TextTarget {
+    None,
+    EventID,
+    Version,
+    Level,
+    Task,
+    Opcode,
+    Keywords,
+    EventRecordID,
+    Channel,
+    Computer,
+}
+
+/// Parse the System section of Windows Event Log XML in a single pass.
+///
+/// Replaces ~28 individual `extract_xml_value`/`extract_xml_attribute`/
+/// `extract_provider_name` calls with one `quick_xml::Reader` traversal.
+pub fn parse_system_section(xml: &str) -> SystemFields {
+    let mut fields = SystemFields::default();
+    let mut reader = Reader::from_str(xml);
+    reader.trim_text(true);
+    let mut buf = Vec::new();
+
+    let mut in_system = false;
+    let mut text_target = TextTarget::None;
+    let mut text_buf = String::new();
+
+    const MAX_ITERATIONS: usize = 2000;
+    let mut iterations = 0;
+
+    loop {
+        if iterations >= MAX_ITERATIONS {
+            break;
+        }
+        iterations += 1;
+
+        match reader.read_event_into(&mut buf) {
+            Ok(XmlEvent::Start(ref e)) => {
+                let local = e.name().local_name();
+                let local = local.as_ref();
+
+                if local == b"System" {
+                    in_system = true;
+                } else if in_system {
+                    text_target = TextTarget::None;
+                    text_buf.clear();
+
+                    match local {
+                        b"Provider" => extract_provider_attrs(e, &mut fields),
+                        b"EventID" => {
+                            extract_qualifiers_attr(e, &mut fields);
+                            text_target = TextTarget::EventID;
+                        }
+                        b"Version" => text_target = TextTarget::Version,
+                        b"Level" => text_target = TextTarget::Level,
+                        b"Task" => text_target = TextTarget::Task,
+                        b"Opcode" => text_target = TextTarget::Opcode,
+                        b"Keywords" => text_target = TextTarget::Keywords,
+                        b"TimeCreated" => extract_time_created_attr(e, &mut fields),
+                        b"EventRecordID" => text_target = TextTarget::EventRecordID,
+                        b"Correlation" => extract_correlation_attrs(e, &mut fields),
+                        b"Execution" => extract_execution_attrs(e, &mut fields),
+                        b"Channel" => text_target = TextTarget::Channel,
+                        b"Computer" => text_target = TextTarget::Computer,
+                        b"Security" => extract_security_attrs(e, &mut fields),
+                        _ => {}
+                    }
+                }
+            }
+            Ok(XmlEvent::Empty(ref e)) => {
+                if !in_system {
+                    if e.name().local_name().as_ref() == b"System" {
+                        // Empty <System/> — nothing to extract
+                        break;
+                    }
+                    buf.clear();
+                    continue;
+                }
+                let local = e.name().local_name();
+                let local = local.as_ref();
+                match local {
+                    b"Provider" => extract_provider_attrs(e, &mut fields),
+                    b"TimeCreated" => extract_time_created_attr(e, &mut fields),
+                    b"Correlation" => extract_correlation_attrs(e, &mut fields),
+                    b"Execution" => extract_execution_attrs(e, &mut fields),
+                    b"Security" => extract_security_attrs(e, &mut fields),
+                    _ => {}
+                }
+            }
+            Ok(XmlEvent::Text(ref e)) => {
+                if in_system && text_target != TextTarget::None {
+                    if let Ok(text) = e.unescape() {
+                        if text_buf.len() + text.len() <= 4096 {
+                            text_buf.push_str(&text);
+                        }
+                    }
+                }
+            }
+            Ok(XmlEvent::End(ref e)) => {
+                let local = e.name().local_name();
+                let local = local.as_ref();
+                if local == b"System" {
+                    // Commit any pending text before exiting
+                    commit_text(&text_target, &text_buf, &mut fields);
+                    break;
+                }
+                if in_system && text_target != TextTarget::None {
+                    commit_text(&text_target, &text_buf, &mut fields);
+                    text_target = TextTarget::None;
+                    text_buf.clear();
+                }
+            }
+            Ok(XmlEvent::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+
+        buf.clear();
+    }
+
+    fields
+}
+
+/// Commit collected element text into the appropriate SystemFields field.
+fn commit_text(target: &TextTarget, text: &str, fields: &mut SystemFields) {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+    match target {
+        TextTarget::EventID => fields.event_id = trimmed.parse().unwrap_or(0),
+        TextTarget::Version => fields.version = trimmed.parse().ok(),
+        TextTarget::Level => fields.level = trimmed.parse().unwrap_or(0),
+        TextTarget::Task => fields.task = trimmed.parse().unwrap_or(0),
+        TextTarget::Opcode => fields.opcode = trimmed.parse().unwrap_or(0),
+        TextTarget::Keywords => fields.keywords = parse_keywords_hex(trimmed),
+        TextTarget::EventRecordID => fields.record_id = trimmed.parse().unwrap_or(0),
+        TextTarget::Channel => fields.channel = trimmed.to_string(),
+        TextTarget::Computer => fields.computer = trimmed.to_string(),
+        TextTarget::None => {}
+    }
+}
+
+fn parse_keywords_hex(s: &str) -> u64 {
+    s.strip_prefix("0x")
+        .or_else(|| s.strip_prefix("0X"))
+        .and_then(|hex| u64::from_str_radix(hex, 16).ok())
+        .or_else(|| s.parse::<u64>().ok())
+        .unwrap_or(0)
+}
+
+fn extract_provider_attrs(e: &quick_xml::events::BytesStart<'_>, fields: &mut SystemFields) {
+    for attr in e.attributes().flatten() {
+        match attr.key.local_name().as_ref() {
+            b"Name" => fields.provider_name = String::from_utf8_lossy(&attr.value).into_owned(),
+            b"Guid" => {
+                fields.provider_guid = Some(String::from_utf8_lossy(&attr.value).into_owned())
+            }
+            _ => {}
+        }
+    }
+}
+
+fn extract_qualifiers_attr(e: &quick_xml::events::BytesStart<'_>, fields: &mut SystemFields) {
+    for attr in e.attributes().flatten() {
+        if attr.key.local_name().as_ref() == b"Qualifiers" {
+            fields.qualifiers = String::from_utf8_lossy(&attr.value).parse().ok();
+        }
+    }
+}
+
+fn extract_time_created_attr(e: &quick_xml::events::BytesStart<'_>, fields: &mut SystemFields) {
+    for attr in e.attributes().flatten() {
+        if attr.key.local_name().as_ref() == b"SystemTime" {
+            fields.system_time = Some(String::from_utf8_lossy(&attr.value).into_owned());
+        }
+    }
+}
+
+fn extract_correlation_attrs(e: &quick_xml::events::BytesStart<'_>, fields: &mut SystemFields) {
+    for attr in e.attributes().flatten() {
+        match attr.key.local_name().as_ref() {
+            b"ActivityID" => {
+                fields.activity_id = Some(String::from_utf8_lossy(&attr.value).into_owned())
+            }
+            b"RelatedActivityID" => {
+                fields.related_activity_id = Some(String::from_utf8_lossy(&attr.value).into_owned())
+            }
+            _ => {}
+        }
+    }
+}
+
+fn extract_execution_attrs(e: &quick_xml::events::BytesStart<'_>, fields: &mut SystemFields) {
+    for attr in e.attributes().flatten() {
+        match attr.key.local_name().as_ref() {
+            b"ProcessID" => {
+                fields.process_id = String::from_utf8_lossy(&attr.value).parse().unwrap_or(0)
+            }
+            b"ThreadID" => {
+                fields.thread_id = String::from_utf8_lossy(&attr.value).parse().unwrap_or(0)
+            }
+            _ => {}
+        }
+    }
+}
+
+fn extract_security_attrs(e: &quick_xml::events::BytesStart<'_>, fields: &mut SystemFields) {
+    for attr in e.attributes().flatten() {
+        if attr.key.local_name().as_ref() == b"UserID" {
+            fields.user_id = Some(String::from_utf8_lossy(&attr.value).into_owned());
+        }
+    }
+}
+
+/// Build a WindowsEvent from pre-parsed SystemFields and raw XML.
+///
+/// Applies event ID filters, age filters, and parses EventData/UserData.
+/// Returns `Ok(None)` for filtered events.
+pub fn build_event(
+    xml: String,
+    channel: &str,
+    config: &WindowsEventLogConfig,
+    rendered_message: Option<String>,
+    system_fields: SystemFields,
+) -> Result<Option<WindowsEvent>, WindowsEventLogError> {
+    let record_id = system_fields.record_id;
+    let event_id = system_fields.event_id;
+
+    if record_id == 0 && event_id == 0 {
+        debug!(
+            message = "Failed to parse event XML - no valid EventID or RecordID found.",
+            channel = %channel
+        );
+        return Ok(None);
+    }
+
+    // Apply event ID filters early
+    if let Some(ref only_ids) = config.only_event_ids
+        && !only_ids.contains(&event_id)
+    {
+        counter!("windows_event_log_events_filtered_total", "reason" => "event_id_not_in_only_list")
+            .increment(1);
+        return Ok(None);
+    }
+
+    if config.ignore_event_ids.contains(&event_id) {
+        counter!("windows_event_log_events_filtered_total", "reason" => "event_id_ignored")
+            .increment(1);
+        return Ok(None);
+    }
+
+    // Parse timestamp
+    let time_created = system_fields
+        .system_time
+        .as_deref()
+        .and_then(|s| {
+            DateTime::parse_from_rfc3339(s)
+                .or_else(|_| DateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f%z"))
+                .or_else(|_| DateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%z"))
+                .ok()
+        })
+        .map(|dt| {
+            let dt_utc = dt.with_timezone(&Utc);
+            let diff = (Utc::now() - dt_utc).num_days().abs();
+            if diff > 365 * 10 {
+                warn!(
+                    message = "Event timestamp is more than 10 years from current time.",
+                    timestamp = %dt_utc,
+                    channel = %channel,
+                    record_id = record_id,
+                );
+            }
+            dt_utc
+        })
+        .unwrap_or_else(Utc::now);
+
+    // Apply age filter
+    if let Some(max_age_secs) = config.max_event_age_secs {
+        let age = Utc::now().signed_duration_since(time_created);
+        if age.num_seconds() > max_age_secs as i64 {
+            counter!("windows_event_log_events_filtered_total", "reason" => "max_age_exceeded")
+                .increment(1);
+            return Ok(None);
+        }
+    }
+
+    let event_data_result = extract_event_data(&xml, config);
+
+    let event = WindowsEvent {
+        record_id,
+        event_id,
+        level: system_fields.level,
+        task: system_fields.task,
+        opcode: system_fields.opcode,
+        keywords: system_fields.keywords,
+        time_created,
+        provider_name: system_fields.provider_name,
+        provider_guid: system_fields.provider_guid,
+        channel: if system_fields.channel.is_empty() {
+            channel.to_string()
+        } else {
+            system_fields.channel
+        },
+        computer: system_fields.computer,
+        user_id: system_fields.user_id,
+        process_id: system_fields.process_id,
+        thread_id: system_fields.thread_id,
+        activity_id: system_fields.activity_id,
+        related_activity_id: system_fields.related_activity_id,
+        rendered_message,
+        raw_xml: if config.include_xml {
+            let mut raw = xml;
+            truncate_utf8(&mut raw, 32768);
+            raw
+        } else {
+            String::new()
+        },
+        event_data: event_data_result.structured_data,
+        user_data: event_data_result.user_data,
+        task_name: None,
+        opcode_name: None,
+        keyword_names: Vec::new(),
+        user_name: None,
+        version: system_fields.version,
+        qualifiers: system_fields.qualifiers,
+        string_inserts: event_data_result.string_inserts,
+    };
+
+    Ok(Some(event))
+}
+
+/// Convenience wrapper: parse System section + build event in one call.
+#[cfg(test)]
+pub fn parse_event_xml(
+    xml: String,
+    channel: &str,
+    config: &WindowsEventLogConfig,
+    rendered_message: Option<String>,
+) -> Result<Option<WindowsEvent>, WindowsEventLogError> {
+    let system_fields = parse_system_section(&xml);
+    build_event(xml, channel, config, rendered_message, system_fields)
+}
+
+/// Extract EventData and UserData sections from event XML.
+pub fn extract_event_data(xml: &str, config: &WindowsEventLogConfig) -> EventDataResult {
+    let mut structured_data = HashMap::new();
+    let mut string_inserts = Vec::new();
+    let mut user_data = HashMap::new();
+
+    parse_section(xml, "EventData", &mut structured_data, &mut string_inserts);
+    parse_section(xml, "UserData", &mut user_data, &mut Vec::new());
+
+    // Apply configurable truncation
+    if config.max_event_data_length > 0 {
+        for value in structured_data.values_mut() {
+            truncate_utf8(value, config.max_event_data_length);
+        }
+        for value in user_data.values_mut() {
+            truncate_utf8(value, config.max_event_data_length);
+        }
+        for value in string_inserts.iter_mut() {
+            truncate_utf8(value, config.max_event_data_length);
+        }
+    }
+
+    EventDataResult {
+        structured_data,
+        string_inserts,
+        user_data,
+    }
+}
+
+/// Parse a specific XML section (EventData or UserData).
+fn parse_section(
+    xml: &str,
+    section_name: &str,
+    named_data: &mut HashMap<String, String>,
+    inserts: &mut Vec<String>,
+) {
+    let mut reader = Reader::from_str(xml);
+    reader.trim_text(true);
+
+    let mut buf = Vec::new();
+    let mut inside_section = false;
+    let mut inside_data = false;
+    let mut current_data_name = String::new();
+    let mut current_data_value = String::new();
+
+    const MAX_ITERATIONS: usize = 500;
+    const MAX_FIELDS: usize = 100;
+    let mut iterations = 0;
+
+    loop {
+        if iterations >= MAX_ITERATIONS
+            || (named_data.len() >= MAX_FIELDS || inserts.len() >= MAX_FIELDS)
+        {
+            break;
+        }
+        iterations += 1;
+
+        match reader.read_event_into(&mut buf) {
+            Ok(XmlEvent::Start(ref e)) => {
+                let name = e.name();
+                if name.as_ref() == section_name.as_bytes() {
+                    inside_section = true;
+                } else if inside_section && name.as_ref() == b"Data" {
+                    inside_data = true;
+                    current_data_name.clear();
+                    current_data_value.clear();
+
+                    for attr in e.attributes().flatten() {
+                        if attr.key.as_ref() == b"Name" {
+                            let name_value = String::from_utf8_lossy(&attr.value);
+                            if name_value.len() <= 128 && !name_value.trim().is_empty() {
+                                current_data_name = name_value.into_owned();
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+            Ok(XmlEvent::End(ref e)) => {
+                let name = e.name();
+                if name.as_ref() == section_name.as_bytes() {
+                    inside_section = false;
+                } else if name.as_ref() == b"Data" && inside_data {
+                    inside_data = false;
+
+                    if !current_data_name.is_empty() {
+                        named_data.insert(current_data_name.clone(), current_data_value.clone());
+                    } else if section_name == "EventData" && inserts.len() < MAX_FIELDS {
+                        inserts.push(current_data_value.clone());
+                    }
+                }
+            }
+            Ok(XmlEvent::Text(ref e)) => {
+                if inside_section
+                    && inside_data
+                    && let Ok(text) = e.unescape()
+                {
+                    const MAX_VALUE_SIZE: usize = 1024 * 1024;
+                    if current_data_value.len() + text.len() <= MAX_VALUE_SIZE {
+                        current_data_value.push_str(&text);
+                    }
+                }
+            }
+            Ok(XmlEvent::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+
+        buf.clear();
+    }
+}
+
+/// Check if bookmark XML is valid (contains an actual bookmark position).
+pub fn is_valid_bookmark_xml(xml: &str) -> bool {
+    !xml.is_empty() && xml.contains("<Bookmark") && xml.contains("RecordId")
+}
+
+/// Extract a single element's text content by tag name.
+///
+/// Prefer `parse_system_section` for bulk System field extraction (single pass).
+/// This function is retained for one-off lookups outside the hot path.
+#[cfg(test)]
+pub fn extract_xml_value(xml: &str, tag: &str) -> Option<String> {
+    let mut reader = Reader::from_str(xml);
+    reader.trim_text(true);
+
+    let mut buf = Vec::new();
+    let mut inside_target = false;
+    let mut current_element = String::new();
+
+    const MAX_ITERATIONS: usize = 5000;
+    let mut iterations = 0;
+
+    loop {
+        if iterations >= MAX_ITERATIONS {
+            warn!(message = "XML parsing iteration limit exceeded.");
+            return None;
+        }
+        iterations += 1;
+
+        match reader.read_event_into(&mut buf) {
+            Ok(XmlEvent::Start(ref e)) => {
+                let name = e.name();
+                let element_name = String::from_utf8_lossy(name.as_ref());
+                if element_name == tag {
+                    inside_target = true;
+                    current_element.clear();
+                }
+            }
+            Ok(XmlEvent::Text(ref e)) => {
+                if inside_target {
+                    match e.unescape() {
+                        Ok(text) => {
+                            if current_element.len() + text.len() > 4096 {
+                                warn!(message = "XML element text too long, truncating.");
+                                break;
+                            }
+                            current_element.push_str(&text);
+                        }
+                        Err(_) => return None,
+                    }
+                }
+            }
+            Ok(XmlEvent::End(ref e)) => {
+                let name = e.name();
+                let element_name = String::from_utf8_lossy(name.as_ref());
+                if element_name == tag && inside_target {
+                    return Some(current_element.trim().to_string());
+                }
+            }
+            Ok(XmlEvent::Eof) => break,
+            Err(_) => return None,
+            _ => {}
+        }
+
+        buf.clear();
+    }
+
+    None
+}
+
+/// Extract an XML attribute value by attribute name via string search.
+///
+/// Prefer `parse_system_section` for bulk System field extraction (single pass).
+/// This function is retained for one-off lookups outside the hot path.
+#[cfg(test)]
+pub fn extract_xml_attribute(xml: &str, attr_name: &str) -> Option<String> {
+    let needle = format!("{attr_name}='");
+    if let Some(start) = xml.find(&needle) {
+        let value_start = start + needle.len();
+        if let Some(end) = xml[value_start..].find('\'') {
+            return Some(xml[value_start..value_start + end].to_string());
+        }
+    }
+    let needle = format!("{attr_name}=\"");
+    if let Some(start) = xml.find(&needle) {
+        let value_start = start + needle.len();
+        if let Some(end) = xml[value_start..].find('"') {
+            return Some(xml[value_start..value_start + end].to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FULL_EVENT_XML: &str = r#"
+    <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+        <System>
+            <Provider Name="Microsoft-Windows-Kernel-General" Guid="{A68CA8B7-004F-D7B6-A698-07E2DE0F1F5D}"/>
+            <EventID Qualifiers="16384">1</EventID>
+            <Version>2</Version>
+            <Level>4</Level>
+            <Task>100</Task>
+            <Opcode>1</Opcode>
+            <Keywords>0x8000000000000000</Keywords>
+            <TimeCreated SystemTime="2025-08-29T00:15:41.123456Z"/>
+            <EventRecordID>12345</EventRecordID>
+            <Correlation ActivityID="{AAAA-BBBB}" RelatedActivityID="{CCCC-DDDD}"/>
+            <Execution ProcessID="1234" ThreadID="5678"/>
+            <Channel>System</Channel>
+            <Computer>TEST-MACHINE</Computer>
+            <Security UserID="S-1-5-18"/>
+        </System>
+    </Event>
+    "#;
+
+    #[test]
+    fn test_parse_system_section_full() {
+        let fields = parse_system_section(FULL_EVENT_XML);
+
+        assert_eq!(fields.provider_name, "Microsoft-Windows-Kernel-General");
+        assert_eq!(
+            fields.provider_guid.as_deref(),
+            Some("{A68CA8B7-004F-D7B6-A698-07E2DE0F1F5D}")
+        );
+        assert_eq!(fields.event_id, 1);
+        assert_eq!(fields.qualifiers, Some(16384));
+        assert_eq!(fields.version, Some(2));
+        assert_eq!(fields.level, 4);
+        assert_eq!(fields.task, 100);
+        assert_eq!(fields.opcode, 1);
+        assert_eq!(fields.keywords, 0x8000000000000000);
+        assert_eq!(
+            fields.system_time.as_deref(),
+            Some("2025-08-29T00:15:41.123456Z")
+        );
+        assert_eq!(fields.record_id, 12345);
+        assert_eq!(fields.activity_id.as_deref(), Some("{AAAA-BBBB}"));
+        assert_eq!(fields.related_activity_id.as_deref(), Some("{CCCC-DDDD}"));
+        assert_eq!(fields.process_id, 1234);
+        assert_eq!(fields.thread_id, 5678);
+        assert_eq!(fields.channel, "System");
+        assert_eq!(fields.computer, "TEST-MACHINE");
+        assert_eq!(fields.user_id.as_deref(), Some("S-1-5-18"));
+    }
+
+    #[test]
+    fn test_parse_system_section_minimal() {
+        let xml = r#"
+        <Event>
+            <System>
+                <Provider Name="TestProvider"/>
+                <EventID>42</EventID>
+                <Channel>Application</Channel>
+                <Computer>PC</Computer>
+            </System>
+        </Event>
+        "#;
+
+        let fields = parse_system_section(xml);
+        assert_eq!(fields.provider_name, "TestProvider");
+        assert_eq!(fields.event_id, 42);
+        assert_eq!(fields.channel, "Application");
+        assert_eq!(fields.computer, "PC");
+        assert_eq!(fields.level, 0);
+        assert_eq!(fields.record_id, 0);
+        assert!(fields.provider_guid.is_none());
+        assert!(fields.system_time.is_none());
+    }
+
+    #[test]
+    fn test_parse_system_section_stops_at_end_of_system() {
+        // Ensure parser stops after </System> and doesn't scan EventData
+        let xml = r#"
+        <Event>
+            <System>
+                <Provider Name="P1"/>
+                <EventID>1</EventID>
+                <Channel>App</Channel>
+                <Computer>PC</Computer>
+            </System>
+            <EventData>
+                <Data Name="Channel">ShouldNotBeUsed</Data>
+            </EventData>
+        </Event>
+        "#;
+
+        let fields = parse_system_section(xml);
+        assert_eq!(fields.channel, "App");
+        assert_eq!(fields.provider_name, "P1");
+    }
+
+    #[test]
+    fn test_extract_xml_value() {
+        let xml = r#"
+        <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+            <System>
+                <Provider Name="Microsoft-Windows-Kernel-General" Guid="{A68CA8B7-004F-D7B6-A698-07E2DE0F1F5D}"/>
+                <EventID>1</EventID>
+                <Level>4</Level>
+                <EventRecordID>12345</EventRecordID>
+                <Channel>System</Channel>
+                <Computer>TEST-MACHINE</Computer>
+            </System>
+        </Event>
+        "#;
+
+        assert_eq!(extract_xml_value(xml, "EventID"), Some("1".to_string()));
+        assert_eq!(extract_xml_value(xml, "Level"), Some("4".to_string()));
+        assert_eq!(
+            extract_xml_value(xml, "EventRecordID"),
+            Some("12345".to_string())
+        );
+        assert_eq!(
+            extract_xml_value(xml, "Channel"),
+            Some("System".to_string())
+        );
+        assert_eq!(
+            extract_xml_value(xml, "Computer"),
+            Some("TEST-MACHINE".to_string())
+        );
+        assert_eq!(extract_xml_value(xml, "NonExistent"), None);
+    }
+
+    #[test]
+    fn test_extract_xml_attribute() {
+        let xml = r#"
+        <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+            <System>
+                <Provider Name="Microsoft-Windows-Kernel-General" Guid="{A68CA8B7-004F-D7B6-A698-07E2DE0F1F5D}"/>
+                <TimeCreated SystemTime="2025-08-29T00:15:41.123456Z"/>
+            </System>
+        </Event>
+        "#;
+
+        assert_eq!(
+            extract_xml_attribute(xml, "Name"),
+            Some("Microsoft-Windows-Kernel-General".to_string())
+        );
+        assert_eq!(
+            extract_xml_attribute(xml, "SystemTime"),
+            Some("2025-08-29T00:15:41.123456Z".to_string())
+        );
+        assert_eq!(extract_xml_attribute(xml, "NonExistent"), None);
+    }
+
+    #[test]
+    fn test_windows_event_level_name() {
+        let event = WindowsEvent {
+            record_id: 1,
+            event_id: 1000,
+            level: 2,
+            task: 0,
+            opcode: 0,
+            keywords: 0,
+            time_created: Utc::now(),
+            provider_name: "Test".to_string(),
+            provider_guid: None,
+            channel: "Test".to_string(),
+            computer: "localhost".to_string(),
+            user_id: None,
+            process_id: 0,
+            thread_id: 0,
+            activity_id: None,
+            related_activity_id: None,
+            raw_xml: String::new(),
+            rendered_message: None,
+            event_data: HashMap::new(),
+            user_data: HashMap::new(),
+            task_name: None,
+            opcode_name: None,
+            keyword_names: Vec::new(),
+            user_name: None,
+            version: Some(1),
+            qualifiers: Some(0),
+            string_inserts: vec![],
+        };
+
+        assert_eq!(event.level_name(), "Error");
+    }
+
+    #[test]
+    fn test_level_0_maps_to_information() {
+        let mut event = WindowsEvent {
+            record_id: 1,
+            event_id: 4624,
+            level: 0,
+            task: 12544,
+            opcode: 0,
+            keywords: 0x0020000000000000,
+            time_created: Utc::now(),
+            provider_name: "Microsoft-Windows-Security-Auditing".to_string(),
+            provider_guid: None,
+            channel: "Security".to_string(),
+            computer: "localhost".to_string(),
+            user_id: None,
+            process_id: 0,
+            thread_id: 0,
+            activity_id: None,
+            related_activity_id: None,
+            raw_xml: String::new(),
+            rendered_message: None,
+            event_data: HashMap::new(),
+            user_data: HashMap::new(),
+            task_name: None,
+            opcode_name: None,
+            keyword_names: Vec::new(),
+            user_name: None,
+            version: Some(2),
+            qualifiers: Some(0),
+            string_inserts: vec![],
+        };
+
+        assert_eq!(event.level_name(), "Information");
+
+        event.level = 4;
+        assert_eq!(event.level_name(), "Information");
+    }
+
+    #[test]
+    fn test_security_limits() {
+        let large_xml = format!(
+            r#"
+        <Event>
+            <System>
+                <EventID>{}</EventID>
+            </System>
+        </Event>
+        "#,
+            "x".repeat(10000)
+        );
+
+        let result = extract_xml_value(&large_xml, "EventID");
+        assert!(
+            result.is_none(),
+            "Security limits should reject excessively large XML content"
+        );
+    }
+
+    #[test]
+    fn test_configurable_truncation_disabled_by_default() {
+        let config = WindowsEventLogConfig::default();
+        assert_eq!(
+            config.max_event_data_length, 0,
+            "Event data truncation should be disabled by default"
+        );
+    }
+
+    #[test]
+    fn test_event_data_truncation_when_enabled() {
+        let xml = r#"
+        <Event>
+            <EventData>
+                <Data Name="LongValue">This is a very long value that should be truncated when the limit is set</Data>
+                <Data Name="ShortValue">Short</Data>
+            </EventData>
+        </Event>
+        "#;
+
+        let mut config = WindowsEventLogConfig::default();
+        config.max_event_data_length = 20;
+
+        let result = extract_event_data(xml, &config);
+
+        let long_value = result.structured_data.get("LongValue").unwrap();
+        assert!(
+            long_value.ends_with("...[truncated]"),
+            "Long value should be truncated"
+        );
+        assert!(
+            long_value.len() <= 20 + "...[truncated]".len(),
+            "Truncated value should respect limit"
+        );
+
+        let short_value = result.structured_data.get("ShortValue").unwrap();
+        assert_eq!(short_value, "Short", "Short value should not be truncated");
+        assert!(
+            !short_value.contains("truncated"),
+            "Short value should not have truncation marker"
+        );
+    }
+
+    #[test]
+    fn test_event_data_no_truncation_when_disabled() {
+        let xml = r#"
+        <Event>
+            <EventData>
+                <Data Name="LongValue">This is a very long value that should NOT be truncated when truncation is disabled by setting max_event_data_length to 0</Data>
+            </EventData>
+        </Event>
+        "#;
+
+        let config = WindowsEventLogConfig::default();
+        assert_eq!(
+            config.max_event_data_length, 0,
+            "Default should be no truncation"
+        );
+
+        let result = extract_event_data(xml, &config);
+
+        let long_value = result.structured_data.get("LongValue").unwrap();
+        assert!(
+            !long_value.ends_with("...[truncated]"),
+            "Value should not be truncated when limit is 0"
+        );
+        assert!(long_value.len() > 100, "Full value should be preserved");
+        assert!(
+            long_value.contains("disabled by setting max_event_data_length to 0"),
+            "Full text should be present"
+        );
+    }
+
+    #[test]
+    fn test_is_valid_bookmark_xml() {
+        let valid = r#"<BookmarkList>
+  <Bookmark Channel='Application' RecordId='12345' IsCurrent='true'/>
+</BookmarkList>"#;
+        assert!(
+            is_valid_bookmark_xml(valid),
+            "Should accept valid bookmark with RecordId"
+        );
+
+        assert!(!is_valid_bookmark_xml(""), "Should reject empty string");
+
+        let empty_list = "<BookmarkList/>";
+        assert!(
+            !is_valid_bookmark_xml(empty_list),
+            "Should reject empty BookmarkList"
+        );
+
+        let empty_list2 = "<BookmarkList></BookmarkList>";
+        assert!(
+            !is_valid_bookmark_xml(empty_list2),
+            "Should reject BookmarkList without Bookmark element"
+        );
+
+        let no_record_id = "<BookmarkList><Bookmark Channel='System'/></BookmarkList>";
+        assert!(
+            !is_valid_bookmark_xml(no_record_id),
+            "Should reject Bookmark without RecordId"
+        );
+    }
+
+    #[test]
+    fn test_parse_event_xml_basic() {
+        let xml = r#"
+        <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+            <System>
+                <Provider Name="TestProvider"/>
+                <EventID>1000</EventID>
+                <Level>4</Level>
+                <EventRecordID>12345</EventRecordID>
+                <TimeCreated SystemTime="2025-01-01T00:00:00.000000Z"/>
+                <Channel>Application</Channel>
+                <Computer>TEST-PC</Computer>
+            </System>
+        </Event>
+        "#;
+
+        let config = WindowsEventLogConfig::default();
+
+        let result = parse_event_xml(xml.to_string(), "Application", &config, None);
+
+        let event = result.unwrap().unwrap();
+        assert_eq!(event.event_id, 1000);
+        assert_eq!(event.record_id, 12345);
+        assert_eq!(event.provider_name, "TestProvider");
+        assert_eq!(event.channel, "Application");
+        assert_eq!(event.computer, "TEST-PC");
+        assert!(
+            event.rendered_message.is_none(),
+            "rendered_message should be None when not provided"
+        );
+    }
+
+    #[test]
+    fn test_parse_event_xml_with_rendered_message() {
+        let xml = r#"
+        <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+            <System>
+                <Provider Name="TestProvider"/>
+                <EventID>1000</EventID>
+                <Level>4</Level>
+                <EventRecordID>12345</EventRecordID>
+                <TimeCreated SystemTime="2025-01-01T00:00:00.000000Z"/>
+                <Channel>Application</Channel>
+                <Computer>TEST-PC</Computer>
+            </System>
+        </Event>
+        "#;
+
+        let config = WindowsEventLogConfig::default();
+        let rendered_msg = Some("The application started successfully.".to_string());
+
+        let result = parse_event_xml(xml.to_string(), "Application", &config, rendered_msg);
+
+        let event = result.unwrap().unwrap();
+        assert_eq!(event.event_id, 1000);
+        assert_eq!(
+            event.rendered_message,
+            Some("The application started successfully.".to_string())
+        );
+    }
+
+    #[test]
+    fn test_keywords_hex_parsing() {
+        assert_eq!(parse_keywords_hex("0x8000000000000000"), 0x8000000000000000);
+        assert_eq!(parse_keywords_hex("0X8000000000000000"), 0x8000000000000000);
+        assert_eq!(parse_keywords_hex("12345"), 12345);
+        assert_eq!(parse_keywords_hex("invalid"), 0);
+        assert_eq!(parse_keywords_hex("0x0020000000000000"), 0x0020000000000000);
+    }
+
+    #[test]
+    fn test_max_event_age_secs_filters_old_events() {
+        let xml = r#"
+        <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+            <System>
+                <Provider Name="TestProvider"/>
+                <EventID>1000</EventID>
+                <Level>4</Level>
+                <EventRecordID>12345</EventRecordID>
+                <TimeCreated SystemTime="2020-01-01T00:00:00.000000Z"/>
+                <Channel>Application</Channel>
+                <Computer>TEST-PC</Computer>
+            </System>
+        </Event>
+        "#;
+
+        let mut config = WindowsEventLogConfig::default();
+        config.max_event_age_secs = Some(3600); // 1 hour
+
+        let result = parse_event_xml(xml.to_string(), "Application", &config, None);
+        assert!(
+            result.unwrap().is_none(),
+            "Old event should be filtered by max_event_age_secs"
+        );
+    }
+
+    #[test]
+    fn test_max_event_age_secs_allows_recent_events() {
+        // Use a timestamp very close to now
+        let now = Utc::now().format("%Y-%m-%dT%H:%M:%S%.6fZ").to_string();
+        let xml = format!(
+            r#"
+            <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+                <System>
+                    <Provider Name="TestProvider"/>
+                    <EventID>1000</EventID>
+                    <Level>4</Level>
+                    <EventRecordID>12345</EventRecordID>
+                    <TimeCreated SystemTime="{now}"/>
+                    <Channel>Application</Channel>
+                    <Computer>TEST-PC</Computer>
+                </System>
+            </Event>
+            "#
+        );
+
+        let mut config = WindowsEventLogConfig::default();
+        config.max_event_age_secs = Some(3600); // 1 hour
+
+        let result = parse_event_xml(xml, "Application", &config, None);
+        assert!(
+            result.unwrap().is_some(),
+            "Recent event should pass max_event_age_secs filter"
+        );
+    }
+}

--- a/src/sources/windows_event_log/xml_parser.rs
+++ b/src/sources/windows_event_log/xml_parser.rs
@@ -344,12 +344,12 @@ pub fn build_event(
     }
 
     // Apply event ID filters early
-    if let Some(ref only_ids) = config.only_event_ids
-        && !only_ids.contains(&event_id)
-    {
-        counter!("windows_event_log_events_filtered_total", "reason" => "event_id_not_in_only_list")
-            .increment(1);
-        return Ok(None);
+    if let Some(ref only_ids) = config.only_event_ids {
+        if !only_ids.contains(&event_id) {
+            counter!("windows_event_log_events_filtered_total", "reason" => "event_id_not_in_only_list")
+                .increment(1);
+            return Ok(None);
+        }
     }
 
     if config.ignore_event_ids.contains(&event_id) {
@@ -543,13 +543,12 @@ fn parse_section(
                 }
             }
             Ok(XmlEvent::Text(ref e)) => {
-                if inside_section
-                    && inside_data
-                    && let Ok(text) = e.unescape()
-                {
-                    const MAX_VALUE_SIZE: usize = 1024 * 1024;
-                    if current_data_value.len() + text.len() <= MAX_VALUE_SIZE {
-                        current_data_value.push_str(&text);
+                if inside_section && inside_data {
+                    if let Ok(text) = e.unescape() {
+                        const MAX_VALUE_SIZE: usize = 1024 * 1024;
+                        if current_data_value.len() + text.len() <= MAX_VALUE_SIZE {
+                            current_data_value.push_str(&text);
+                        }
                     }
                 }
             }

--- a/tests/integration/windows-event-log/config/test.yaml
+++ b/tests/integration/windows-event-log/config/test.yaml
@@ -1,0 +1,17 @@
+features:
+- windows-event-log-integration-tests
+
+test_filter: '::windows_event_log::integration_tests::'
+
+runner:
+  env: {}
+
+matrix:
+  default: ["default"]
+
+# changes to these files/paths will invoke the integration test in CI
+# expressions are evaluated using https://github.com/micromatch/picomatch
+paths:
+- "src/sources/windows_event_log/**"
+- "src/internal_events/windows_event_log.rs"
+- "tests/integration/windows-event-log/**"

--- a/website/content/en/docs/reference/configuration/sources/windows_event_log.md
+++ b/website/content/en/docs/reference/configuration/sources/windows_event_log.md
@@ -1,0 +1,14 @@
+---
+title: Windows Event Log
+description: Collect logs from [Windows Event Log](https://learn.microsoft.com/en-us/windows/win32/wes/windows-event-log) channels using the native Windows Event Log API
+component_kind: source
+layout: component
+tags: ["windows_event_log", "component", "source", "logs"]
+---
+
+{{/*
+This doc is generated using:
+
+1. The template in layouts/docs/component.html
+2. The relevant CUE data in cue/reference/components/...
+*/}}

--- a/website/cue/reference/components/sources/base/windows_event_log.cue
+++ b/website/cue/reference/components/sources/base/windows_event_log.cue
@@ -1,0 +1,283 @@
+package metadata
+
+generated: components: sources: windows_event_log: configuration: {
+	acknowledgements: {
+		deprecated: true
+		description: """
+			Controls how acknowledgements are handled for this source.
+
+			When enabled, the source will wait for downstream sinks to acknowledge
+			receipt of events before updating checkpoints. This provides exactly-once
+			delivery guarantees at the cost of potential duplicate events on restart
+			if acknowledgements are pending.
+
+			When disabled (default), checkpoints are updated immediately after reading
+			events, which may result in data loss if Vector crashes before events are
+			delivered to sinks.
+			"""
+		required: false
+		type: object: options: enabled: {
+			description: "Whether or not end-to-end acknowledgements are enabled for this source."
+			required:    false
+			type: bool: {}
+		}
+	}
+	batch_size: {
+		description: """
+			Batch size for event processing.
+
+			This controls how many events are processed in a single batch.
+			"""
+		required: false
+		type: uint: {
+			default: 100
+			examples: [10, 100]
+		}
+	}
+	channels: {
+		description: """
+			A comma-separated list of channels to read from.
+
+			Common channels include "System", "Application", "Security", "Windows PowerShell".
+			Use Windows Event Viewer to discover available channels.
+			"""
+		required: true
+		type: array: items: type: string: examples: ["System,Application,Security", "System"]
+	}
+	checkpoint_interval_secs: {
+		description: """
+			Interval in seconds between periodic checkpoint flushes.
+
+			Controls how often bookmarks are persisted to disk in synchronous mode.
+			Lower values reduce the window of events that may be re-processed after
+			a crash, at the cost of more frequent disk writes.
+			"""
+		required: false
+		type: uint: {
+			default: 5
+			examples: [5, 1, 30]
+		}
+	}
+	connection_timeout_secs: {
+		description: """
+			Connection timeout in seconds for event subscription.
+
+			This controls how long to wait for event subscription connection.
+			"""
+		required: false
+		type: uint: {
+			default: 30
+			examples: [30, 60]
+		}
+	}
+	data_dir: {
+		description: """
+			The directory where checkpoint data is stored.
+
+			By default, the [global `data_dir` option][global_data_dir] is used.
+			Make sure the running user has write permissions to this directory.
+
+			[global_data_dir]: https://vector.dev/docs/reference/configuration/global-options/#data_dir
+			"""
+		required: false
+		type: string: examples: ["/var/lib/vector", "C:\\ProgramData\\vector"]
+	}
+	event_data_format: {
+		description: """
+			Custom event data formatting options.
+
+			Maps event field names to custom formatting options.
+			"""
+		required: false
+		type: object: options: "*": {
+			description: "An individual event data format override."
+			required:    true
+			type: string: enum: {
+				auto: """
+					Keep the original format unchanged (passthrough).
+					The field value will not be converted or modified.
+					"""
+				boolean: """
+					Parse and format the field value as a boolean.
+					Recognizes "true", "1", "yes", "on" as true (case-insensitive).
+					"""
+				float:   "Parse and format the field value as a floating-point number."
+				integer: "Parse and format the field value as an integer."
+				string:  "Format the field value as a string."
+			}
+		}
+	}
+	event_query: {
+		description: """
+			The XPath query for filtering events.
+
+			Allows filtering events using XML Path Language queries.
+			If not specified, all events from the specified channels will be collected.
+			"""
+		required: false
+		type: string: examples: ["*[System[Level=1 or Level=2 or Level=3]]", "*[System[(Level=1 or Level=2 or Level=3) and TimeCreated[timediff(@SystemTime) <= 86400000]]]"]
+	}
+	event_timeout_ms: {
+		description: """
+			Timeout in milliseconds for waiting for new events.
+
+			Controls the maximum time `WaitForMultipleObjects` blocks before
+			returning to check for shutdown signals. Lower values increase
+			shutdown responsiveness at the cost of more frequent wake-ups.
+			"""
+		required: false
+		type: uint: {
+			default: 5000
+			examples: [5000, 10000]
+		}
+	}
+	events_per_second: {
+		description: """
+			Maximum number of events to process per second.
+
+			When set to a non-zero value, Vector will rate-limit event processing
+			to prevent overwhelming downstream systems. A value of 0 (default) means
+			no rate limiting is applied.
+			"""
+		required: false
+		type: uint: {
+			default: 0
+			examples: [100, 1000, 5000]
+		}
+	}
+	field_filter: {
+		description: """
+			Event field inclusion/exclusion patterns.
+
+			Controls which event fields are included in the output.
+			"""
+		required: false
+		type: object: options: {
+			exclude_fields: {
+				description: """
+					Fields to exclude from the output.
+
+					These fields will be removed from the event data.
+					"""
+				required: false
+				type: array: items: type: string: {}
+			}
+			include_event_data: {
+				description: """
+					Whether to include event data fields.
+
+					Event data fields contain application-specific data.
+					"""
+				required: false
+				type: bool: default: true
+			}
+			include_fields: {
+				description: """
+					Fields to include in the output.
+
+					If specified, only these fields will be included.
+					"""
+				required: false
+				type: array: items: type: string: {}
+			}
+			include_system_fields: {
+				description: """
+					Whether to include system fields.
+
+					System fields include metadata like Computer, TimeCreated, etc.
+					"""
+				required: false
+				type: bool: default: true
+			}
+			include_user_data: {
+				description: """
+					Whether to include user data fields.
+
+					User data fields contain additional custom data.
+					"""
+				required: false
+				type: bool: default: true
+			}
+		}
+	}
+	ignore_event_ids: {
+		description: """
+			Ignore specific event IDs.
+
+			Events with these IDs will be filtered out and not sent downstream.
+			"""
+		required: false
+		type: array: {
+			default: []
+			items: type: uint: examples: [4624, 4625, 4634]
+		}
+	}
+	include_xml: {
+		description: """
+			Whether to include raw XML data in the output.
+
+			When enabled, the raw XML representation of the event is included
+			in the `xml` field of the output event.
+			"""
+		required: false
+		type: bool: default: false
+	}
+	max_event_age_secs: {
+		description: """
+			Maximum age of events to process (in seconds).
+
+			Events older than this value will be ignored. If not specified,
+			all events will be processed regardless of age.
+			"""
+		required: false
+		type: uint: examples: [86400, 604800]
+	}
+	max_event_data_length: {
+		description: """
+			Maximum length for event data field values.
+
+			Event data values longer than this will be truncated with "...\\[truncated\\]" appended.
+			Set to 0 for no limit.
+			"""
+		required: false
+		type: uint: {
+			default: 0
+			examples: [1024, 4096]
+		}
+	}
+	only_event_ids: {
+		description: """
+			Only include specific event IDs.
+
+			If specified, only events with these IDs will be processed.
+			Takes precedence over `ignore_event_ids`.
+			"""
+		required: false
+		type: array: items: type: uint: examples: [1000, 1001, 1002]
+	}
+	read_existing_events: {
+		description: """
+			Whether to read existing events or only new events.
+
+			When set to `true`, the source will read all existing events from the channels.
+			When set to `false` (default), only new events will be read.
+			"""
+		required: false
+		type: bool: default: false
+	}
+	render_message: {
+		description: """
+			Whether to render human-readable event messages.
+
+			When enabled (default), Vector will use the Windows EvtFormatMessage API
+			to render localized, human-readable event messages with parameter
+			substitution. This matches the behavior of Windows Event Viewer.
+
+			Provider DLL handles are cached per provider, so the performance cost
+			is limited to the first event from each provider. Disable only if you
+			do not need rendered messages and want to eliminate the DLL loads entirely.
+			"""
+		required: false
+		type: bool: default: true
+	}
+}

--- a/website/cue/reference/components/sources/windows_event_log.cue
+++ b/website/cue/reference/components/sources/windows_event_log.cue
@@ -1,0 +1,113 @@
+package metadata
+
+components: sources: windows_event_log: {
+	title: "Windows Event Log"
+
+	description: """
+		Collects log events from Windows Event Log channels using the native
+		Windows Event Log API.
+		"""
+
+	classes: {
+		commonly_used: false
+		delivery:      "at_least_once"
+		deployment_roles: ["daemon"]
+		development:   "beta"
+		egress_method: "stream"
+		stateful:      true
+	}
+
+	features: {
+		auto_generated:   true
+		acknowledgements: true
+		collect: {
+			checkpoint: enabled: true
+			from: service: {
+				name:     "Windows Event Log"
+				thing:    "Windows Event Log channels"
+				url:      "https://learn.microsoft.com/en-us/windows/win32/wes/windows-event-log"
+				versions: null
+			}
+		}
+		multiline: enabled: false
+	}
+
+	support: {
+		requirements: [
+			"""
+				This source is only supported on Windows. Attempting to use it on
+				other operating systems will result in an error at startup.
+				""",
+		]
+		warnings: []
+		notices: []
+	}
+
+	installation: {
+		platform_name: null
+	}
+
+	configuration: generated.components.sources.windows_event_log.configuration
+
+	output: {
+		logs: event: {
+			description: "An individual Windows Event Log event."
+			fields: {
+				source_type: {
+					description: "The name of the source type."
+					required:    true
+					type: string: {
+						examples: ["windows_event_log"]
+					}
+				}
+				timestamp: {
+					description: "The timestamp of the event."
+					required:    false
+					type: timestamp: {}
+				}
+				message: {
+					description: "The rendered event message."
+					required:    false
+					type: string: {
+						examples: ["The service was started successfully."]
+					}
+				}
+				channel: {
+					description: "The event log channel name."
+					required:    false
+					type: string: {
+						examples: ["System", "Application", "Security"]
+					}
+				}
+				event_id: {
+					description: "The event identifier."
+					required:    false
+					type: uint: {
+						examples: [7036, 4624, 1000]
+					}
+				}
+				provider_name: {
+					description: "The name of the event provider."
+					required:    false
+					type: string: {
+						examples: ["Microsoft-Windows-Security-Auditing"]
+					}
+				}
+				computer: {
+					description: "The name of the computer that generated the event."
+					required:    false
+					type: string: {
+						examples: ["DESKTOP-ABC123"]
+					}
+				}
+				level: {
+					description: "The event severity level."
+					required:    false
+					type: string: {
+						examples: ["Information", "Warning", "Error", "Critical"]
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

  Cherry-picks the upstream **Windows Event Log source** (vectordotdev/vector PR #24305, commit `891643ed`) into the fork, along with two upstream follow-up bug fixes and one adapted observability fix, plus
  the changes required to make it build on this fork's toolchain.

  ## Commits

  | Commit | Description |
  |---|---|
  | `feat(new source)` | Cherry-pick of upstream #24305 — the full `windows_event_log` source (source, tests, CI workflow, docs). Conflicts resolved: kept fork's `windows-service 0.7.0` + `wef` entries;
  relocated generated cue to `sources/base/`; kept fork's `internal_events/mod.rs` layout. |
  | `fix: prevent permanent freeze from lost wakeup` | Upstream #25195 — fixes a race where the source could hang indefinitely after idle. |
  | `fix: add source metadata` | Upstream #25337 — attaches standard `source_type`/timestamp metadata to emitted events. |
  | `fix: propagate component span into spawned tasks` | Adapted from upstream #25521 (fork lacks `spawn_in_current_span()`; used `.in_current_span()`). |
  | `chore(deps): update Cargo.lock` | Adds the `windows 0.58` dependency tree. |
  | `fix(deps): add cfg-if dependency` | The source uses `cfg_if!`; fork's `vector` crate only had it in `[workspace.dependencies]`. |
  | `fix: make it compile on fork's toolchain/edition` | Enable `dep:lru`; replace absent `NamedInternalEvent` derive with manual `InternalEvent::name()`; rewrite 5 let-chains as nested conditionals
  (edition 2021 + rustc 1.88). |

  ## Validation
  
  - `cargo check --no-default-features --features sources-windows_event_log` (host) — clean.
  - Cross-compiled and **linked a Windows binary** (`x86_64-pc-windows-gnu`, mingw-w64) with `sources-windows_event_log` + `sinks-console` + `transforms-remap` — clean.

  ## Caveats / follow-ups

  - Cross-compiled as **windows-gnu**; the fork ships **windows-msvc**. Final validation should run on the fork's Windows CI (`make test-integration-windows-event-log`).
  - The `Security` channel requires Administrator/LocalSystem privileges at runtime.
  - Runtime behavior was not executed (no Windows host available during development).