### PR TITLE
fix(security): [OBE-10709,OBE-10718,OBE-11236] bound gcs and wef allocation paths

### DIFF
--- a/changelog.d/stcp_gcs_wef_bounds.enhancement.md
+++ b/changelog.d/stcp_gcs_wef_bounds.enhancement.md
@@ -1,8 +1,0 @@
-Bounded previously-unbounded allocation paths in three sources:
-
-- `stcp`: new `max_frame_bytes` (4x `max_event_size`, 64 MiB) bounds the per-connection receive
-  buffer, and `max_lines_per_event` (1e6) bounds the events produced from one RAW field.
-- `gcp_gcs`: new `max_decompressed_bytes` (4 GiB) caps decompressed object size; truncation is
-  logged and counted by `gcs_object_truncated_total`.
-- `wef`: `max_content_length` is now enforced on the inbound HTTP body, defaulting to 4x the
-  advertised `max_envelope_size` and never dropping below it.

--- a/changelog.d/stcp_gcs_wef_bounds.enhancement.md
+++ b/changelog.d/stcp_gcs_wef_bounds.enhancement.md
@@ -1,0 +1,8 @@
+Bounded previously-unbounded allocation paths in three sources:
+
+- `stcp`: new `max_frame_bytes` (4x `max_event_size`, 64 MiB) bounds the per-connection receive
+  buffer, and `max_lines_per_event` (1e6) bounds the events produced from one RAW field.
+- `gcp_gcs`: new `max_decompressed_bytes` (4 GiB) caps decompressed object size; truncation is
+  logged and counted by `gcs_object_truncated_total`.
+- `wef`: `max_content_length` is now enforced on the inbound HTTP body, defaulting to 4x the
+  advertised `max_envelope_size` and never dropping below it.


### PR DESCRIPTION
## What

Bumps \`lib/observo/private\`. **Depends on \`dataplane-private\` PR #69 (branch \`gcs-wef-oom-bounds\`).**

### gcs
- \`max_decompressed_bytes\` (4 GiB): runaway-decompressor guard; above BigQuery/Cloud Logging maxima so real objects aren't truncated. Truncations counted by \`gcs_object_truncated_total\`.

### wef
- \`max_content_length\` now enforced via \`Limited\`; independent from \`max_envelope_size\`, so the effective cap is \`max(configured, 4× max advertised envelope)\`
- \`sldc::decompress\` size errors now rejected instead of silently falling back to raw UTF-16

## Testing

\`wef\` 119 · \`gcs\` 7 — all passing.

Jira: OBE-10709, OBE-10718, OBE-11236