### PR TITLE
chore(OBE-11298): add Qodo PR agent config

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,26 @@
+## Qodo configuration for vector — quiet-hardened Balanced preset
+## Reference: https://docs.qodo.ai/install-and-configure/configuration-overview/configuration-and-command-reference
+
+# Pilot feedback: full CI-log-dump comments add no signal beyond the check itself.
+[checks]
+enable_auto_checks_feedback = false
+
+[github_app]
+pr_commands = ["/agentic_review"]  # also disables Qodo's auto-describe comment (redundant with our own PR descriptions)
+handle_push_trigger = true
+push_commands = ["/agentic_review"]
+feedback_on_draft_pr = true
+
+[review_agent]
+comments_location_policy = "both"
+inline_comments_severity_threshold = 2
+demand_self_review = true
+approve_pr_on_self_review = false
+# TODO: VERIFY — pilot feedback recommended `prefer_single_line_comments = true` here to suppress
+# the GIF-placeholder comment noise Qodo posts on review start, but that key is not documented in
+# Qodo's own config reference (https://docs.qodo.ai/install-and-configure/configuration-overview/configuration-and-command-reference).
+# `persistent_comment_notification = false` is a real documented key that may be the actual mechanism —
+# confirm against Qodo support or real review behavior before enabling.
+
+[pr_code_suggestions]
+enable_chat_in_code_suggestions = true


### PR DESCRIPTION
## Summary
Adds `.pr_agent.toml` to onboard this repo to Qodo (SentinelOne's AI code-review platform), using the same quiet-hardened Balanced preset already merged in `manager` and now proposed for `pipeline`, `common`, `helm`, and `dataplane-private`.

The preset turns off two noisy stock defaults flagged during the Qodo pilot:
- `enable_auto_checks_feedback = false` — suppresses full CI-log-dump comments, which add no signal beyond the check itself.
- `pr_commands = ["/agentic_review"]` — drops Qodo's auto-describe comment, which is redundant with our own PR descriptions.

The `TODO: VERIFY` comment about `prefer_single_line_comments` is carried over verbatim: pilot feedback recommended it, but it is not a documented Qodo config key ([config reference](https://docs.qodo.ai/install-and-configure/configuration-overview/configuration-and-command-reference)), so it is deliberately left unset rather than shipped as a silent no-op.

## Why
Config-only, so that when the Qodo app is installed on this repo it reviews with low-noise defaults from day one instead of the stock preset. Keeping the file byte-identical across our repos (apart from the repo name in the header comment) means they all behave the same under review and can be retuned in one pass.

Note: unlike our GitHub Enterprise repos, this repo lives on github.com, so the Qodo app installation is **not** covered by the `s1-ghe-admin` allowlist — that has to be arranged separately. This PR only lands the config.

Ticket: OBE-11298

## Test plan
- Config-only change; no Rust code touched, no behavior to unit test.
- Verified `.pr_agent.toml` parses as valid TOML.
- Verified the file body is byte-identical to the version merged in `manager`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
