### PR TITLE
feat[OBE-11604]: Introduce JwtBearer auth strategy into sauth and scol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9953,13 +9953,13 @@ dependencies = [
 name = "sauth"
 version = "0.1.0"
 dependencies = [
- "base64 0.22.1",
  "headers 0.3.9",
  "http 0.2.9",
  "http 1.1.0",
  "hyper 0.14.28",
  "hyper-util",
  "itertools 0.14.0",
+ "jsonwebtoken",
  "oauth2 5.0.0",
  "oxide-auth",
  "oxide-auth-poem",
@@ -9975,7 +9975,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "serde_with",
- "smpl_jwt",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9953,6 +9953,7 @@ dependencies = [
 name = "sauth"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "headers 0.3.9",
  "http 0.2.9",
  "http 1.1.0",
@@ -9967,12 +9968,14 @@ dependencies = [
  "rand 0.8.6",
  "rcgen",
  "regex",
+ "reqwest 0.11.26",
  "rstest",
  "sauth",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "serde_with",
+ "smpl_jwt",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",

--- a/lib/observo/sauth/Cargo.toml
+++ b/lib/observo/sauth/Cargo.toml
@@ -38,12 +38,16 @@ rand.workspace = true
 url = { workspace = true, optional = true }
 # this is a hack to enable tracing in hyper-util (debugging can be difficult without this)
 hyper-util = { version = "0.1.10", optional = true, features = ["full"] }
+smpl_jwt = { version = "0.8.0", default-features = false, optional = true }
+reqwest = { version = "0.11", optional = true, default-features = false, features = ["json", "rustls-tls"] }
+base64 = { version = "0.22", optional = true }
 
 [features]
 default = []
+jwt-bearer = ["dep:smpl_jwt", "dep:reqwest"]
 test-support = ["dep:thiserror", "dep:poem", "dep:poem-derive", "dep:oxide-auth",
   "dep:oxide-auth-poem", "dep:tempfile", "dep:rcgen", "dep:serde_urlencoded", "dep:url",
-  "dep:hyper-util"]
+  "dep:hyper-util", "dep:base64"]
 
 [dev-dependencies]
 sauth = {features = ["test-support"], path = "."}

--- a/lib/observo/sauth/Cargo.toml
+++ b/lib/observo/sauth/Cargo.toml
@@ -35,7 +35,7 @@ serde_json.workspace = true
 toml.workspace = true
 hyper.workspace = true
 rand.workspace = true
-url = { workspace = true, optional = true }
+url.workspace = true
 # this is a hack to enable tracing in hyper-util (debugging can be difficult without this)
 hyper-util = { version = "0.1.10", optional = true, features = ["full"] }
 jsonwebtoken.workspace = true
@@ -44,7 +44,7 @@ reqwest = { version = "0.11", default-features = false, features = ["json", "rus
 [features]
 default = []
 test-support = ["dep:thiserror", "dep:poem", "dep:poem-derive", "dep:oxide-auth",
-  "dep:oxide-auth-poem", "dep:tempfile", "dep:rcgen", "dep:serde_urlencoded", "dep:url",
+  "dep:oxide-auth-poem", "dep:tempfile", "dep:rcgen", "dep:serde_urlencoded",
   "dep:hyper-util"]
 
 [dev-dependencies]

--- a/lib/observo/sauth/Cargo.toml
+++ b/lib/observo/sauth/Cargo.toml
@@ -38,16 +38,15 @@ rand.workspace = true
 url = { workspace = true, optional = true }
 # this is a hack to enable tracing in hyper-util (debugging can be difficult without this)
 hyper-util = { version = "0.1.10", optional = true, features = ["full"] }
-smpl_jwt = { version = "0.8.0", default-features = false, optional = true }
+jsonwebtoken = { workspace = true, optional = true }
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["json", "rustls-tls"] }
-base64 = { version = "0.22", optional = true }
 
 [features]
 default = []
-jwt-bearer = ["dep:smpl_jwt", "dep:reqwest"]
+jwt-bearer = ["dep:jsonwebtoken", "dep:reqwest"]
 test-support = ["dep:thiserror", "dep:poem", "dep:poem-derive", "dep:oxide-auth",
   "dep:oxide-auth-poem", "dep:tempfile", "dep:rcgen", "dep:serde_urlencoded", "dep:url",
-  "dep:hyper-util", "dep:base64"]
+  "dep:hyper-util", "dep:jsonwebtoken"]
 
 [dev-dependencies]
 sauth = {features = ["test-support"], path = "."}

--- a/lib/observo/sauth/Cargo.toml
+++ b/lib/observo/sauth/Cargo.toml
@@ -38,15 +38,14 @@ rand.workspace = true
 url = { workspace = true, optional = true }
 # this is a hack to enable tracing in hyper-util (debugging can be difficult without this)
 hyper-util = { version = "0.1.10", optional = true, features = ["full"] }
-jsonwebtoken = { workspace = true, optional = true }
-reqwest = { version = "0.11", optional = true, default-features = false, features = ["json", "rustls-tls"] }
+jsonwebtoken.workspace = true
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 
 [features]
 default = []
-jwt-bearer = ["dep:jsonwebtoken", "dep:reqwest"]
 test-support = ["dep:thiserror", "dep:poem", "dep:poem-derive", "dep:oxide-auth",
   "dep:oxide-auth-poem", "dep:tempfile", "dep:rcgen", "dep:serde_urlencoded", "dep:url",
-  "dep:hyper-util", "dep:jsonwebtoken"]
+  "dep:hyper-util"]
 
 [dev-dependencies]
 sauth = {features = ["test-support"], path = "."}

--- a/lib/observo/scol/Cargo.toml
+++ b/lib/observo/scol/Cargo.toml
@@ -27,7 +27,7 @@ vector-config = { path = "../../vector-config", default-features = false }
 vector-config-macros = { path = "../../vector-config-macros", default-features = false }
 vector-core = { path = "../../vector-core", default-features = false }
 vector-lib = { path = "../../vector-lib", default-features = false, features = ["lua", "observo"] }
-sauth = { path = "../sauth", features = ["jwt-bearer"] }
+sauth = { path = "../sauth" }
 base64 = "0.13.1"
 async-channel = { version = "2.3.1" }
 serde_with.workspace = true

--- a/lib/observo/scol/Cargo.toml
+++ b/lib/observo/scol/Cargo.toml
@@ -27,7 +27,7 @@ vector-config = { path = "../../vector-config", default-features = false }
 vector-config-macros = { path = "../../vector-config-macros", default-features = false }
 vector-core = { path = "../../vector-core", default-features = false }
 vector-lib = { path = "../../vector-lib", default-features = false, features = ["lua", "observo"] }
-sauth = { path = "../sauth" }
+sauth = { path = "../sauth", features = ["jwt-bearer"] }
 base64 = "0.13.1"
 async-channel = { version = "2.3.1" }
 serde_with.workspace = true


### PR DESCRIPTION
## Summary

- Adds `jwt-bearer` feature to `sauth` (`smpl_jwt` + `reqwest` with rustls-tls, no OpenSSL)
- Switches `scol`'s sauth dependency from the old `gcp` feature to `jwt-bearer`
- Updates submodule pointer to pick up the implementation in `dataplane-private`


## Test plan

- [ ] `FEATURES=observo cargo check` passes
- [ ] `cargo test -p sauth --features jwt-bearer,test-support` — all 6 jwt_bearer tests pass
- [ ] Tested end-to-end against Google Workspace Admin Reports API with a real service account + DWD