### PR TITLE
fix(sources): OBE-11881 defer listen-port bind out of source build()

### DIFF
--- a/changelog.d/OBE-11881_defer_source_bind.fix.md
+++ b/changelog.d/OBE-11881_defer_source_bind.fix.md
@@ -1,0 +1,5 @@
+The `splunk_hec`, `datadog_agent`, and `aws_kinesis_firehose` sources no longer bind their
+listen port while the configuration is being built. Previously `vector validate` would bind
+the port as a side effect of building the source, so validating a config in the same network
+namespace as a running Vector failed with "Address already in use". These sources now bind
+when the source starts, matching the behavior of `http_server`, `opentelemetry`, and `socket`.

--- a/changelog.d/OBE-11881_defer_source_bind.fix.md
+++ b/changelog.d/OBE-11881_defer_source_bind.fix.md
@@ -3,3 +3,5 @@ listen port while the configuration is being built. Previously `vector validate`
 the port as a side effect of building the source, so validating a config in the same network
 namespace as a running Vector failed with "Address already in use". These sources now bind
 when the source starts, matching the behavior of `http_server`, `opentelemetry`, and `socket`.
+
+authors: JuanMantica45

--- a/changelog.d/OBE-11881_defer_source_bind.fix.md
+++ b/changelog.d/OBE-11881_defer_source_bind.fix.md
@@ -1,7 +1,0 @@
-The `splunk_hec`, `datadog_agent`, and `aws_kinesis_firehose` sources no longer bind their
-listen port while the configuration is being built. Previously `vector validate` would bind
-the port as a side effect of building the source, so validating a config in the same network
-namespace as a running Vector failed with "Address already in use". These sources now bind
-when the source starts, matching the behavior of `http_server`, `opentelemetry`, and `socket`.
-
-authors: JuanMantica45

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -188,13 +188,18 @@ impl SourceConfig for AwsKinesisFirehoseConfig {
         );
 
         let tls = MaybeTlsSettings::from_config(self.tls.as_ref(), true)?;
