### PR TITLE
fix(internal_events): remove duplicate mod file declaration

### DIFF
--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -136,12 +136,6 @@ mod unix;
 #[cfg(any(feature = "sources-websocket", feature = "sinks-websocket"))]
 mod websocket;
 
-#[cfg(any(
-    feature = "sources-file",
-    feature = "sources-kubernetes_logs",
-    feature = "sinks-file",
-))]
-mod file;
 #[cfg(all(windows, feature = "sources-windows_event_log"))]
 mod windows_event_log;
 mod windows;


### PR DESCRIPTION
## Summary

- The `OBE-11604` merge introduced a second `#[cfg(...)] mod file;` block at the end of `src/internal_events/mod.rs`
- The canonical declaration already existed at line 57 (alphabetically placed, same cfg gates)
- The duplicate caused a compile error on master CI: `file` module defined multiple times

## Root cause

`OBE-11604` was branched from a point before the alphabetical `mod file;` was added to master. The branch retained its own copy at the bottom of the file. When merged, both copies landed.

## Fix

Remove the trailing duplicate block (6 lines). The gated declaration at line 57 is the correct one.

## Test plan

- [ ] CI on this branch compiles cleanly
- [ ] No functional change — same module is included, just once