-        let listener = tls.bind(&self.address).await?;
-        let listener = listener
-            .with_allowlist(self.permit_origin.clone().map(Into::into));
-
+        let address = self.address;
+        let permit_origin = self.permit_origin.clone();
         let keepalive_settings = self.keepalive.clone();
         let shutdown = cx.shutdown;
         Ok(Box::pin(async move {
+            // Bind when the source starts, not when it is built: `vector validate` builds
+            // sources without running them, so binding here would collide with a live instance.
+            let listener = tls.bind(&address).await.map_err(|err| {
+                error!("An error occurred: {:?}.", err);
+            })?;
+            let listener = listener.with_allowlist(permit_origin.map(Into::into));
+
             let span = Span::current();
             let make_svc = make_service_fn(move |conn: &MaybeTlsIncomingStream<TcpStream>| {
                 let svc = ServiceBuilder::new()
@@ -339,6 +344,40 @@ mod tests {
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<AwsKinesisFirehoseConfig>();
+    }
+
+    /// OBE-11881: `build()` must not bind the listen port. In a containerized site the
+    /// control-agent runs `dataplane validate` in the same network namespace as the live
+    /// dataplane, so binding during config validation collides with the already-running
+    /// pipeline and fails the deploy with "Address already in use".
+    #[tokio::test]
+    async fn build_does_not_bind_the_listen_port() {
+        let address = next_addr();
+        let _occupied = tokio::net::TcpListener::bind(address).await.unwrap();
+
+        let (sender, _recv) = SourceSender::new_test();
+        let config = AwsKinesisFirehoseConfig {
+            address,
+            tls: None,
+            access_key: None,
+            access_keys: None,
+            store_access_key: false,
+            record_compression: Compression::None,
+            framing: default_framing_message_based(),
+            decoding: default_decoding(),
+            acknowledgements: true.into(),
+            log_namespace: Some(false),
+            keepalive: Default::default(),
+            permit_origin: None,
+        };
+
+        assert!(
+            config
+                .build(SourceContext::new_test(sender, None))
+                .await
+                .is_ok(),
+            "build() must succeed while the port is already bound",
+        );
     }
 
     async fn source(

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -198,17 +198,23 @@ impl SourceConfig for DatadogAgentConfig {
             self.parse_ddtags,
             cx.globals.limits.compression,
         );
-        let listener = tls.bind(&self.address).await?;
-        let listener = listener
-            .with_allowlist(self.permit_origin.clone().map(Into::into));
         let acknowledgements = cx.do_acknowledgements(self.acknowledgements);
         let filters = source.build_warp_filters(cx.out, acknowledgements, self)?;
         let shutdown = cx.shutdown;
+        let address = self.address;
+        let permit_origin = self.permit_origin.clone();
         let keepalive_settings = self.keepalive.clone();
 
-        info!(message = "Building HTTP server.", address = %self.address);
-
         Ok(Box::pin(async move {
+            info!(message = "Building HTTP server.", address = %address);
+
+            // Bind when the source starts, not when it is built: `vector validate` builds
+            // sources without running them, so binding here would collide with a live instance.
+            let listener = tls.bind(&address).await.map_err(|err| {
+                error!("An error occurred: {:?}.", err);
+            })?;
+            let listener = listener.with_allowlist(permit_origin.map(Into::into));
+
             let routes = filters.recover(|r: Rejection| async move {
                 if let Some(e_msg) = r.find::<ErrorMessage>() {
                     let json = warp::reply::json(e_msg);

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -209,6 +209,33 @@ fn generate_config() {
     crate::test_util::test_generate_config::<DatadogAgentConfig>();
 }
 
+/// OBE-11881: `build()` must not bind the listen port. In a containerized site the
+/// control-agent runs `dataplane validate` in the same network namespace as the live
+/// dataplane, so binding during config validation collides with the already-running
+/// pipeline and fails the deploy with "Address already in use".
+#[tokio::test]
+async fn build_does_not_bind_the_listen_port() {
+    let address = next_addr();
+    let _occupied = tokio::net::TcpListener::bind(address).await.unwrap();
+
+    let (sender, _recv) = SourceSender::new_test();
+    let config = toml::from_str::<DatadogAgentConfig>(&format!(
+        indoc! { r#"
+            address = "{}"
+        "#},
+        address
+    ))
+    .unwrap();
+
+    assert!(
+        config
+            .build(SourceContext::new_test(sender, None))
+            .await
+            .is_ok(),
+        "build() must succeed while the port is already bound",
+    );
+}
+
 async fn source(
     status: EventStatus,
     acknowledgements: bool,

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -176,12 +176,17 @@ impl SourceConfig for SplunkConfig {
             )
             .or_else(finish_err);
 
-        let listener = tls.bind(&self.address).await?;
-        let listener = listener
-            .with_allowlist(self.permit_origin.clone().map(Into::into));
-
+        let address = self.address;
+        let permit_origin = self.permit_origin.clone();
         let keepalive_settings = self.keepalive.clone();
         Ok(Box::pin(async move {
+            // Bind when the source starts, not when it is built: `vector validate` builds
+            // sources without running them, so binding here would collide with a live instance.
+            let listener = tls.bind(&address).await.map_err(|err| {
+                error!("An error occurred: {:?}.", err);
+            })?;
+            let listener = listener.with_allowlist(permit_origin.map(Into::into));
+
             let span = Span::current();
             let make_svc = make_service_fn(move |conn: &MaybeTlsIncomingStream<TcpStream>| {
                 let svc = ServiceBuilder::new()
@@ -1328,6 +1333,30 @@ mod tests {
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<SplunkConfig>();
+    }
+
+    /// OBE-11881: `build()` must not bind the listen port. In a containerized site the
+    /// control-agent runs `dataplane validate` in the same network namespace as the live
+    /// dataplane, so binding during config validation collides with the already-running
+    /// pipeline and fails the deploy with "Address already in use".
+    #[tokio::test]
+    async fn build_does_not_bind_the_listen_port() {
+        let address = next_addr();
+        let _occupied = tokio::net::TcpListener::bind(address).await.unwrap();
+
+        let (sender, _recv) = SourceSender::new_test();
+        let config = SplunkConfig {
+            address,
+            ..Default::default()
+        };
+
+        assert!(
+            config
+                .build(SourceContext::new_test(sender, None))
+                .await
+                .is_ok(),
+            "build() must succeed while the port is already bound",
+        );
     }
 
     /// Splunk token


### PR DESCRIPTION
## Why

On a **containerized site**, any pipeline edit fails to deploy with:

```
Component errors:
  ID: 100000000000001951
  Name: suf2
  Type: Source
  Error: TCP bind failed: Address already in use (os error 98)
```

The config is fine — **the running pipeline is blocking its own update.**

`splunk_hec`, `datadog_agent`, and `aws_kinesis_firehose` bind their listen port inside
`SourceConfig::build()`. `vector validate` builds every source via `TopologyPieces::build()`
without ever running it, so merely validating a config takes the port as a side effect.

On a containerized site the control-agent runs `dataplane validate` from the same container —
and therefore the same network namespace — as the live dataplane, so validation collides with
the running pipeline's own listener. Kubernetes never hits this because control-agent runs in a
separate pod.

Reported as OBE-11881 against Splunk HEC only. Auditing every `bind(` call under `src/sources/`
showed **exactly three** sources bind eagerly — the other two are broken identically and simply
had not been tried yet on a containerized site, so all three are fixed here.

## What

Move the bind into the returned source future, so it happens when the source *starts* rather
than when it is *built*. This is what `http_server`, `opentelemetry`, `socket`, and the gRPC
sources already do — these three were the outliers.

## Trade-off

A genuine port collision is no longer caught during validation: a duplicate-port config now
deploys and the affected source fails at startup instead. That is already the existing behavior
for every other listening source, so this makes the three consistent rather than introducing a
new failure mode. A config-level duplicate-port check belongs upstream in site-manager and is
deliberately **not** bundled here.

## Tests

Each source gets a regression test that reproduces the bug directly — occupy the port, then
build — failing on `master` with `Address already in use` and passing here:

```rust
let address = next_addr();
let _occupied = tokio::net::TcpListener::bind(address).await.unwrap();
assert!(config.build(SourceContext::new_test(sender, None)).await.is_ok());
```

Full suites pass, which is what proves the sources still actually serve traffic after the move:

| Suite | Result |
|---|---|
| `sources::splunk_hec` | 65 passed |
| `sources::datadog_agent` | 39 passed |
| `sources::aws_kinesis_firehose` | 22 passed |

## Smoke test

Per @alif.biswas's suggested procedure: build vector, run a dataplane process listening on
port X, then run `dataplane validate` with a config that also listens on port X.

Two binaries were built from this same tree, differing **only** by this fix, so the binary is
the single variable:

| Binary | Sources |
|---|---|
| `dataplane` | this branch |
| `dataplane-prefix` | `master`'s three source files, rebuilt |

One `dataplane` process was left running on port 8088 (Splunk HEC source -> blackhole sink),
then each binary validated a config claiming that same port.

**Baseline** — the live pipeline is serving before anything else happens:

```
POST /services/collector/event -> {"text":"Success","code":0}  HTTP 200
```

**1. Pre-fix binary validating:**

```
√ Loaded [".../pipeline.yaml"]

Component errors
----------------
x Source "hec": TCP bind failed: Address already in use (os error 48)

>>> exit code: 78
```

**2. Fixed binary — same live process, same config, same port:**

```
√ Loaded [".../pipeline.yaml"]
√ Component configuration
√ Health check "out"
                                                    Validated
>>> exit code: 0
```

Exit 78 -> exit 0, with the binary as the only difference. (`os error 48` is macOS's
`EADDRINUSE`; Linux reports the same condition as 98, matching the original report.)

### Verifying the fix does not break serving

"Validate stops erroring" is not sufficient on its own — this change moves a bind, so the
risk worth checking is whether the source still serves and whether validation now disturbs a
running pipeline. After the successful validate above, against the still-running process:

```
POST after validate  -> {"text":"Success","code":0}  HTTP 200
still listening      -> dataplane 45372 TCP *:8088 (LISTEN)
events processed     -> events=2
errors/panics logged by the live process during validate -> none
```

Both POSTs landed and the live listener was untouched, so `validate` is now genuinely inert
against a running pipeline rather than merely failing more quietly.

### Scope of this smoke test

It was run with a locally built binary, not the released image. The compiled code path is
identical — the `observo` feature is composed of `lext`, `chkpts`, `lv3`, `vrl`, and `ssa`,
none of which touch these three sources, none of the sources contain `cfg(feature = "observo")`
code, and `dataplane-private` does not reference them.

What it therefore does **not** cover:

- control-agent's real invocation (`--log-validation-errors`, the `lookup-packs-config.yaml`
  argument, the socat stderr redirect) — `validate` was invoked directly here.
- `updateVectorDataDirAndHealthCheckConfigForValidation`, the real config-rewriting step;
  `data_dir` was set by hand to an equivalent value.
- s6 supervision and the container network namespace.
- A production-scale config: this used one source and one sink with TLS off, while the
  reported config had multiple components.
- Only `splunk_hec` was exercised. `datadog_agent` and `aws_kinesis_firehose` received the
  identical change and are covered by unit tests, but have not been run end-to-end.

An end-to-end run on a containerized dev site is still worth doing before release, since that
is what exercises control-agent's wrapper and a real config.

## Notes for reviewers

- `cargo fmt` introduces **no** new drift on these files (they are not rustfmt-clean on `master`
  to begin with); it actually clears three pre-existing complaints.
- Local `cargo clippy` could not be run to completion — `vector-common`, `enrichment`,
  `vector-config`, and `vector-config-common` fail dozens of pre-existing pedantic lints under a
  reduced feature set, in crates untouched by this PR. Relying on CI's clippy here.

## Shipping

This fix only reaches customers once `pipeline/data-plane/Dockerfile` bumps its pinned
`FROM .../vector:<tag>`. If the release is cut after this merges but before that bump, the
release ships **without** the fix.
